### PR TITLE
fix(list-manager): fix list manager return value

### DIFF
--- a/libs/cdk/src/lib/template-management/list-template-manager.ts
+++ b/libs/cdk/src/lib/template-management/list-template-manager.ts
@@ -118,7 +118,7 @@ export function createListTemplateManager<
         // Cancel old renders
         switchMap(([{ changes, items }, strategy]) => {
           if (!changes) {
-            return [];
+            return of([]);
           }
           const listChanges = listViewHandler.getListChanges(changes, items);
           changesArr = listChanges[0];


### PR DESCRIPTION
## Description

The current implementation returns `[]` when no changes were detected from the `IterableDiffer`. This causes the `switchMap` to stop emitting values which in turn results in no `renderCallback` called.

```ts
// list-template-manager.ts 119
switchMap(([{ changes, items }, strategy]) => {
          if (!changes) {
            return [];
          }
```

When u put an empty array `[]` into the `rxFor` directive (aka listManager), the `renderCallback` won't emit properly. Imho a new value which results in no change should trigger `renderCallback` since the change got processed.

## Fix

```ts
// list-template-manager.ts 119
switchMap(([{ changes, items }, strategy]) => {
          if (!changes) {
            return of([]); // of should be fine even though it completes since this gets ignored currently? Do we have to keep future rxComplete, rxError templates in mind and use NEVER.pipe(mapTo([])) instead??
          }
```