### PR TITLE
fix(viewport-prio): disconnect the observer to allow the directive to be GCed

### DIFF
--- a/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
+++ b/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
@@ -134,6 +134,8 @@ export class ViewportPrioDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.observer && this.observer.disconnect();
+    if (this.observer) {
+      this.observer.disconnect();
+    }
   }
 }

--- a/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
+++ b/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, OnInit, Optional } from '@angular/core';
+import { Directive, ElementRef, OnDestroy, OnInit, Optional } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { filter, map, mergeAll, tap, withLatestFrom } from 'rxjs/operators';
 import { getZoneUnPatchedApi } from '../../core';
@@ -73,7 +73,7 @@ const observerSupported = () =>
   // tslint:disable-next-line:directive-selector
   selector: '[viewport-prio]'
 })
-export class ViewportPrioDirective implements OnInit {
+export class ViewportPrioDirective implements OnInit, OnDestroy {
   entriesSubject = new Subject<IntersectionObserverEntry[]>();
   entries$: Observable<IntersectionObserverEntry> = this.entriesSubject.pipe(
     mergeAll()
@@ -131,5 +131,9 @@ export class ViewportPrioDirective implements OnInit {
         })
       )
       .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.observer && this.observer.disconnect();
   }
 }


### PR DESCRIPTION
Hey! I didn't open an issue since this seems to be a tiny change. Currently, the `IntersectionObserver` is not disconnected and prevents the `ViewportPrioDirective` and `LetDirective` to be garbage collected.