### PR TITLE
perf(cdk): use existing `rxjs` schedulers

### DIFF
--- a/apps/demos/src/app/rx-angular-pocs/template/directives/unpatch/unpatch-events.directive.ts
+++ b/apps/demos/src/app/rx-angular-pocs/template/directives/unpatch/unpatch-events.directive.ts
@@ -27,7 +27,7 @@ export function unpatchEventListener(elem: HTMLElement, event: string): void {
     // Remove and reapply listeners with patched API
     elem.removeEventListener(event, listener);
     // Reapply listeners with un-patched API
-    unpatchAddEventListener(event).addEventListener(listener);
+    unpatchAddEventListener(elem).addEventListener(event, listener);
   });
 }
 

--- a/libs/cdk/zone-less/src/browser/browser.ts
+++ b/libs/cdk/zone-less/src/browser/browser.ts
@@ -152,11 +152,13 @@ export function clearTimeout(id: number): void {
 
 /**
  * This function is a zone un-patched implementation of Element#addEventListener() method.
- * @param elem
+ * @param target
  */
-export function unpatchAddEventListener(elem) {
-  elem.addEventListener = getZoneUnPatchedApi('addEventListener', elem).bind(
-    elem
-  );
-  return elem;
+export function unpatchAddEventListener<T extends EventTarget>(target: T): T {
+  target.addEventListener = getZoneUnPatchedApi(
+    'addEventListener',
+    target
+  ).bind(target);
+
+  return target;
 }

--- a/libs/cdk/zone-less/src/index.ts
+++ b/libs/cdk/zone-less/src/index.ts
@@ -16,7 +16,7 @@ export { timer } from './rxjs/observable/timer';
 
 export { fromEvent } from './rxjs/operators/fromEvent';
 
-export { async as asyncScheduler } from './rxjs/scheduler/async/async';
-export { asap } from './rxjs/scheduler/asap/asap';
-export { queue } from './rxjs/scheduler/queue/queue';
-export { animationFrame } from './rxjs/scheduler/animation-frame/animationFrame';
+export { asyncScheduler } from './rxjs/scheduler/async/async';
+export { asapScheduler } from './rxjs/scheduler/asap/asap';
+export { queueScheduler } from './rxjs/scheduler/queue/queue';
+export { animationFrameScheduler } from './rxjs/scheduler/animation-frame/animationFrame';

--- a/libs/cdk/zone-less/src/rxjs/observable/interval.ts
+++ b/libs/cdk/zone-less/src/rxjs/observable/interval.ts
@@ -1,5 +1,5 @@
 import { Observable, SchedulerAction, SchedulerLike, Subscriber } from 'rxjs';
-import { async } from '../scheduler/async/async';
+import { asyncScheduler } from '../scheduler/async/async';
 import { isNumeric } from './utils';
 
 /**
@@ -52,14 +52,14 @@ import { isNumeric } from './utils';
  */
 export function interval(
   period = 0,
-  scheduler: SchedulerLike = async
+  scheduler: SchedulerLike = asyncScheduler
 ): Observable<number> {
   if (!isNumeric(period) || period < 0) {
     period = 0;
   }
 
   if (!scheduler || typeof scheduler.schedule !== 'function') {
-    scheduler = async;
+    scheduler = asyncScheduler;
   }
 
   return new Observable<number>((subscriber) => {

--- a/libs/cdk/zone-less/src/rxjs/observable/timer.ts
+++ b/libs/cdk/zone-less/src/rxjs/observable/timer.ts
@@ -1,5 +1,5 @@
 import { Observable, SchedulerAction, SchedulerLike, Subscriber } from 'rxjs';
-import { async } from '../scheduler/async/async';
+import { asyncScheduler } from '../scheduler/async/async';
 import { isNumeric, isScheduler } from './utils';
 
 /**
@@ -65,7 +65,7 @@ export function timer(
   }
 
   if (!isScheduler(scheduler)) {
-    scheduler = async;
+    scheduler = asyncScheduler;
   }
 
   return new Observable((subscriber) => {

--- a/libs/cdk/zone-less/src/rxjs/scheduler/Scheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/Scheduler.ts
@@ -1,12 +1,5 @@
 // tslint:disable
-import { Subscription } from 'rxjs';
-import { Action } from './Action';
-import { SchedulerAction, SchedulerLike } from './types';
-
-export function nowFn() {
-  const fn = () => Date.now();
-  return fn;
-}
+import { SchedulerLike } from './types';
 
 /**
  * An execution context and a data structure to order tasks and schedule their
@@ -27,53 +20,4 @@ export function nowFn() {
  * should not be used directly. Rather, create your own class and implement
  * {@link SchedulerLike}
  */
-export class Scheduler implements SchedulerLike {
-  /**
-   * Note: the extra arrow function wrapper is to make testing by overriding
-   * Date.now easier.
-   * @nocollapse
-   */
-  public static now: () => number = nowFn();
-
-  constructor(
-    private SchedulerAction: typeof Action,
-    now: () => number = Scheduler.now
-  ) {
-    this.now = now;
-  }
-
-  /**
-   * A getter method that returns a number representing the current time
-   * (at the time this function was called) according to the scheduler's own
-   * internal clock.
-   * @return {number} A number that represents the current time. May or may not
-   * have a relation to wall-clock time. May or may not refer to a time unit
-   * (e.g. milliseconds).
-   */
-  public now: () => number;
-
-  /**
-   * Schedules a function, `work`, for execution. May happen at some point in
-   * the future, according to the `delay` parameter, if specified. May be passed
-   * some context object, `state`, which will be passed to the `work` function.
-   *
-   * The given arguments will be processed an stored as an Action object in a
-   * queue of actions.
-   *
-   * @param {function(state: ?T): ?Subscription} work A function representing a
-   * task, or some unit of work to be executed by the Scheduler.
-   * @param {number} [delay] Time to wait before executing the work, where the
-   * time unit is implicit and defined by the Scheduler itself.
-   * @param {T} [state] Some contextual data that the `work` function uses when
-   * called by the Scheduler.
-   * @return {Subscription} A subscription in order to be able to unsubscribe
-   * the scheduled work.
-   */
-  public schedule<T>(
-    work: (this: SchedulerAction<T>, state?: T) => void,
-    delay: number = 0,
-    state?: T
-  ): Subscription {
-    return new this.SchedulerAction<T>(this, work).schedule(state, delay);
-  }
-}
+export type Scheduler = SchedulerLike;

--- a/libs/cdk/zone-less/src/rxjs/scheduler/animation-frame/AnimationFrameScheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/animation-frame/AnimationFrameScheduler.ts
@@ -1,31 +1,4 @@
 // tslint:disable
-import { AsyncAction } from '../async/AsyncAction';
 import { AsyncScheduler } from '../async/AsyncScheduler';
 
-export class AnimationFrameScheduler extends AsyncScheduler {
-  public flush(action?: AsyncAction<any>): void {
-    this.active = true;
-    this.scheduled = undefined;
-
-    const { actions } = this;
-    let error: any;
-    let index: number = -1;
-    let count: number = actions.length;
-    action = action || actions.shift();
-
-    do {
-      if ((error = action!.execute(action!.state, action!.delay))) {
-        break;
-      }
-    } while (++index < count && (action = actions.shift()));
-
-    this.active = false;
-
-    if (error) {
-      while (++index < count && (action = actions.shift())) {
-        action.unsubscribe();
-      }
-      throw error;
-    }
-  }
-}
+export interface AnimationFrameScheduler extends AsyncScheduler {}

--- a/libs/cdk/zone-less/src/rxjs/scheduler/animation-frame/animationFrame.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/animation-frame/animationFrame.ts
@@ -1,6 +1,7 @@
 // tslint:disable file-name-casing
+import * as rxjs from 'rxjs';
 import { AnimationFrameAction } from './AnimationFrameAction';
-import { AnimationFrameScheduler } from './AnimationFrameScheduler';
+import { createScheduler } from '../create-scheduler';
 
 /**
  *
@@ -35,4 +36,7 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
  * // You will see a div element growing in height
  * ```
  */
-export const animationFrame = new AnimationFrameScheduler(AnimationFrameAction);
+export const animationFrameScheduler = createScheduler(
+  rxjs.animationFrameScheduler,
+  AnimationFrameAction
+);

--- a/libs/cdk/zone-less/src/rxjs/scheduler/asap/AsapScheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/asap/AsapScheduler.ts
@@ -1,31 +1,4 @@
 // tslint:disable
-import { AsyncAction } from '../async/AsyncAction';
 import { AsyncScheduler } from '../async/AsyncScheduler';
 
-export class AsapScheduler extends AsyncScheduler {
-  public flush(action?: AsyncAction<any>): void {
-    this.active = true;
-    this.scheduled = undefined;
-
-    const { actions } = this;
-    let error: any;
-    let index: number = -1;
-    let count: number = actions.length;
-    action = action || actions.shift();
-
-    do {
-      if ((error = action!.execute(action!.state, action!.delay))) {
-        break;
-      }
-    } while (++index < count && (action = actions.shift()));
-
-    this.active = false;
-
-    if (error) {
-      while (++index < count && (action = actions.shift())) {
-        action.unsubscribe();
-      }
-      throw error;
-    }
-  }
-}
+export interface AsapScheduler extends AsyncScheduler {}

--- a/libs/cdk/zone-less/src/rxjs/scheduler/asap/asap.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/asap/asap.ts
@@ -1,6 +1,7 @@
 // tslint:disable file-name-casing
+import * as rxjs from 'rxjs';
 import { AsapAction } from './AsapAction';
-import { AsapScheduler } from './AsapScheduler';
+import { createScheduler } from '../create-scheduler';
 
 /**
  *
@@ -38,4 +39,4 @@ import { AsapScheduler } from './AsapScheduler';
  * // ... but 'asap' goes first!
  * ```
  */
-export const asap = new AsapScheduler(AsapAction);
+export const asapScheduler = createScheduler(rxjs.asapScheduler, AsapAction);

--- a/libs/cdk/zone-less/src/rxjs/scheduler/async/AsyncScheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/async/AsyncScheduler.ts
@@ -1,80 +1,10 @@
 // tslint:disable
 import { AsyncAction } from './AsyncAction';
-import { Action } from '../Action';
 import { Scheduler } from '../Scheduler';
-import { SchedulerAction } from '../types';
-import { Subscription } from 'rxjs';
 
-export class AsyncScheduler extends Scheduler {
-  public static delegate?: Scheduler = null;
-  public actions: Array<AsyncAction<any>> = [];
-  /**
-   * A flag to indicate whether the Scheduler is currently executing a batch of
-   * queued actions.
-   * @type {boolean}
-   * @deprecated internal use only
-   */
-  public active: boolean = false;
-  /**
-   * An internal ID used to track the latest asynchronous task such as those
-   * coming from `setTimeout`, `setInterval`, `requestAnimationFrame`, and
-   * others.
-   * @type {any}
-   * @deprecated internal use only
-   */
-  public scheduled: any = undefined;
-
-  constructor(
-    SchedulerAction: typeof Action,
-    now: () => number = Scheduler.now
-  ) {
-    super(SchedulerAction, () => {
-      if (AsyncScheduler.delegate && AsyncScheduler.delegate !== this) {
-        return AsyncScheduler.delegate.now();
-      } else {
-        return now();
-      }
-    });
-  }
-
-  public schedule<T>(
-    work: (this: SchedulerAction<T>, state?: T) => void,
-    delay: number = 0,
-    state?: T
-  ): Subscription {
-    if (AsyncScheduler.delegate && AsyncScheduler.delegate !== this) {
-      return AsyncScheduler.delegate.schedule(work, delay, state);
-    } else {
-      return super.schedule(work, delay, state);
-    }
-  }
-
-  public flush(action: AsyncAction<any>): void {
-    const { actions } = this;
-
-    if (this.active) {
-      actions.push(action);
-      return;
-    }
-
-    let error: any;
-    this.active = true;
-
-    do {
-      if ((error = action.execute(action.state, action.delay))) {
-        break;
-      }
-      // @ts-ignore
-    } while ((action = actions.shift())); // exhaust the scheduler queue
-
-    this.active = false;
-
-    if (error) {
-      // @ts-ignore
-      while ((action = actions.shift())) {
-        action.unsubscribe();
-      }
-      throw error;
-    }
-  }
+export interface AsyncScheduler extends Scheduler {
+  actions: AsyncAction<any>[];
+  active: boolean;
+  scheduled: any;
+  flush(action: AsyncAction<any>): void;
 }

--- a/libs/cdk/zone-less/src/rxjs/scheduler/async/async.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/async/async.ts
@@ -1,6 +1,7 @@
 // tslint:disable file-name-casing
+import * as rxjs from 'rxjs';
 import { AsyncAction } from './AsyncAction';
-import { AsyncScheduler } from './AsyncScheduler';
+import { createScheduler } from '../create-scheduler';
 
 /**
  *
@@ -50,4 +51,4 @@ import { AsyncScheduler } from './AsyncScheduler';
  * // 3 after 6s
  * ```
  */
-export const async = new AsyncScheduler(AsyncAction);
+export const asyncScheduler = createScheduler(rxjs.asyncScheduler, AsyncAction);

--- a/libs/cdk/zone-less/src/rxjs/scheduler/create-scheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/create-scheduler.ts
@@ -1,0 +1,17 @@
+import { SchedulerLike } from 'rxjs';
+import { Action } from './Action';
+
+/**
+ * Schedulers rely on provided actions and actions are using some asynchronous API
+ * internally, e.g. `setInterval`, etc. We don't wanna copy-paste the code of all schedulers
+ * here since it'll increase the bundle size. We can re-use constructors of RxJS schedulers
+ * and provide our custom actions that use the unpatched API.
+ */
+export function createScheduler<T extends SchedulerLike>(
+  scheduler: T,
+  action: typeof Action
+): T {
+  // The `Reflect.construct` is a cross-browser feature, it's only not supported in IE11,
+  // but apps anyway require polyfills if they want to be run in IE11.
+  return Reflect.construct(scheduler.constructor, [action]);
+}

--- a/libs/cdk/zone-less/src/rxjs/scheduler/queue/QueueAction.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/queue/QueueAction.ts
@@ -1,8 +1,8 @@
 // tslint:disable
 import { AsyncAction } from '../async/AsyncAction';
 import { Subscription } from 'rxjs';
-import { QueueScheduler } from './QueueScheduler';
 import { SchedulerAction } from '../types';
+import { QueueScheduler } from './QueueScheduler';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.

--- a/libs/cdk/zone-less/src/rxjs/scheduler/queue/QueueScheduler.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/queue/QueueScheduler.ts
@@ -1,4 +1,4 @@
 // tslint:disable
 import { AsyncScheduler } from '../async/AsyncScheduler';
 
-export class QueueScheduler extends AsyncScheduler {}
+export interface QueueScheduler extends AsyncScheduler {}

--- a/libs/cdk/zone-less/src/rxjs/scheduler/queue/queue.ts
+++ b/libs/cdk/zone-less/src/rxjs/scheduler/queue/queue.ts
@@ -1,6 +1,7 @@
 // tslint:disable file-name-casing
+import * as rxjs from 'rxjs';
 import { QueueAction } from './QueueAction';
-import { QueueScheduler } from './QueueScheduler';
+import { createScheduler } from '../create-scheduler';
 
 /**
  *
@@ -66,4 +67,4 @@ import { QueueScheduler } from './QueueScheduler';
  * // "after", 1
  * ```
  */
-export const queue = new QueueScheduler(QueueAction);
+export const queueScheduler = createScheduler(rxjs.queueScheduler, QueueAction);


### PR DESCRIPTION
I removed the implementation of all schedulers and just re-used the existing constructors.

I still left interfaces to make the compiler happy, since schedulers are not exposed publicly by rxjs (tho they don't affect the bundle size).