### PR TITLE
refactor: replace deprecated async with waitForAsync

### DIFF
--- a/libs/template/spec/let/let.directive.complete.spec.ts
+++ b/libs/template/spec/let/let.directive.complete.spec.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
 import { EMPTY, Observable, of } from 'rxjs';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries
@@ -44,7 +44,7 @@ const setupLetDirectiveTestComponentComplete = (): void => {
 
 describe('LetDirective when complete', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupLetDirectiveTestComponentComplete));
+  beforeEach(waitForAsync(setupLetDirectiveTestComponentComplete));
 
   it('should render true if completed', () => {
     letDirectiveTestComponent.value$ = EMPTY;

--- a/libs/template/spec/let/let.directive.error.spec.ts
+++ b/libs/template/spec/let/let.directive.error.spec.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '../../src/lib/let';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries
@@ -43,7 +43,7 @@ let componentNativeElement: any;
 
 describe('LetDirective when error', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupLetDirectiveTestComponentError));
+  beforeEach(waitForAsync(setupLetDirectiveTestComponentError));
 
   it('should render the error to false if next or complete', () => {
     letDirectiveTestComponent.value$ = of(1);

--- a/libs/template/spec/let/let.directive.template-binding.all.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.all.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { EMPTY, interval, NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -43,7 +43,7 @@ const setUpFixture = () => {
 
 describe('LetDirective when template binding with all templates', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupTestComponent));
+  beforeEach(waitForAsync(setupTestComponent));
   beforeEach(setUpFixture);
 
   it('should be initiated', () => {

--- a/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { EMPTY, Observable, of } from 'rxjs';
 // tslint:disable-next-line:nx-enforce-module-boundaries
@@ -41,7 +41,7 @@ const setUpFixture = () => {
 
 describe('LetDirective when template binding without "complete" template', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupTestComponent));
+  beforeEach(waitForAsync(setupTestComponent));
   beforeEach(setUpFixture);
 
   it('should be initiated', () => {

--- a/libs/template/spec/let/let.directive.template-binding.no-error.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-error.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { Observable, of, Subject } from 'rxjs';
 // tslint:disable-next-line:nx-enforce-module-boundaries
@@ -41,7 +41,7 @@ const setUpFixture = () => {
 
 describe('LetDirective when template binding without "error" template', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupTestComponent));
+  beforeEach(waitForAsync(setupTestComponent));
   beforeEach(setUpFixture);
 
   it('should be initiated', () => {

--- a/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-suspense.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 import { Observable, of, Subject } from 'rxjs';
 // tslint:disable-next-line:nx-enforce-module-boundaries
@@ -42,7 +42,7 @@ const setUpFixture = () => {
 
 describe('LetDirective when template binding without "suspense" template', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupTestComponent));
+  beforeEach(waitForAsync(setupTestComponent));
   beforeEach(setUpFixture);
 
   it('should be initiated', () => {

--- a/libs/template/spec/push/push.pipe.service.spec.ts
+++ b/libs/template/spec/push/push.pipe.service.spec.ts
@@ -1,5 +1,5 @@
 import { PushPipe } from '../../src/lib/push';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ChangeDetectorRef } from '@angular/core';
 import { EMPTY, NEVER, of } from 'rxjs';
 import { MockChangeDetectorRef } from '../fixtures';
@@ -20,7 +20,7 @@ const setupPushPipeComponent = () => {
 
 describe('PushPipe used as a Service', () => {
   beforeAll(() => mockConsole());
-  beforeEach(async(setupPushPipeComponent));
+  beforeEach(waitForAsync(setupPushPipeComponent));
 
   it('should be instantiable', () => {
     expect(pushPipe).toBeDefined();

--- a/libs/template/spec/render-strategies/render-strategies/global.strategy.spec.ts
+++ b/libs/template/spec/render-strategies/render-strategies/global.strategy.spec.ts
@@ -3,7 +3,7 @@ import { getStrategies } from '../../../src/lib/render-strategies';
 import * as AngularCore from '@angular/core';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { CallsExpectations, getMockStrategyConfig, testStrategyMethod } from '../../fixtures';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LetDirective } from '@rx-angular/template';
 
 @Component({
@@ -46,7 +46,7 @@ const callsExpectations: CallsExpectations = {
 
 describe('global Strategy', () => {
   // beforeAll(() => mockConsole());
-  beforeEach(async(setupTestComponent));
+  beforeEach(waitForAsync(setupTestComponent));
   beforeEach(setUpFixture);
   beforeEach(spyOnMarkDirty);
 


### PR DESCRIPTION
`async` is deprecated and replaced with `waitForAsync` since Angular v10.1.0