### PR TITLE
Add migration schematic

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -600,6 +600,9 @@
                 "command": "npx cpx libs/template/schematics/collection.json dist/libs/template/schematics"
               },
               {
+                "command": "npx cpx libs/template/schematics/migration.json dist/libs/template/schematics"
+              },
+              {
                 "command": "npx cpx libs/template/schematics/src/**/files/** dist/libs/template/schematics/src"
               },
               {

--- a/libs/template/package.json
+++ b/libs/template/package.json
@@ -59,5 +59,8 @@
   "schematics": "./schematics/collection.json",
   "ng-add": {
     "save": "dependencies"
+  },
+  "ng-update": {
+    "migrations": "./schematics/migration.json"
   }
 }

--- a/libs/template/schematics/migration.json
+++ b/libs/template/schematics/migration.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "template-migration-01": {
+      "version": "1.0.0",
+      "description": "Update @rx-angular/template to version 1.0.0",
+      "factory": "./src/migrations/update-1-0-0"
+    }
+  }
+}

--- a/libs/template/schematics/src/common/utils/changes.ts
+++ b/libs/template/schematics/src/common/utils/changes.ts
@@ -1,0 +1,25 @@
+import { RemoveChange, ReplaceChange } from '@nrwl/workspace/src/utils/ast-utils';
+import * as ts from 'typescript';
+
+export function createRemoveChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  pos = node.getStart(sourceFile),
+  toRemove = node.getFullText(sourceFile)
+): RemoveChange {
+  return new RemoveChange(sourceFile.fileName, pos, toRemove);
+}
+
+export function createReplaceChange(
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+  oldText: string,
+  newText: string
+): ReplaceChange {
+  return new ReplaceChange(
+    sourceFile.fileName,
+    node.getStart(sourceFile),
+    oldText,
+    newText
+  );
+}

--- a/libs/template/schematics/src/common/utils/visitors.ts
+++ b/libs/template/schematics/src/common/utils/visitors.ts
@@ -1,0 +1,44 @@
+import * as ts from 'typescript';
+import { Tree, DirEntry } from '@angular-devkit/schematics';
+
+export function visitTSSourceFiles<Result = void>(
+  tree: Tree,
+  visitor: (
+    sourceFile: ts.SourceFile,
+    tree: Tree,
+    result?: Result
+  ) => Result | undefined
+): Result | undefined {
+  let result: Result | undefined = undefined;
+  for (const sourceFile of visit(tree.root)) {
+    result = visitor(sourceFile, tree, result);
+  }
+
+  return result;
+}
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        const source = ts.createSourceFile(
+          entry.path,
+          content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        yield source;
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules') {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
+}

