### PR TITLE
build: do not publish Ivy compiled packages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -514,11 +514,6 @@
           "options": {
             "tsConfig": "libs/state/tsconfig.lib.json",
             "project": "libs/state/ng-package.json"
-          },
-          "configurations": {
-            "production": {
-              "tsConfig": "libs/state/tsconfig.lib.prod.json"
-            }
           }
         },
         "lint": {
@@ -595,7 +590,7 @@
           "options": {
             "commands": [
               {
-                "command": "nx test state && nx build state --prod && cd ./dist/libs/state && npm publish"
+                "command": "nx test state && nx build state && cd ./dist/libs/state && npm publish"
               }
             ]
           }
@@ -618,11 +613,6 @@
           "options": {
             "tsConfig": "libs/template/tsconfig.lib.json",
             "project": "libs/template/ng-package.json"
-          },
-          "configurations": {
-            "production": {
-              "tsConfig": "libs/template/tsconfig.lib.prod.json"
-            }
           }
         },
         "build-schematics": {
@@ -707,7 +697,7 @@
           "options": {
             "commands": [
               {
-                "command": "nx test template && nx build template --prod && cd ./dist/libs/template && npm publish"
+                "command": "nx test template && nx build template && cd ./dist/libs/template && npm publish"
               }
             ]
           }

--- a/libs/state/tsconfig.lib.json
+++ b/libs/state/tsconfig.lib.json
@@ -12,6 +12,7 @@
     ]
   },
   "angularCompilerOptions": {
+    "enableIvy": false,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "enableResourceInlining": true

--- a/libs/state/tsconfig.lib.prod.json
+++ b/libs/state/tsconfig.lib.prod.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.lib.json",
-  "angularCompilerOptions": {
-    "enableIvy": false
-  }
-}

--- a/libs/template/tsconfig.lib.json
+++ b/libs/template/tsconfig.lib.json
@@ -12,6 +12,7 @@
     ]
   },
   "angularCompilerOptions": {
+    "enableIvy": false,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "enableResourceInlining": true

--- a/libs/template/tsconfig.lib.prod.json
+++ b/libs/template/tsconfig.lib.prod.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.lib.json",
-  "angularCompilerOptions": {
-    "enableIvy": false
-  }
-}


### PR DESCRIPTION
Note that `package` builder doesn't support configurations. You can check it with:

```js
$ node
{ execSync } = require('child_process')
packageImpl = require('@nrwl/angular/src/builders/package/package.impl')
run = packageImpl.run
packageImpl.run = (options, context) => {
  console.log(options.tsConfig);
  return run(options, context);
}
execSync('yarn build template --prod --skip-nx-cache').toString()
```