### PR TITLE
chore(ci): run only ssr e2e tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,6 +47,6 @@ jobs:
 
     - run: yarn nx affected:lint --parallel --base=origin/master
     - run: yarn nx affected:test --parallel --base=origin/master
-    - run: yarn nx affected:e2e --parallel --headless --base=origin/master
+    - run: yarn nx run ssr-e2e:e2e --headless --base=origin/master
     # Do not run builds in parallel since it will cause `ngcc` compiler deadlocks.
     - run: yarn nx affected:build --with-deps --base=origin/master


### PR DESCRIPTION
This PR fixes e2e tests in the CI because:

- **demos-e2e** tests are broken
- **vanilla-case-studies-e2e** tests also broken

Suggestion for another PR: fixes demos-e2e (is it relevant?) and remove vanilla-case-studies-e2e