### PR TITLE
Docs/usage

### DIFF
--- a/libs/state/docs/api/operators/stateful.md
+++ b/libs/state/docs/api/operators/stateful.md
@@ -20,6 +20,8 @@ You will sometimes (aka situational) need:
 - a subset of the state (derivations)
 - compose the state with other Observables or change the Observables behaviour
 
+Note that `RxState#connect` already applies the `stateful` operator under the hood.
+
 _Example_
 
 ```typescript


### PR DESCRIPTION
Hi, this PR adds : 
- a basic `RxState#hold` usage example
- a small note on `stateful` operator to explicit the fact that it's useless to apply `stateful` on `RxState#select`