### PR TITLE
Fix state get return value

### DIFF
--- a/libs/state/spec/core/utils/safe-pluck.spec.ts
+++ b/libs/state/spec/core/utils/safe-pluck.spec.ts
@@ -18,6 +18,10 @@ describe('safePluck', () => {
     expect(safePluck(obj, 'foo')).toEqual(obj.foo);
   });
 
+  it('should return null if key does not exist', () => {
+    expect(safePluck(obj, 'wasd' as any)).toEqual(null);
+  });
+
   describe('edge cases', () => {
     it('should return undefined when object is not valid', () => {
       expect(safePluck([undefined] as any, ['prop1'] as any)).toEqual(undefined);

--- a/libs/state/spec/core/utils/safe-pluck.spec.ts
+++ b/libs/state/spec/core/utils/safe-pluck.spec.ts
@@ -18,8 +18,8 @@ describe('safePluck', () => {
     expect(safePluck(obj, 'foo')).toEqual(obj.foo);
   });
 
-  it('should return null if key does not exist', () => {
-    expect(safePluck(obj, 'wasd' as any)).toEqual(null);
+  it('should return undefined if key does not exist', () => {
+    expect(safePluck(obj, 'doesNotExist' as any)).toEqual(undefined);
   });
 
   describe('edge cases', () => {

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -122,20 +122,40 @@ describe('RxStateService', () => {
   });
 
   describe('get', () => {
-    const state = setupState({ initialState: initialPrimitiveState });
+
+    it('should return undefined as initial value', () => {
+      const state = setupState({ initialState: undefined });
+      const val = state.get();
+      expect(val).toEqual(undefined);
+    });
+
+    it('should return undefined for an undefined property', () => {
+      const state = setupState<{ num: number }>({ initialState: undefined });
+      const val = state.get('num');
+      expect(val).toEqual(undefined);
+    });
 
     it('should return value when keys are provided as params', () => {
+      const state = setupState({ initialState: initialPrimitiveState });
       const val = state.get('num');
       expect(val).toEqual(initialPrimitiveState.num);
     });
 
     it('should return whole state object when no keys provided', () => {
+      const state = setupState({ initialState: initialPrimitiveState });
       const val = state.get();
       expect(val.num).toEqual(initialPrimitiveState.num);
     });
   });
 
   describe('select', () => {
+    it('should return undefined as initial value', () => {
+      testScheduler.run(({ expectObservable }) => {
+        const state = setupState({ initialState: undefined });
+        expectObservable(state.select()).toBe('-');
+      });
+    });
+
     it('should return initial state', () => {
       testScheduler.run(({ expectObservable }) => {
         const state = setupState({ initialState: initialPrimitiveState });

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -160,10 +160,12 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
     | T[K1][K2][K3][K4][K5]
     | T[K1][K2][K3][K4][K5][K6] {
     const hasStateAnyKeys = Object.keys(this.accumulator.state).length > 0;
-    if (hasStateAnyKeys && !!keys && keys.length > 0) {
+    if (!!keys && keys.length) {
       return safePluck(this.accumulator.state, keys);
     } else {
-      return this.accumulator.state;
+      return hasStateAnyKeys ?
+             this.accumulator.state :
+              undefined as unknown as T;
     }
   }
 


### PR DESCRIPTION
## Description

Currently, the `RxState#get` method returns `{}` as initial value. Furthermore it returns `{}` if the state is empty and you want to read a property, but it should be `undefined` instead.

### Example 
```ts
const state = new RxState();
state.get('prop'); // will return {}

const state2 = new RxState();
state2.set({ prop2: 'someVal' });
state2.get('prop'); // will return undefined

```

I have fixed this behavior by always returning `undefined` if the state is empty. In all other cases `safePluck` will do the work for us. I have added some tests to ensure this behavior.