### PR TITLE
Fix labeler from forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler/blob/master/README.md
 
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
Referring to [this comment](https://github.com/actions/labeler/issues/12#issuecomment-670967607) should fix the labeler not working from forks.