### PR TITLE
RenderAware fix

### DIFF
--- a/apps/demos/src/app/features/template/push/push-basic-example/push-basic-example.component.ts
+++ b/apps/demos/src/app/features/template/push/push-basic-example/push-basic-example.component.ts
@@ -1,12 +1,49 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, map, share, shareReplay } from 'rxjs/operators';
 
 @Component({
   selector: 'rxa-push-basic-example',
   template: `
-    @TODO
+    <div class="row mb-2">
+      <div class="col">
+        <button mat-raised-button unpatch (click)="updateClick.next()">Update</button>
+      </div>
+    </div>
+    <rxa-dirty-check></rxa-dirty-check>
+    <div class="row">
+      <div class="col-4">
+        <div class="mat-headline">
+          Value
+        </div>
+        <div> {{ value$ | push }}</div>
+      </div>
+      <div class="col-4">
+        <div class="mat-headline">
+          Value
+        </div>
+        <div> {{ value$ | push }}</div>
+      </div>
+      <div class="col-4">
+        <div class="mat-headline">
+          Value
+        </div>
+        <div> {{ value$ | push }}</div>
+      </div>
+    </div>
   `,
+  styles: [`
+
+  `],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PushBasicExampleComponent {
 
+  readonly updateClick = new Subject<void>();
+
+  readonly value$ = this.updateClick.pipe(
+    map(() => Math.ceil(Math.random() * 100)),
+    distinctUntilChanged(),
+    share()
+  )
 }

--- a/apps/demos/src/app/features/template/push/push-basic-example/push-basic-example.module.ts
+++ b/apps/demos/src/app/features/template/push/push-basic-example/push-basic-example.module.ts
@@ -1,10 +1,11 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { RouterModule } from '@angular/router';
-import { PushModule } from '@rx-angular/template';
-import { ROUTES } from './push-basic-example.routes';
+import { PushModule, UnpatchEventsModule } from '@rx-angular/template';
 import { DirtyChecksModule } from '../../../../shared/debug-helper/dirty-checks';
 import { PushBasicExampleComponent } from './push-basic-example.component';
+import { ROUTES } from './push-basic-example.routes';
 
 const DECLARATIONS = [PushBasicExampleComponent];
 
@@ -14,7 +15,9 @@ const DECLARATIONS = [PushBasicExampleComponent];
     CommonModule,
     RouterModule.forChild(ROUTES),
     PushModule,
-    DirtyChecksModule
+    DirtyChecksModule,
+    MatButtonModule,
+    UnpatchEventsModule
   ],
   exports: [DECLARATIONS]
 })

--- a/libs/template/src/lib/core/render-aware/render-aware_creator.ts
+++ b/libs/template/src/lib/core/render-aware/render-aware_creator.ts
@@ -1,4 +1,13 @@
-import { MonoTypeOperatorFunction, Observable, of, ReplaySubject, Subscribable, Subscriber, Subscription } from 'rxjs';
+import {
+  concat,
+  MonoTypeOperatorFunction, NEVER,
+  Observable,
+  of,
+  ReplaySubject,
+  Subscribable,
+  Subscriber,
+  Subscription
+} from 'rxjs';
 import { distinctUntilChanged, filter, map, shareReplay, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { RenderStrategy, StrategySelection } from './interfaces';
 import { RxTemplateObserver } from '../model';
@@ -104,7 +113,7 @@ function renderWithLatestStrategy<T>(
       withLatestFrom(strategyChanges$),
       // always use latest strategy on value change
       switchMap(([renderValue, strategy]) =>
-        of(renderValue).pipe(strategy.rxScheduleCD)
+        concat(of(renderValue), NEVER).pipe(strategy.rxScheduleCD)
       )
     );
   };


### PR DESCRIPTION
fixed custom `renderWithLatestStrategy` operator. It completed instantly which sometimes leads to over-emitting push pipes. The `coalesceWith` operator emits instantly when the subscription completes.