### PR TITLE
chore(cdk): enable strict mode

### DIFF
--- a/libs/cdk/coalescing/src/lib/coalesceWith.ts
+++ b/libs/cdk/coalescing/src/lib/coalesceWith.ts
@@ -58,7 +58,7 @@ export function coalesceWith<T>(
       outerObserver: Subscriber<T>,
       rootSubscription: Subscription
     ): Observer<T> {
-      let actionSubscription: Unsubscribable;
+      let actionSubscription: Unsubscribable | undefined;
       let latestValue: T | undefined;
 
       const tryEmitLatestValue = () => {

--- a/libs/cdk/tsconfig.lib.json
+++ b/libs/cdk/tsconfig.lib.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "es2015",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "inlineSources": true,
     "importHelpers": true,
     "lib": ["dom", "es2018"]
@@ -13,7 +17,9 @@
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,
+    "strictTemplates": true,
     "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
     "enableResourceInlining": true
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
Fixes #990 .

Seems pretty straightforward. The only thing I haven't finally got my head around ist the following error:

```
libs/cdk/coalescing/src/lib/coalescingManager.ts:69:9 - error TS2345: Argument of type '([prop, value]: [KeyOf<P>, ValueOf<P>]) => void' is not assignable to parameter of type '(value: unknown, index: number, array: unknown[]) => void'.
  Types of parameters '__0' and 'value' are incompatible.
    Type 'unknown' is not assignable to type '[keyof P, ValueOf<P>]'.

69         ([prop, value]: [KeyOf<P>, ValueOf<P>]): void => {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```