### PR TITLE
fix(cd-aware) fixed rendering effect to correctly call updateObserver

### DIFF
--- a/apps/ng-reactive-experiments/src/app/strategies/local01/local01.component.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/local01/local01.component.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { Subject } from 'rxjs';
+import { pluck } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+interface Local01State {
+  value1: number;
+  value2: number;
+}
+
+@Component({
+  selector: 'ngx-rx-strategies-local01',
+  changeDetection: environment.changeDetection,
+  template: `
+    <h1>Local 01</h1>
+    <button (click)="change()">Click</button>
+    <div style="border: 1px solid red; padding: 1rem">
+      <h3>Component</h3>
+      <ng-container *ngrxLet="value1$; let v; config: strategy">
+        <span>value1: {{ v }}</span>
+      </ng-container><br>
+      <ng-container *ngrxLet="value2$; let v; config: strategy">
+        <span>value2: {{ v }}</span>
+      </ng-container>
+    </div>
+
+  `
+})
+export class Local01Component {
+
+  readonly strategy = 'local';
+
+  readonly state$ = new Subject<Local01State>();
+
+  readonly value1$ = this.state$.pipe(pluck('value1'));
+  readonly value2$ = this.state$.pipe(pluck('value2'));
+
+  constructor() {
+
+  }
+
+  change() {
+    const value1 = Math.floor(Math.random() * 100);
+    const value2 = Math.floor(Math.random() * 100);
+    this.state$.next({ value1, value2 });
+  }
+}

--- a/apps/ng-reactive-experiments/src/app/strategies/strategies.menu.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/strategies.menu.ts
@@ -9,6 +9,10 @@ export const STRATEGIES_MENU: MenuItem[] = [
       {
         link: 'strategies/virtual-scroll',
         label: 'Virtual Scroll'
+      },
+      {
+        link: 'strategies/local01',
+        label: 'Local 01'
       }
     ]
   }

--- a/apps/ng-reactive-experiments/src/app/strategies/strategies.module.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/strategies.module.ts
@@ -1,19 +1,20 @@
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ReactiveComponentModule } from '@ngx-rx/ngrx-component-experiments';
-import { STRATEGY_ROUTES } from './strategies.routes';
-import { VirtualScrollDemoComponent } from './virtual-scroll-demo/virtual-scroll-demo.component';
+import { Local01Component } from './local01/local01.component';
 import { StrategiesOverviewComponent } from './strategies.overview.component';
+import { STRATEGY_ROUTES } from './strategies.routes';
 import { ScrollItemComponent } from './virtual-scroll-demo/scroll-item.component';
-
+import { VirtualScrollDemoComponent } from './virtual-scroll-demo/virtual-scroll-demo.component';
 
 
 @NgModule({
   declarations: [
     VirtualScrollDemoComponent,
     StrategiesOverviewComponent,
+    Local01Component,
     ScrollItemComponent
   ],
   imports: [

--- a/apps/ng-reactive-experiments/src/app/strategies/strategies.routes.ts
+++ b/apps/ng-reactive-experiments/src/app/strategies/strategies.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { Local01Component } from './local01/local01.component';
 import { StrategiesOverviewComponent } from './strategies.overview.component';
 import { VirtualScrollDemoComponent } from './virtual-scroll-demo/virtual-scroll-demo.component';
 
@@ -10,5 +11,9 @@ export const STRATEGY_ROUTES: Routes = [
   {
     path: 'virtual-scroll',
     component: VirtualScrollDemoComponent
+  },
+  {
+    path: 'local01',
+    component: Local01Component
   }
 ]

--- a/libs/ngrx-component-experiments/src/lib/core/cd-aware/cd-aware_creator.ts
+++ b/libs/ngrx-component-experiments/src/lib/core/cd-aware/cd-aware_creator.ts
@@ -1,8 +1,6 @@
 import {
   BehaviorSubject,
-  combineLatest, concat, defer,
   EMPTY,
-  isObservable,
   NextObserver,
   Observable,
   PartialObserver,
@@ -10,19 +8,9 @@ import {
   Subscribable,
   Subscription
 } from 'rxjs';
-import {
-  catchError,
-  distinctUntilChanged, map,
-  mergeAll,
-  switchMap, switchMapTo, take,
-  tap
-} from 'rxjs/operators';
-import {
-  CdStrategy,
-  DEFAULT_STRATEGY_NAME,
-  StrategySelection
-} from './strategy';
+import { catchError, distinctUntilChanged, map, mergeAll, switchMap, tap } from 'rxjs/operators';
 import { nameToStrategy } from './nameToStrategy';
+import { CdStrategy, DEFAULT_STRATEGY_NAME, StrategySelection } from './strategy';
 
 export interface CdAware<U> extends Subscribable<U> {
   nextPotentialObservable: (value: any) => void;
@@ -66,10 +54,9 @@ export function createCdAware<U>(cfg: {
       }
       strategy.render();
     }),
-    map(o$ => o$.pipe(strategy.behaviour())),
+    map(o$ => o$.pipe(distinctUntilChanged(), tap(cfg.updateObserver.next), strategy.behaviour())),
     switchMap((observable$) => (observable$ == null) ? EMPTY : observable$),
     distinctUntilChanged(),
-    tap(cfg.updateObserver),
     tap(() => strategy.render()),
     catchError(e => {
       console.error(e);


### PR DESCRIPTION
found a nasty bug in the rendering sideffect inside `CdAware`. The next call to the `cfg.updateObserver` was falsy in two ways.

1. There was a missing .next call in the tap operator.
2. The timing when it got called was incorrect. The updateObserver only got updated after the `behavior`, which is incorrect. It should get updated every time a new value arives. This leads to missing changes in the view when rendering with `local` strategy.

I have implemented an example `Local01Component` where you can verify that changes aren't rendered without the fix. **Sadly, you have to manually set the local strategy as default in order to get it running in this branch. something is fucked up with the strategy changing...**