### PR TITLE
feature(strategies) added a new very aggressive (brutal) strategy

### DIFF
--- a/apps/ng-reactive-experiments/src/app/config-panel.component.ts
+++ b/apps/ng-reactive-experiments/src/app/config-panel.component.ts
@@ -45,7 +45,8 @@ import { RxState } from '@ngx-rx-state';
                 'native',
                 'noop',
                 'global',
-                'local'
+                'local',
+                'brutal'
               ]
             "
           >

--- a/apps/ng-reactive-experiments/src/app/strategies/virtual-scroll-demo/scroll-item.component.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/virtual-scroll-demo/scroll-item.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { interval } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import { CdConfigService } from '../../cd-config.service';
 import { map } from 'rxjs/operators';
 
@@ -7,13 +8,16 @@ import { map } from 'rxjs/operators';
   selector: 'ngx-rx-scroll-item',
   styleUrls: ['scroll-item.component.scss'],
   template: `
-    <ng-content></ng-content><span style="margin: 0 1rem;">Val: {{ val$ | ngrxPush: strategy$ }}</span><span>Rendered by: {{ strategy$ | ngrxPush }}</span>
+    <ng-content></ng-content><span class="margin-left: 10px">Renderings: {{ rerender() }}</span><span style="margin: 0 1rem;">Val: {{ val$ | ngrxPush: strategy$ }}</span><span>Rendered by: {{ strategy$ | ngrxPush }}</span>
   `,
+  changeDetection: environment.changeDetection
 })
 export class ScrollItemComponent {
 
   // this can be ANY value from ANY service which causes re-rendering
-  readonly val$ = interval(1000);
+  readonly val$ = interval(2500);
+
+  private numRender = 0;
 
   readonly strategy$ = this.cdConfig.$.pipe(map(s => s.strategy));
 
@@ -21,6 +25,10 @@ export class ScrollItemComponent {
     private cdConfig: CdConfigService
   ) {
 
+  }
+
+  rerender() {
+    return ++this.numRender;
   }
 
 }

--- a/apps/ng-reactive-experiments/src/app/strategies/virtual-scroll-demo/virtual-scroll-demo.component.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/virtual-scroll-demo/virtual-scroll-demo.component.ts
@@ -1,5 +1,6 @@
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'ngx-rx-virtual-scroll-demo',
@@ -13,6 +14,7 @@ import { AfterViewInit, Component, ViewChild } from '@angular/core';
         </ngx-rx-scroll-item>
       </div>
     </cdk-virtual-scroll-viewport>`,
+  changeDetection: environment.changeDetection
 })
 export class VirtualScrollDemoComponent implements AfterViewInit {
 

--- a/libs/ngrx-component-experiments/src/lib/core/cd-aware/strategy.ts
+++ b/libs/ngrx-component-experiments/src/lib/core/cd-aware/strategy.ts
@@ -8,7 +8,7 @@ import {
   ɵmarkDirty as markDirty,
 } from '@angular/core';
 import { apiZonePatched, getGlobalThis, isViewEngineIvy } from '@ts-etc';
-import { mapTo } from 'rxjs/operators';
+import { mapTo, tap } from 'rxjs/operators';
 import { getZoneUnPatchedDurationSelector } from './duration-selector';
 
 export interface StrategyFactoryConfig {
@@ -37,6 +37,7 @@ export function getStrategies<T>(
     noop: createNoopStrategy<T>(),
     global: createGlobalStrategy<T>(config),
     local: createLocalStrategy<T>(config),
+    brutal: createBrutalStrategy<T>(config),
   };
 }
 
@@ -203,5 +204,71 @@ export function createLocalStrategy<T>(
     behaviour,
     render,
     name: 'local',
+  };
+}
+
+/**
+ *  Local Strategy
+ *
+ * This strategy is rendering the actual component and
+ * all it's children that are on a path
+ * that is marked as dirty or has components with `ChangeDetectionStrategy.Default`.
+ *
+ * As detectChanges has no coalescing of render calls
+ * like `ChangeDetectorRef#markForCheck` or `ɵmarkDirty` has, so we have to apply our own coalescing, 'scoped' on component level.
+ *
+ * Coalescing, in this very manner,
+ * means **collecting all events** in the same [EventLoop](https://developer.mozilla.org/de/docs/Web/JavaScript/EventLoop) tick,
+ * that would cause a re-render and execute **re-rendering only once**.
+ *
+ * 'Scoped' coalescing, in addition, means **grouping the collected events by** a specific context.
+ * E. g. the **component** from which the re-rendering was initiated.
+ *
+ * | Name        | ZoneLess VE/I | Render Method VE/I  | Coalescing VE/I  |
+ * |-------------| --------------| ------------ ------ | ---------------- |
+ * | `local`     | ✔️/✔️          | dC / ɵDC            | ✔️ + C/ LV       |
+ *
+ * @param config { StrategyFactoryConfig } - The values this strategy needs to get calculated.
+ * @return {CdStrategy<T>} - The calculated strategy
+ *
+ */
+export function createBrutalStrategy<T>(
+  config: StrategyFactoryConfig
+): CdStrategy<T> {
+  const durationSelector = getZoneUnPatchedDurationSelector();
+  // @Notice this part of the code is in the coalescing PR https://github.com/ngrx/platform/pull/2456
+  //const coalesceConfig: CoalesceConfig
+  const coalesceConfig: any = {
+    // @TODO ensure that context is === to _lView across class and template (all cases!!!)
+    // If yes, kick out _lView
+    context: (IS_VIEW_ENGINE_IVY
+              ? (config.cdRef as any)._lView
+              : (config.cdRef as any).context) as any,
+  };
+
+  function render() {
+    // @TODO ensure that detectChanges is behaves identical to ɵdetectChanges
+    // If yes, kick out ɵdetectChanges
+    config.cdRef.reattach();
+    if (!IS_VIEW_ENGINE_IVY) {
+      config.cdRef.detectChanges();
+    } else {
+      detectChanges((config.cdRef as any).context);
+    }
+    config.cdRef.detach();
+  }
+
+  const behaviour = () => (o$: Observable<T>): Observable<T> => {
+    return o$
+      .pipe(
+        // @Notice this part of the code is in the coalescing PR https://github.com/ngrx/platform/pull/2456
+        coalesce(durationSelector, coalesceConfig)
+      );
+  };
+
+  return {
+    behaviour,
+    render,
+    name: 'brutal',
   };
 }


### PR DESCRIPTION
implemented a strategy called 'brutal' which `detaches` the component entirely from the `changeDetection`. The component will get `reattached` before each rendering cycle and after that being `detached` again.