### PR TITLE
test(cdk): coerceDistinctWith unit test

### DIFF
--- a/libs/cdk/coercing/spec/coerceDistinctObservableWith.spec.ts
+++ b/libs/cdk/coercing/spec/coerceDistinctObservableWith.spec.ts
@@ -1,3 +1,5 @@
+// tslint:disable:nx-enforce-module-boundaries
+// eslint:disable:nx-enforce-module-boundaries
 import { concatAll, exhaustAll, mergeAll, Observable, ObservableInput, Subject, take } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 


### PR DESCRIPTION
# Description

Closes #970

This PR adds unit tests for `coerceDistinctWith` under `cdk` package using following flattening operators:

1. `switchAll` (the default)
2. `mergeAll`
3. `concatAll`
4. `exhaustAll`