### PR TITLE
fix(build): make sure cdk gets build when template gets build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -718,7 +718,7 @@
                 "command": "rimraf dist/libs/template"
               },
               {
-                "command": "ng run template:build-lib"
+                "command": "ng run template:build-lib --with-deps"
               },
               {
                 "command": "nx run template:build-schematics"

--- a/nx.json
+++ b/nx.json
@@ -31,7 +31,8 @@
       "tags": ["type:util"]
     },
     "cdk": {
-      "tags": ["type:lib", "type:cdk"]
+      "tags": ["type:lib", "type:cdk"],
+      "implicitDependencies": ["template"]
     },
     "state": {
       "tags": ["type:lib"]

--- a/nx.json
+++ b/nx.json
@@ -31,8 +31,7 @@
       "tags": ["type:util"]
     },
     "cdk": {
-      "tags": ["type:lib", "type:cdk"],
-      "implicitDependencies": ["template"]
+      "tags": ["type:lib", "type:cdk"]
     },
     "state": {
       "tags": ["type:lib"]


### PR DESCRIPTION
set `@rx-angular/template` as `implicitDependency` for `@rx-angular/cdk`. This ensures `cdk` gets build whenever `template` gets build. This way we ensure `template` has a built version of `cdk` whenever it needs