### PR TITLE
fix(state): disable Ivy + partial compilation

### DIFF
--- a/libs/state/tsconfig.lib.json
+++ b/libs/state/tsconfig.lib.json
@@ -11,8 +11,7 @@
     "lib": ["dom", "es2018"]
   },
   "angularCompilerOptions": {
-    "enableIvy": "true",
-    "compilationMode": "partial",
+    "enableIvy": false,
     "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,


### PR DESCRIPTION
Revert Ivy and let Ngcc do the job to avoid breaking ViewEngine apps. Fixes #928.