### PR TITLE
docs(fix) switch back to has route

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,13 +94,13 @@
         // Show sidebar
         loadSidebar: true,
         // Coverpage url
-        coverpage: './rx-angular/web/partials/_coverpage.md',
+        coverpage: './web/partials/_coverpage.md',
         // Prevents multiple downloads of sidebar
         alias: {
-          '/.*/_sidebar.md': './rx-angular/web/partials/_sidebar.md',
-          '/_sidebar.md': './rx-angular/web/partials/_sidebar.md',
+          '/.*/_sidebar.md': './web/partials/_sidebar.md',
+          '/_sidebar.md': './web/partials/_sidebar.md',
         },
-        routerMode: 'history',
+        // routerMode: 'history',
         // Autoscroll content to the top when changing page
         auto2top: true,
         relativePath: true,

--- a/docs/web/partials/_sidebar.md
+++ b/docs/web/partials/_sidebar.md
@@ -24,36 +24,36 @@
 
   - Getting started
 
-    - [Overview](/rx-angular/web/state/general/overview.md)
-    - [Setup](/rx-angular/web/state/general/basic-setup.md)
+    - [Overview](/web/state/general/overview.md)
+    - [Setup](/web/state/general/basic-setup.md)
 
   - API
 
-    - [RxState](/rx-angular/web/state/api/rx-state.md)
-    - [RxJS Operators](/rx-angular/web/state/api/rxjs-operators.md)
-    - [Transformation helpers](/rx-angular/web/state/api/transformation-helpers.md)
-    - [Interfaces](/rx-angular/web/state/api/interfaces.md)
+    - [RxState](/web/state/api/rx-state.md)
+    - [RxJS Operators](/web/state/api/rxjs-operators.md)
+    - [Transformation helpers](/web/state/api/transformation-helpers.md)
+    - [Interfaces](/web/state/api/interfaces.md)
 
   - Tutorials
 
-    - [Basic tutorial](/rx-angular/web/state/tutorials/basic-tutorial.md)
-    - [Incrementing a value](/rx-angular/web/state/tutorials/incrementing-value.md)
-    - [Migrating to RxState](/rx-angular/web/state/tutorials/from-imperative-to-reactive.md)
-    - [Passing observables directly](/rx-angular/web/state/tutorials/passing-observables.md)
+    - [Basic tutorial](/web/state/tutorials/basic-tutorial.md)
+    - [Incrementing a value](/web/state/tutorials/incrementing-value.md)
+    - [Migrating to RxState](/web/state/tutorials/from-imperative-to-reactive.md)
+    - [Passing observables directly](/web/state/tutorials/passing-observables.md)
 
   - Recipes
 
-    - [Determine state type](/rx-angular/web/state/howtos/determine-state.md)
-    - [Manage ViewModel](/rx-angular/web/state/howtos/manage-viewmodel.md)
-    - [Run partial updates](/rx-angular/web/state/howtos/partial-updates.md)
-    - [Load data on route change](/rx-angular/web/state/howtos/load-data-on-route-change.md)
-    - [Work with HostBindings](/rx-angular/web/state/howtos/hostbindings.md)
-    - [Use RxState as Global State](/rx-angular/web/state/howtos/rx-state-as-global-state.md)
+    - [Determine state type](/web/state/howtos/determine-state.md)
+    - [Manage ViewModel](/web/state/howtos/manage-viewmodel.md)
+    - [Run partial updates](/web/state/howtos/partial-updates.md)
+    - [Load data on route change](/web/state/howtos/load-data-on-route-change.md)
+    - [Work with HostBindings](/web/state/howtos/hostbindings.md)
+    - [Use RxState as Global State](/web/state/howtos/rx-state-as-global-state.md)
 
   - Integrations
 
-    - [Reuse ngrx selectors to compose state](/rx-angular/web/state/integrations/compose-state-using-ngrx-selectors.md)
-    - [Manage entities using `@ngrx/entity`](/rx-angular/web/state/integrations/manage-entities-ngrx.md)
+    - [Reuse ngrx selectors to compose state](/web/state/integrations/compose-state-using-ngrx-selectors.md)
+    - [Manage entities using `@ngrx/entity`](/web/state/integrations/manage-entities-ngrx.md)
 
 ---
 


### PR DESCRIPTION
History based route not working properly with Github Pages. Direct links open 404 page. 🤕

The workaround for this is to serve the whole documentation using redirects from the 404 page. This hack is not recommended and not SEO friendly.

See these issues: 
- https://github.com/docsifyjs/docsify/issues/238
- https://github.com/facebook/create-react-app/issues/1765