### PR TITLE
Enabled Template Bindings demo in the "demos" app

### DIFF
--- a/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-subject-example.component.ts
+++ b/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-subject-example.component.ts
@@ -88,7 +88,7 @@ import { scan, startWith } from 'rxjs/operators';
       }
 
       .btn-reset {
-        margin-left: 6rem;
+        margin-left: 2rem;
       }
 
       .card {

--- a/apps/demos/src/app/features/template/rx-let/let-template-binding/let-template-binding.module.ts
+++ b/apps/demos/src/app/features/template/rx-let/let-template-binding/let-template-binding.module.ts
@@ -15,8 +15,10 @@ import {
   UnpatchEventsModule,
 } from '@rx-angular/template';
 import { MatBadgeModule } from '@angular/material/badge';
+import { ToStringPipe } from './to-string.pipe';
 
 const DECLARATIONS = [
+  ToStringPipe,
   LetTemplateBindingComponent,
   LetTemplateBindingHttpExampleComponent,
   LetTemplateBindingSubjectExampleComponent,

--- a/apps/demos/src/app/features/template/rx-let/let-template-binding/let-template-binding.routes.ts
+++ b/apps/demos/src/app/features/template/rx-let/let-template-binding/let-template-binding.routes.ts
@@ -1,8 +1,8 @@
-import { HttpErrorsComponent } from '../http-errors/http-errors.component';
+import { LetTemplateBindingComponent } from './let-template-binding.component';
 
 export const ROUTES = [
   {
     path: '',
-    component: HttpErrorsComponent
+    component: LetTemplateBindingComponent
   }
 ];


### PR DESCRIPTION
"Template Bindings" demo in the "demos" app was forwarding to the error page. This PR serves as a fix for that, enabling this demo.