### PR TITLE
docs(web): enable history based router

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,6 +100,7 @@
           '/.*/_sidebar.md': './web/partials/_sidebar.md',
           '/_sidebar.md': './web/partials/_sidebar.md',
         },
+        routerMode: 'history',
         // Autoscroll content to the top when changing page
         auto2top: true,
         relativePath: true,


### PR DESCRIPTION
Changed docs router from hash-based to history-based

⚠️ After the merge, existing links to our web docs might be broken