### PR TITLE
fix: ng-add for rx-template

### DIFF
--- a/libs/template/tsconfig.schematics.json
+++ b/libs/template/tsconfig.schematics.json
@@ -11,7 +11,7 @@
     "noImplicitThis": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
-    "rootDir": "schematics/src",
+    "rootDir": "schematics",
     "outDir": "../../dist/libs/template/schematics",
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Currently due to the root path src folder is not generated in the dist folder.

and the schematics look for below files when executed inside src 
 "schema": "./src/commands/ng-add/schema.json",
 "factory": "./src/commands/ng-add/index#ngAdd",

The solution was one of the below.
1. Change the root path from tsconfig.schematics.json
2. move files outside src and refer the path, and change the root path as well.