### PR TITLE
Updated docs for LetDirective and UnpatchEventDirective

### DIFF
--- a/libs/template/docs/api/let-directive.md
+++ b/libs/template/docs/api/let-directive.md
@@ -161,7 +161,7 @@ The default strategy is `'local'`.
 @Component({
   selector: 'app-root',
   template: `
-    <ng-container *rxLet="hero$; let hero; strategy: 'local'">
+    <ng-container *rxLet="hero$; let hero; strategy: strategy">
       <app-hero [hero]="hero"></app-hero>
     </ng-container>
   `

--- a/libs/template/src/lib/experimental/unpatch/events/unpatch-events.directive.ts
+++ b/libs/template/src/lib/experimental/unpatch/events/unpatch-events.directive.ts
@@ -85,10 +85,19 @@ export class UnpatchEventsDirective implements AfterViewInit, OnDestroy {
   subscription = new Subscription();
   events$ = new BehaviorSubject<string[]>(zonePatchedEvents);
 
+  /**
+   * @description
+   * List of events that the element should be unpatched from. When input is empty or undefined,
+   * the element is unpatched from all zone-patched events.
+   *
+   * Full list of zone-patched browser events can be found in
+   * [this document](https://github.com/angular/angular/blob/master/packages/zone.js/STANDARD-APIS.md#browser).
+   *
+   */
   @Input('unpatch')
-  set events(value: string[]) {
-    if (value && value.length > 0) {
-      this.events$.next(value);
+  set events(events: string[]) {
+    if (events && events.length > 0) {
+      this.events$.next(events);
     } else {
       this.events$.next(zonePatchedEvents);
     }

--- a/libs/template/src/lib/let/let.directive.ts
+++ b/libs/template/src/lib/let/let.directive.ts
@@ -212,7 +212,7 @@ export class LetDirective<U> implements OnInit, OnDestroy {
    * \@Component({
    *   selector: 'app-root',
    *   template: `
-   *     <ng-container *rxLet="hero$; let hero; strategy: 'local'">
+   *     <ng-container *rxLet="hero$; let hero; strategy: strategy">
    *       <app-hero [hero]="hero"></app-hero>
    *     </ng-container>
    *   `


### PR DESCRIPTION
As per https://github.com/rx-angular/rx-angular/issues/313:
- Updated jsdoc example for `LetDirective`.
- Added description for the input binding for the `UnpatchEventsDirective` for it to be a little bit more clearer that it doesn't have to be provided.