### PR TITLE
fix: use Angular variable to get the `globalThis`

### DIFF
--- a/libs/template/src/lib/core/utils/get-global-this.ts
+++ b/libs/template/src/lib/core/utils/get-global-this.ts
@@ -1,3 +1,5 @@
+import { ɵglobal } from '@angular/core';
+
 /**
  * @description
  *
@@ -11,5 +13,5 @@
  *  @return {globalThis} - A reference to globalThis. `window` in the Browser.
  */
 export function getGlobalThis(): any {
-  return ((window as any) || (self as any) || (globalThis as any)) as any;
+  return ɵglobal;
 }


### PR DESCRIPTION
Previously it was throwing `window is not defined` in Node.js environment.