### PR TITLE
feat(cdk): improve template manager view-context

### DIFF
--- a/apps/demos/src/app/app.module.ts
+++ b/apps/demos/src/app/app.module.ts
@@ -24,8 +24,8 @@ import { HomeComponent } from './features/home/home.component';
     {
       provide: RX_ANGULAR_CONFIG,
       useValue: {
-        primaryStrategy: 'immediate',
-        patchZone: false
+        primaryStrategy: 'normal',
+        patchZone: true
       }
     }
   ],

--- a/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.component.ts
+++ b/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Component({

--- a/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.component.ts
+++ b/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
   template: `
     <rxa-visualizer>
       <div visualizerHeader>
-        <h2>rxLet POC</h2>
+        <h2>rxLet BASIC</h2>
         <rxa-strategy-select
           (strategyChange)="strategy = $event"
         ></rxa-strategy-select>

--- a/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.module.ts
+++ b/apps/demos/src/app/features/template/rx-let/basic/rx-let-basic.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterModule, Routes } from '@angular/router';
 import { DirtyChecksModule } from '../../../../rx-angular-pocs/cdk/debug/dirty-check/dirty-checks.module';
-import { RxLetModule } from '../../../../rx-angular-pocs/template/directives/let/let.module';
 import { UnpatchEventsModule } from '../../../../rx-angular-pocs/template/directives/unpatch/unpatch-events.module';
 import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select/strategy-select.module';
 import { ValueProvidersModule } from '../../../../shared/debug-helper/value-provider/value-providers.module';
 import { VisualizerModule } from '../../../../shared/debug-helper/visualizer/visualizer.module';
 import { RxLetBasicComponent } from './rx-let-basic.component';
+import { LetModule } from '@rx-angular/template';
 
 const routes: Routes = [
   {
@@ -26,7 +26,7 @@ const routes: Routes = [
     UnpatchEventsModule,
     StrategySelectModule,
     VisualizerModule,
-    RxLetModule,
+    LetModule,
   ],
 })
 export class RxLetBasicModule {}

--- a/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-http-example.component.ts
+++ b/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-http-example.component.ts
@@ -61,10 +61,11 @@ import { map, share, switchMap, takeUntil, withLatestFrom } from 'rxjs/operators
         <h2>Completed!</h2>
       </div>
     </ng-template>
-    <ng-template #error>
+    <ng-template #error let-value let-error="$error">
       <div>
         <mat-icon class="error-icon">thumb_down</mat-icon>
-        <h2>Something went wrong...</h2>
+        <h2>{{ error }}</h2>
+        <strong>Last valid value: {{ value }}</strong>
       </div>
     </ng-template>
     <ng-template #suspense>

--- a/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-subject-example.component.ts
+++ b/apps/demos/src/app/features/template/rx-let/let-template-binding/examples/let-template-binding-subject-example.component.ts
@@ -48,16 +48,18 @@ import { scan, startWith } from 'rxjs/operators';
       </mat-card-actions>
     </mat-card>
 
-    <ng-template #complete>
+    <ng-template #complete let-value>
       <div>
         <mat-icon class="notification-icon complete-icon">thumb_up</mat-icon>
         <h2>Completed!</h2>
+        <strong>Last valid value: {{ value }}</strong>
       </div>
     </ng-template>
-    <ng-template #error>
+    <ng-template #error let-value let-error="$error">
       <div>
-        <mat-icon class="notification-icon error-icon">thumb_down</mat-icon>
-        <h2>Something went wrong...</h2>
+        <mat-icon class="error-icon">thumb_down</mat-icon>
+        <h2>{{ error }}</h2>
+        <strong>Last valid value: {{ value }}</strong>
       </div>
     </ng-template>
     <ng-template #suspense>

--- a/apps/demos/src/app/shared/debug-helper/strategy-select/strategy-select.module.ts
+++ b/apps/demos/src/app/shared/debug-helper/strategy-select/strategy-select.module.ts
@@ -2,9 +2,8 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { PushModule, UnpatchEventsModule } from '@rx-angular/template';
+import { LetModule, PushModule, UnpatchEventsModule } from '@rx-angular/template';
 import { RxForModule } from '../../../rx-angular-pocs/template/directives/for/rx-for.module';
-import { RxLetModule } from '../../../rx-angular-pocs/template/directives/let/let.module';
 import { StrategySelectComponent } from './strategy-select/strategy-select.component';
 
 @NgModule({
@@ -16,7 +15,7 @@ import { StrategySelectComponent } from './strategy-select/strategy-select.compo
     MatIconModule,
     MatSelectModule,
     RxForModule,
-    RxLetModule,
+    LetModule,
   ],
   exports: [StrategySelectComponent],
 })

--- a/libs/cdk/src/lib/model.ts
+++ b/libs/cdk/src/lib/model.ts
@@ -24,27 +24,27 @@ export type RxNextNotification<T> = Pick<
 > & {
   kind: RxNotificationKind;
 } & { error: boolean } & { complete: boolean };
-export type RxSuspenseNotification = Pick<
-  Notification<unknown>,
+export type RxSuspenseNotification<T> = Pick<
+  Notification<T>,
   RxNotificationValue
 > & { kind: RxNotificationKind.suspense } & { error: false } & {
   complete: false;
 };
-export type RxErrorNotification = Pick<
-  Notification<unknown>,
+export type RxErrorNotification<T> = Pick<
+  Notification<T>,
   RxNotificationValue
 > & { kind: RxNotificationKind.error } & { error: any } & { complete: false };
-export type RxCompleteNotification = Pick<
-  Notification<unknown>,
+export type RxCompleteNotification<T> = Pick<
+  Notification<T>,
   RxNotificationValue
 > & { kind: RxNotificationKind.complete } & { complete: boolean } & {
   error: false;
 };
 export type RxNotification<T> =
   | RxNextNotification<T>
-  | RxSuspenseNotification
-  | RxErrorNotification
-  | RxCompleteNotification;
+  | RxSuspenseNotification<T>
+  | RxErrorNotification<T>
+  | RxCompleteNotification<T>;
 
 export type RxRenderWork = <T = unknown>(
   cdRef: ChangeDetectorRef,

--- a/libs/cdk/src/lib/utils/notification-transforms.ts
+++ b/libs/cdk/src/lib/utils/notification-transforms.ts
@@ -5,31 +5,37 @@ import {
   RxCompleteNotification,
 } from '../model';
 
-export const toRxErrorNotification = (
+export function toRxErrorNotification<T>(
   error?: any,
-  value?: any
-): RxErrorNotification => ({
-  kind: RxNotificationKind.error,
-  hasValue: value || false,
-  value: value || undefined,
-  complete: false,
-  error: error || true,
-});
-export const toRxSuspenseNotification = (
-  value?: any
-): RxSuspenseNotification => ({
-  kind: RxNotificationKind.suspense,
-  hasValue: value || false,
-  value,
-  complete: false,
-  error: false,
-});
-export const toRxCompleteNotification = (
-  value?: any
-): RxCompleteNotification => ({
-  kind: RxNotificationKind.complete,
-  hasValue: value || false,
-  value,
-  complete: true,
-  error: false,
-});
+  value?: T
+): RxErrorNotification<T> {
+  return {
+    kind: RxNotificationKind.error,
+    hasValue: !!value || false,
+    value: value,
+    complete: false,
+    error: error || true,
+  };
+}
+export function toRxSuspenseNotification<T>(
+  value?: T
+): RxSuspenseNotification<T> {
+  return {
+    kind: RxNotificationKind.suspense,
+    hasValue: !!value || false,
+    value,
+    complete: false,
+    error: false,
+  };
+}
+export function toRxCompleteNotification<T>(
+  value?: T
+): RxCompleteNotification<T> {
+  return {
+    kind: RxNotificationKind.complete,
+    hasValue: !!value || false,
+    value,
+    complete: true,
+    error: false,
+  };
+}

--- a/libs/cdk/src/lib/utils/rxMaterialize.ts
+++ b/libs/cdk/src/lib/utils/rxMaterialize.ts
@@ -6,6 +6,10 @@ import {
   RxNotificationKind,
 } from '../model';
 import { map, materialize, tap } from 'rxjs/operators';
+import {
+  toRxCompleteNotification,
+  toRxErrorNotification,
+} from './notification-transforms';
 
 const notificationToRxNotification = <T>(
   notification: Notification<T>
@@ -31,25 +35,6 @@ const rxJsToRxA: Record<'N' | 'E' | 'C', RxNotificationKind> = {
   E: RxNotificationKind.error,
   N: RxNotificationKind.next,
 };
-
-const toRxErrorNotification = (
-  error?: any,
-  value?: any
-): RxErrorNotification => ({
-  kind: RxNotificationKind.error,
-  hasValue: value || false,
-  value: value || undefined,
-  complete: false,
-  error: error || true,
-});
-// const toRxSuspenseNotification = (value?: any): RxSuspenseNotification => ({kind: RxNotificationKind.suspense, hasValue: value || false, value, complete: false, error: false});
-const toRxCompleteNotification = (value?: any): RxCompleteNotification => ({
-  kind: RxNotificationKind.complete,
-  hasValue: value || false,
-  value,
-  complete: true,
-  error: false,
-});
 
 export function rxMaterialize<T>(): OperatorFunction<T, RxNotification<T>> {
   return (o$: Observable<T>): Observable<RxNotification<T>> =>

--- a/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
+++ b/libs/template/spec/let/let.directive.template-binding.no-complete.spec.ts
@@ -9,16 +9,13 @@ import { RX_ANGULAR_CONFIG } from '@rx-angular/cdk';
 
 @Component({
   template: `
-    <ng-container *rxLet="value$; let value; rxSuspense: suspense; rxError: error;">{{
+    <ng-container *rxLet="value$; let value;">{{
       value === undefined
         ? 'undefined'
         : value === null
         ? 'null'
         : (value | json)
     }}</ng-container>
-
-    <ng-template #error>error</ng-template>
-    <ng-template #suspense>suspense</ng-template>
   `
 })
 class LetDirectiveNoCompleteTemplateTestComponent {


### PR DESCRIPTION
# Description

When an observable bound to an `rxLet` (TemplateManager) `completes` or `errors` it is not possible to display the latest value in the provided templates.
I have improved the `RxTemplateManager` and `templateNotifier` so that the `RxViewContext` will always contain the latest emitted value of the bound value.

A little example:
![rx-let-viewcontext](https://user-images.githubusercontent.com/4904455/109306752-e9758d00-783f-11eb-95d0-5c01185051b9.gif)


Example code:

```html
<ng-template #error let-value let-error="$error">
      <div>
        <mat-icon class="error-icon">thumb_down</mat-icon>
        <h2>{{ error }}</h2>
        <strong>Last valid value: {{ value }}</strong>
      </div>
    </ng-template>
```

```html
<ng-template #complete let-value>
      <div>
        <mat-icon class="notification-icon complete-icon">thumb_up</mat-icon>
        <h2>Completed!</h2>
        <strong>Last valid value: {{ value }}</strong>
      </div>
    </ng-template>
```

Additionally we should talk about the naming of the variables inside the `RxViewContext`. I don't know why prefix all variables with `$`? (`let-error="$error"`) It is only good for `$implicit` since this is a reserved key of angular. All other variables should not contain this imo. @BioPhoton @Karnaukhov-kh . Any suggestions?
