### PR TITLE
build: remove barrel files for modules and directives since it breaks metadata collection

### DIFF
--- a/libs/template/spec/let/let.directive.complete.spec.ts
+++ b/libs/template/spec/let/let.directive.complete.spec.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
 import { EMPTY, Observable, of } from 'rxjs';
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { LetDirective } from '../../src/lib/let';
+import { LetDirective } from '../../src/lib/let/let.directive';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries
 import { mockConsole } from '@test-helpers';

--- a/libs/template/spec/let/let.directive.error.spec.ts
+++ b/libs/template/spec/let/let.directive.error.spec.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { LetDirective } from '../../src/lib/let';
+import { LetDirective } from '../../src/lib/let/let.directive';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries
 import { mockConsole } from '@test-helpers';

--- a/libs/template/spec/let/let.directive.next.spec.ts
+++ b/libs/template/spec/let/let.directive.next.spec.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
 import { EMPTY, interval, NEVER, Observable, of } from 'rxjs';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { LetDirective } from '../../src/lib/let';
+import { LetDirective } from '../../src/lib/let/let.directive';
 import { take } from 'rxjs/operators';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries

--- a/libs/template/spec/let/let.directive.rendered.spec.ts
+++ b/libs/template/spec/let/let.directive.rendered.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 // tslint:disable-next-line:nx-enforce-module-boundaries
 import { mockConsole } from '@test-helpers';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { LetDirective } from '../../src/lib/let';
+import { LetDirective } from '../../src/lib/let/let.directive';
 import { MockChangeDetectorRef } from '../fixtures';
 
 @Component({

--- a/libs/template/spec/let/let.directive.strategy.spec.ts
+++ b/libs/template/spec/let/let.directive.strategy.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@an
 import { RenderStrategy } from '../../src/lib/core/render-aware/interfaces';
 import { Observable, of } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
-import { LetDirective } from '../../src/lib/let';
+import { LetDirective } from '../../src/lib/let/let.directive';
 import { DEFAULT_STRATEGY_NAME } from '../../src/lib/render-strategies/strategies/strategies-map';
 import { MockChangeDetectorRef } from '../fixtures';
 // tslint:disable-next-line:nx-enforce-module-boundaries

--- a/libs/template/spec/push/push.pipe.service.spec.ts
+++ b/libs/template/spec/push/push.pipe.service.spec.ts
@@ -1,4 +1,4 @@
-import { PushPipe } from '../../src/lib/push';
+import { PushPipe } from '../../src/lib/push/push.pipe';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ChangeDetectorRef } from '@angular/core';
 import { EMPTY, NEVER, of } from 'rxjs';

--- a/libs/template/spec/push/push.pipe.spec.ts
+++ b/libs/template/spec/push/push.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { PushPipe } from '../../src/lib/push';
+import { PushPipe } from '../../src/lib/push/push.pipe';
 import { TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { EMPTY, NEVER, Observable, of } from 'rxjs';

--- a/libs/template/src/index.ts
+++ b/libs/template/src/index.ts
@@ -12,26 +12,32 @@ export {
 export { coalesceWith } from './lib/render-strategies/rxjs/operators/coalesceWith';
 export { rxMaterialize } from './lib/core/utils/rx-materialize';
 export { staticCoalesce } from './lib/render-strategies/static';
-export {
-  UnpatchEventsDirective,
-  UnpatchEventsModule,
-} from './lib/experimental/unpatch/events';
-export {
-  ViewportPrioModule,
-  ViewportPrioDirective,
-} from './lib/experimental/viewport-prio';
+
+export { UnpatchEventsModule } from './lib/experimental/unpatch/events/unpatch-events.experimental.module';
+export { UnpatchEventsDirective } from './lib/experimental/unpatch/events/unpatch-events.experimental.directive';
+
+export { ViewportPrioModule } from './lib/experimental/viewport-prio/viewport-prio.module';
+export { ViewportPrioDirective } from './lib/experimental/viewport-prio/viewport-prio.experimental.directive';
+
 // @TODO clarify if we should exports this
 export { getZoneUnPatchedApi, isNgZone, coalescingManager } from './lib/core';
 export { isViewEngineIvy } from './lib/experimental/core/utils/view-engine-checks.experimental';
 
 // STABLE
-export { RxViewContext, RxTemplateObserver, RxNotificationKind } from './lib/core/model';
+export {
+  RxViewContext,
+  RxTemplateObserver,
+  RxNotificationKind,
+} from './lib/core/model';
 
 export {
   getStrategies,
   priorityTickMap,
-  SchedulingPriority
+  SchedulingPriority,
 } from './lib/render-strategies';
 
-export { PushPipe, PushModule } from './lib/push';
-export { LetDirective, LetModule } from './lib/let';
+export { PushPipe } from './lib/push/push.pipe';
+export { PushModule } from './lib/push/push.module';
+
+export { LetModule } from './lib/let/let.module';
+export { LetDirective } from './lib/let/let.directive';

--- a/libs/template/src/lib/experimental/unpatch/events/index.ts
+++ b/libs/template/src/lib/experimental/unpatch/events/index.ts
@@ -1,2 +1,0 @@
-export * from './unpatch-events.experimental.directive';
-export * from './unpatch-events.experimental.module';

--- a/libs/template/src/lib/experimental/unpatch/index.ts
+++ b/libs/template/src/lib/experimental/unpatch/index.ts
@@ -1,1 +1,0 @@
-export * from './events';

--- a/libs/template/src/lib/experimental/viewport-prio/index.ts
+++ b/libs/template/src/lib/experimental/viewport-prio/index.ts
@@ -1,2 +1,0 @@
-export * from './viewport-prio.experimental.directive';
-export * from './viewport-prio.module';

--- a/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
+++ b/libs/template/src/lib/experimental/viewport-prio/viewport-prio.experimental.directive.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, OnInit, Optional } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { filter, map, mergeAll, tap, withLatestFrom } from 'rxjs/operators';
 import { getZoneUnPatchedApi } from '../../core';
-import { LetDirective } from '../../let';
+import { LetDirective } from '../../let/let.directive';
 
 /**
  *

--- a/libs/template/src/lib/let/index.ts
+++ b/libs/template/src/lib/let/index.ts
@@ -1,2 +1,0 @@
-export * from './let.directive';
-export * from './let.module';

--- a/libs/template/src/lib/push/index.ts
+++ b/libs/template/src/lib/push/index.ts
@@ -1,2 +1,0 @@
-export * from './push.pipe';
-export * from './push.module';


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/7337691/106536657-912dc280-6501-11eb-9e27-f630fb6be700.png)

---

**After:**

![image](https://user-images.githubusercontent.com/7337691/106536670-9c80ee00-6501-11eb-9d41-a301d228f2d0.png)