--- a/libs/template/schematics/src/migrations/update-1-0-0/index.spec.ts
+++ b/libs/template/schematics/src/migrations/update-1-0-0/index.spec.ts
@@ -1,0 +1,167 @@
+import { Tree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+describe('Template Migration 1.0.0', () => {
+  let appTree: UnitTestTree;
+
+  it('should replace LetModule + LetDirective module specifier', async () => {
+    appTree = await setupTestFile(`
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { LetModule, LetDirective } from '@rx-angular/template';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+  ],
+  imports: [
+    BrowserModule,
+    LetModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+  `);
+
+    const file = appTree.readContent('app.module.ts');
+
+    expect(file).not.toContain(
+      "import { LetModule, LetDirective } from '@rx-angular/template'"
+    );
+    expect(file).toContain(
+      "import { LetModule } from '@rx-angular/template/let'"
+    );
+    expect(file).toContain(
+      "import { LetDirective } from '@rx-angular/template/let'"
+    );
+  });
+
+  it('should replace PushModule + PushPipe module specifier', async () => {
+    appTree = await setupTestFile(`
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { PushModule, PushPipe } from '@rx-angular/template';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+  ],
+  imports: [
+    BrowserModule,
+    PushModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+  `);
+
+    const file = appTree.readContent('app.module.ts');
+
+    expect(file).not.toContain(
+      "import { PushModule, PushPipe } from '@rx-angular/template'"
+    );
+    expect(file).toContain(
+      "import { PushModule } from '@rx-angular/template/push'"
+    );
+    expect(file).toContain(
+      "import { PushPipe } from '@rx-angular/template/push'"
+    );
+  });
+
+  it('should replace UnpatchModule + UnpatchDirective module specifier', async () => {
+    appTree = await setupTestFile(`
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { UnpatchModule, UnpatchDirective } from '@rx-angular/template';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+  ],
+  imports: [
+    BrowserModule,
+    UnpatchModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+  `);
+
+    const file = appTree.readContent('app.module.ts');
+
+    expect(file).not.toContain(
+      "import { UnpatchModule, UnpatchDirective } from '@rx-angular/template'"
+    );
+    expect(file).toContain(
+      "import { UnpatchModule } from '@rx-angular/template/unpatch'"
+    );
+    expect(file).toContain(
+      "import { UnpatchDirective } from '@rx-angular/template/unpatch'"
+    );
+  });
+
+  it('should replace all module specifiers', async () => {
+    appTree = await setupTestFile(`
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { LetModule, PushModule, UnpatchModule } from '@rx-angular/template';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+  ],
+  imports: [
+    BrowserModule,
+    UnpatchModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+  `);
+
+    const file = appTree.readContent('app.module.ts');
+
+    expect(file).not.toContain(
+      "import { LetModule, PushModule, UnpatchModule } from '@rx-angular/template'"
+    );
+    expect(file).toContain(
+      "import { LetModule } from '@rx-angular/template/let'"
+    );
+    expect(file).toContain(
+      "import { PushModule } from '@rx-angular/template/push'"
+    );
+    expect(file).toContain(
+      "import { UnpatchModule } from '@rx-angular/template/unpatch'"
+    );
+  });
+
+  function setupTestFile(fileInput: string, filePath = './app.module.ts') {
+    const runner = new SchematicTestRunner(
+      '@rx-angular/template',
+      path.join(__dirname, '../../../migration.json')
+    );
+    const tree = new UnitTestTree(Tree.empty());
+
+    tree.create(filePath, fileInput);
+
+    return runner
+      .runSchematicAsync(`template-migration-01`, {}, tree)
+      .toPromise();
+  }
+});

--- a/libs/template/schematics/src/migrations/update-1-0-0/index.ts
+++ b/libs/template/schematics/src/migrations/update-1-0-0/index.ts
@@ -1,0 +1,60 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+
+import { findNodes } from '@nrwl/workspace';
+import { insert, insertImport } from '@nrwl/workspace/src/utils/ast-utils';
+import { visitTSSourceFiles } from '../../common/utils/visitors';
+import { createRemoveChange } from '../../common/utils/changes';
+
+const renames: Record<string, string> = {
+  LetModule: '@rx-angular/template/let',
+  LetDirective: '@rx-angular/template/let',
+  PushModule: '@rx-angular/template/push',
+  PushPipe: '@rx-angular/template/push',
+  UnpatchDirective: '@rx-angular/template/unpatch',
+  UnpatchModule: '@rx-angular/template/unpatch',
+};
+
+export default function (): Rule {
+  return (tree: Tree) => {
+    visitTSSourceFiles(tree, (sourceFile, tree) => {
+      const imports = sourceFile.statements
+        .filter(ts.isImportDeclaration)
+        .filter(
+          ({ moduleSpecifier }) =>
+            moduleSpecifier.getText(sourceFile) === `'@rx-angular/template'` ||
+            moduleSpecifier.getText(sourceFile) === `"@rx-angular/template"`
+        );
+
+      if (imports.length === 0) {
+        return;
+      }
+
+      const changes = updateTemplateImportDeclarations(sourceFile, imports);
+      insert(tree, sourceFile.fileName, changes);
+    });
+  };
+}
+
+function updateTemplateImportDeclarations(
+  sourceFile: ts.SourceFile,
+  imports: ts.ImportDeclaration[]
+) {
+  return imports
+    .flatMap((importDeclaration) => {
+      const importSpecifiers = findNodes(
+        importDeclaration,
+        ts.SyntaxKind.ImportSpecifier
+      );
+      return importSpecifiers.map((importSpecifier) => ({
+        importDeclaration,
+        importSpecifier: importSpecifier.getText(),
+      }));
+    })
+    .flatMap(({ importDeclaration, importSpecifier }) => {
+      return [
+        createRemoveChange(sourceFile, importDeclaration),
+        insertImport(sourceFile, sourceFile.fileName, importSpecifier, renames[importSpecifier])
+      ];
+    });
+}

--- a/libs/template/tsconfig.schematics.json
+++ b/libs/template/tsconfig.schematics.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2019"],
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",

--- a/libs/template/tsconfig.spec.json
+++ b/libs/template/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2019", "dom"],
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": [


### PR DESCRIPTION
As for now this migration script target versions `< 1.0.0` and assumes next version will be `1.0.0`, let me know if you want to release with another version.