### PR TITLE
chore(build): remove deep import

### DIFF
--- a/libs/template/src/lib/core/model.ts
+++ b/libs/template/src/lib/core/model.ts
@@ -1,5 +1,4 @@
-import { Notification } from 'rxjs';
-import { PartialObserver } from 'rxjs/internal/types';
+import { Notification, PartialObserver } from 'rxjs';
 
 export interface RxViewContext<T> {
   // to enable `let` syntax we have to use $implicit (var; let v = var)


### PR DESCRIPTION
> Warning: Entry point '@rx-angular/template' contains deep imports into 'node_modules/rxjs/internal/types'. This is probably not a problem, but may cause the compilation of entry points to be out of order.