### PR TITLE
refactor(cdk): export pick-slice type

### DIFF
--- a/libs/state/src/lib/index.ts
+++ b/libs/state/src/lib/index.ts
@@ -25,4 +25,4 @@ export {
   toggle,
   slice,
 } from './transformation-helpers/object/index';
-export { KeyCompareMap, CompareFn } from './rxjs/interfaces';
+export { KeyCompareMap, CompareFn, PickSlice } from './rxjs/interfaces';

--- a/libs/state/src/lib/rxjs/interfaces/index.ts
+++ b/libs/state/src/lib/rxjs/interfaces/index.ts
@@ -1,2 +1,3 @@
 export { CompareFn } from './compare-fn';
 export { KeyCompareMap } from './key-compare-map';
+export { PickSlice } from './pick-slice';

--- a/libs/state/src/lib/rxjs/interfaces/pick-slice.ts
+++ b/libs/state/src/lib/rxjs/interfaces/pick-slice.ts
@@ -1,0 +1,2 @@
+export type PickSlice<T extends object, K extends keyof T> = Pick<T,
+  { [I in K]: I }[K]>;

--- a/libs/state/src/lib/rxjs/operators/selectSlice.ts
+++ b/libs/state/src/lib/rxjs/operators/selectSlice.ts
@@ -1,6 +1,6 @@
-import { KeyCompareMap } from '../interfaces';
 import { Observable, OperatorFunction } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
+import { KeyCompareMap, PickSlice } from '../interfaces';
 import { distinctUntilSomeChanged } from './distinctUntilSomeChanged';
 
 /**
@@ -119,5 +119,3 @@ export function selectSlice<T extends object, K extends keyof T>(
     );
 }
 
-type PickSlice<T extends object, K extends keyof T> = Pick<T,
-  { [I in K]: I }[K]>;


### PR DESCRIPTION
## Description

the `selectSlice` operator returns the type `PickSlice` type which is not exported currently. This PR exports the `PickSlice` type for usage in other applications.

closes #821 