### PR TITLE
(Docs) render strategies examples

### DIFF
--- a/libs/cdk/render-strategies/docs/README.md
+++ b/libs/cdk/render-strategies/docs/README.md
@@ -31,7 +31,7 @@ This architecture enables modern features like:
 
 **BasicStrategies**
 
-BasicStrategies wrap modern ivy APIs like `ɵmarkDirty` and `ɵdetectChanges` as well as a strategy to "noop" change detection.
+[BasicStrategies](https://github.com/rx-angular/rx-angular/blob/master/libs/cdk/render-strategies/docs/basic-strategies.md) wrap modern ivy APIs like `ɵmarkDirty` and `ɵdetectChanges` as well as a strategy to "noop" change detection.
 As a fallback for the migration process or comparison testing, Angulars default change detection behaviour is also provided as a strategy.
 
 This set aims to get the first option for zone-less rendering (`ɵmarkDirty`), more control on the top-down process, and improve performance drastically by only rendering components that received updates.
@@ -40,14 +40,14 @@ This set aims to get the first option for zone-less rendering (`ɵmarkDirty`), m
 
 **ConcurrentStrategies**
 
-The ConcurrentStrategies utilize the latest technologies to enable priority-based change detection for non-blocking rendering and smooth user experiences. It combines the most performant scheduling techniques with a highly performant queueing mechanism.
+The [ConcurrentStrategies](https://github.com/rx-angular/rx-angular/blob/master/libs/cdk/render-strategies/docs/concurrent-strategies.md) utilize the latest technologies to enable priority-based change detection for non-blocking rendering and smooth user experiences. It combines the most performant scheduling techniques with a highly performant queueing mechanism.
 Read more about the internal techniques [here](https://www.npmjs.com/package/scheduler) or [here](https://github.com/WICG/scheduling-apis).
 
 The name **ConcurrentStrategies** implies that concepts of [react concurrent mode](https://reactjs.org/docs/concurrent-mode-intro.html) are transported into the world of Angular.
 
 ConcurrentStrategies implement not yet released browser features ([Chrome Canary postTask scheduling](https://www.chromestatus.com/feature/6031161734201344)) already today.
 
-Rendering can be executed with the frame budget [long task](https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API) in mind, prioritized at the level of `Component`'s or even `EmbeddedView`'s and provide an excellent tool to improve performance.
+Rendering can be executed with the frame budget and [long task](https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API) in mind, prioritized at the level of `Component`'s or even `EmbeddedView`'s and provide an excellent tool to improve performance.
 
 With these sets of strategies and the possibility of switching them at runtime we can create tools that align with performance best practices (e.g. [RAIL](https://web.dev/rail/)) and implement expert level optimizations. We can control rendering based on viewport visibility, measure the DOM _after_ rendering or re-render only parts of a component.
 
@@ -85,6 +85,10 @@ The sub-package provides the following features:
 | `"low"`          | 4        | 🠗 `detectChanges` | `postMessage`           | 10000ms         |
 | `"idle"`         | 5        | 🠗 `detectChanges` | `postMessage`           | ❌              |
 
+**Zone notification configuration with patchZone property**
+
+By default any event executed with strategy will be notifying `zone.js`. Using `patchZone` property you can run events completely outside of `zone.js` (`patchZone: false`) or in provided `NgZone` (`patchZone: this.ngZone`).
+
 ## Setup
 
 The render strategies can be used directly from the `cdk` package or indirectly through the `template` package.
@@ -103,11 +107,11 @@ yarn add @rx-angular/cdk
 By default, RxAngular render strategies are preconfigured in a way they are still way more performant than native Angular but focusing on being as non-breaking as possible.
 In the majority of cases, you can just drop in the new features, and everything works as before.
 
-You can then partially enable more performance features on RxAngular.
+You can then partially enable more performance features of RxAngular.
 
 Configurations are done with Angular best practies and based on `InjectionToken`'s.
 
-> As all configurtion are controlled by `RxStrategyProvider`, an Angular service we can apply 
+> As all configurtion are controlled by `RxStrategyProvider`, an Angular service, we can apply 
 > all knowledge of Angular DI on global and local level including all life cycles.
 
 We can configure on the following levels:
@@ -205,17 +209,17 @@ Render strategies can be used with the `StrategyProvider` or `Directive` like `p
 ### Usage in the component
 
 The second best place to control rendering is the component.
-Whenevery you have places in your application that uses `ChangeDetectorRef#markForCheck`, `ChangeDetectorRef#markForCheck` or `ApplicationRef#tick` to trigger change detection,
+Whenever you have places in your application that uses `ChangeDetectorRef#markForCheck`, `ChangeDetectorRef#markForCheck` or `ApplicationRef#tick` to trigger change detection,
 you can refactor that part with strategies.
 
-Some of the cases wayh you might have to use custom change detection are:
+Some of the cases where you might have to use custom change detection are:
 
 - projected content
 - changes not triggered by user interaction
 - integration of third-party libraries
 - detached components
 
-To replace that logic you have to import `StrategyProvider` and use the `scheduleCD` API.
+To replace that logic you have to import `RxStrategyProvider` and use the `scheduleCD` API.
 You can configure a strategy by name. Otherwise, the default one is used.
 This API takes the components `ChangeDetectorRef` and uses one of the registered strategies to render the change.
 You can also configure the used strategy per call.
@@ -252,7 +256,7 @@ Here we again have 2 ways to do it. Over `Pipe`'s or `Directive`'s.
 
 In general, all features in `@rx-angular/template/*` have strategies backed in and are fine-grained configurable.
 
-The second best way of using stragegies in the template is by using the `push` pipe.
+The second best way of using strategies in the template is by using the `push` pipe.
 
 ```html
 <hero-list heroes="list$ | push: 'global'"></hero-list>
@@ -282,17 +286,20 @@ The scheduling logic of the strategies is not only valuable for schedule renderi
 A good example is HTTP requests and response processing. As this logic is not directly reflected in the UI, the user will not realize if it is done a little bit later.
 In this case, we can use a low priority.
 
-Again, `StrategyProvider` needs to get imported, and the scheduling APIs needs to be used.
+Again, `RxStrategyProvider` needs to get imported, and the scheduling APIs needs to be used.
 
 ```typescript
 @Injectable({
   profidedIn: 'root',
 })
 export class AnyService {
-  constructor(public strategyProvider: RxStrategyProvider) {}
+  constructor(
+    public strategyProvider: RxStrategyProvider,
+    private apiService: ApiService
+  ) {}
 
   getData() {
-    this.strategyProvider.schedule(() => {}).subscribe();
+    this.strategyProvider.schedule(() => this.apiService.sendRequest(), {strategy: 'low'}).subscribe();
   }
 }
 ```

--- a/libs/cdk/render-strategies/docs/basic-strategies.md
+++ b/libs/cdk/render-strategies/docs/basic-strategies.md
@@ -4,10 +4,10 @@
 
 ### Render work
 
-To apply changes to a component template we need to re-evaluate the template. Internally this is done by calling `???`.
-This method will execute whenever a component's template is re-evaluated through `async`, `push`, `ChangedDetectorRef.detectChanges` or a structural directive template is re-evaluated through `EmbeddedView.detectChanges`
+To apply changes to a component template we need to re-evaluate the template. Internally this is done in the specific strategy.
+This process will execute whenever a component's template is re-evaluated through `async`, `push`, `ChangedDetectorRef.detectChanges` or a structural directive template is re-evaluated through `EmbeddedView.detectChanges`.
 
-This process can be pretty time consuming and directly depends on the following factors:
+It can be pretty time consuming and directly depends on the following factors:
 - HTML size (only for init and destroy and bundle-size)
 - JS size (only for init and destroy and bundle-size)
 - number of event bindings (only for init and destroy)
@@ -18,7 +18,7 @@ This process can be pretty time consuming and directly depends on the following 
 Some of the problems related to work of Angular are:
 
 **Out of bound change detection:**
-If we perform this re-evaluation without any visual change for the user (over-rendering) we introduce noticable performance degradations.
+If we perform this re-evaluation without any visual change for the user (over-rendering) we introduce noticeable performance degradations.
 
 The out of bound change detection can be caused through: 
   - Zone pollution
@@ -27,12 +27,12 @@ The out of bound change detection can be caused through:
   - Pull-based rendering processes 
   
 **Out of bound template evaluation:**
-If we perform a re-evaluation of a single property in the template any other expression/binding also gets reevaluated. 
-Again over-rendering introduces noticable performance degradations.
+If we perform a re-evaluation of a single property in the template any other expression/binding also gets re-evaluated. 
+Again over-rendering introduces noticeable performance degradations.
 
 The out of bound template evaluation can be caused through:
   - Pull-based rendering processes
-  - any reactive change throught `async`
+  - any reactive change through `async`
   - any call to `cdRef.detectChanges`
 
 
@@ -40,9 +40,9 @@ The out of bound template evaluation can be caused through:
 If we perform a re-evaluation or even re-rendering of the DOM of elements outside of the viewport we perform useless work for the user.
 This will pollute the main thread and reduced time for more important content to get rendered.
 
-The re-evaluation or browser re-rendreing can be caused by:
+The re-evaluation or browser re-rendering can be caused by:
 - Bad style changes
-- Big LCP elements
+- Big LCP (Largest Contentful Paint) elements
 - Large amount of content
 
 ### Local vs global CD
@@ -51,7 +51,7 @@ The re-evaluation or browser re-rendreing can be caused by:
 
 The change detection system that is currently implemented in Angular is pull-based, but way more important, as a side effect it also runs CD globally.
 It performs a re-rendering where at optimum every single component on the path from the root to the actual UI update needs to get re-evaluated. 
-A lot of work is performed useless.
+A lot of performed work is useless.
 
 Technically the methods to run change detection are `markForCheck` / `markViewDirty`, `ɵmarkDirty` and `tick`.
 
@@ -71,9 +71,9 @@ Consuming value changes can be done by **constantly** watching the source for ch
 
 In a simple setup the pull might be a quick solution and you just `.get()` the value, but a push based architecture always scales better.
 
-Compare it with HTTP calls vs Websockets.
+Compare it with HTTP calls vs WebSockets.
 
-If we apply this concepts to our change detection mechanis we can directly apply changes where they are needd and skip nearly all the unnessecary work. 
+If we apply this concepts to our change detection mechanics we can directly apply changes where they are needd and skip nearly all the unnessecary work. 
 
 In combination with Observables, and EmbeddedViews change detection can be speed up dramatically by this architecture.
  
@@ -136,7 +136,7 @@ both accessed over the context over `ChangeDetectorRef#context`.
 | ------- | ------------- | ----------------- | ------------------ | ----------------------- |
 | `local` | ✔             | 🠗 `detectChanges` | ✔ ComponentContext | `requestAnimationFrame` |
 
-The best place to use the local strategie is a structural directive like `*rxLet`. Those will have a independent template from the component and prevorm changes only there.
+The best place to use the local strategy is a structural directive like `*rxLet`. Those will have a independent template from the component and perform changes only there.
 
 ![render-strategies - basic-strategies - local - directive_michael-hladky](https://user-images.githubusercontent.com/10064416/145226924-d5b46406-10b6-4e4b-ae46-ae0347309261.png)
 
@@ -163,9 +163,9 @@ import {RxStrategyProvider} from '@rx-angular/cdk/render-strategies';
 @Component()
 class Component {
 
-constructor(private strategyProvider: RxStrategyProvider) {
-  strategyProvider.schedule(() => {}, {strategyName: 'local'})
-}
+  constructor(private strategyProvider: RxStrategyProvider) {
+    strategyProvider.schedule(() => {}, {strategyName: 'local'})
+  }
 
 }
 ```
@@ -178,11 +178,11 @@ import {ForModule} from '@rx-angular/template/for';
 import {PushModule} from '@rx-angular/template/push';
 
 @Module({
-imports: [
-LetModule,
-ForModule,
-PushModule
-]
+  imports: [
+    LetModule,
+    ForModule,
+    PushModule
+  ]
 })
 class Module {
 
@@ -191,6 +191,6 @@ class Module {
 
 ```html
 <h1 *rxLet="title$; strategy:'local'">{{title}}</h1>
-<a *rxFor="let itme of itmes$; strategy:'local'">{{item}}</a>
+<a *rxFor="let itme of itmes$; strategy:'native'">{{item}}</a>
 <p>{{title$ | push : 'local'}}</p>
 ```

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -442,4 +442,4 @@ export class ItemsListComponent {
 ```
 
 > **⚠ Notice:**  
-> This priority fits well for things that should happen but has lower priority. For any non-urgent background process `idle` is the best fit.
+> This priority fits well for low priority background processes that are not affecting user interactions.

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -397,7 +397,6 @@ Urgent work that should happen in the background and is not initiated but visibl
 **Usecase:**
 
 This strategy is especially useful for logic meant to run in the background. Good example of such interaction is background sync.
-Good use case for this strategy will be lazy load of component. For example popup.
 
 <!-- TODO: Add proper image -->
 ![rx-angular-cdk-render-strategies__idle_example](https://user-images.githubusercontent.com/10064416/115316774-49225180-a17a-11eb-9045-3cdd38217b4d.PNG)

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -425,7 +425,10 @@ export class ItemsListComponent {
     private webSocket: WebSocketService
   ) {
     this.items$.pipe(
-      this.strategyProvider.scheduleWith(items => this.webSocket.syncItems(items), {strategy: 'idle'})
+      this.strategyProvider.scheduleWith(
+          items => this.webSocket.syncItems(items), 
+          {strategy: 'idle'}
+       )
     ).subscribe();
   }
 

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -1,27 +1,29 @@
 # Concurrent Strategies
 
-If your app provides user feedback within less than 16ms (less than 60 frames per second), it feels laggy to the user and leads to bad UX.
-
-Based on the [RAIL model](https://web.dev/rail/), a user experiences motion as laggy if the frame rate is lower than 60 frames per second (~16ms per task).
-
-From perspec UX => app should give feedback => if blocked => laggy
+Based on the [RAIL model](https://web.dev/rail/), if your app provides user feedback within more than 16ms (less than 60 frames per second), it feels laggy to the user and leads to bad UX.
+From the UX perspective that means users should not experience blocking periods more than 16 ms.
 
 ## Concepts
-
+There are 5 core concepts of the concurrent strategies:
+- Frame budget / Frame drop
+- Scheduling
+- Priority
+- Chunking
+- Concurrent Scheduling
 ### Frame budget / Frame Drop
 
-The Browsers main thread is a single-threaded system, meaning things happen one after another.
+The Browser has only one UI thread (main thread), meaning things happen one after another.
 
-When we connect this information with the fact that users constantly interact with our site this means if our main thread is busy the user cant interact with the page. The events like scroll or click will get delayed until the main thread is unblocked from work again and can process those interactions.
+Users constantly interract with out site and this means if our main thread is busy, they can't interact whit the page. The events like scroll or click will get delayed until the main thread is unblocked from work again and can process those interactions.
 
 ![Render Strategies - Frame Drop Overview](https://user-images.githubusercontent.com/10064416/145212039-b4b20fe5-19c9-4062-aba3-b5749cca978d.png)
 
 Such situations cause problems like:
 
 - blocking UIs
-- animation jank
-- scroll jank or stottering
-- delayed navigations
+- animation junk
+- scroll junk or stuttering
+- delayed navigation
 - bad frame rates in general
 
 All those problems boil down to the way the user perceives the interactions with the website.
@@ -43,11 +45,9 @@ The related theory is known as the RAIL model.
 When it comes to scripting work we can do 2 things to avoid that:
 
 - reduce scripting work and let the user interact earlier
-- chunk up work and use scheduling API's to distribute the work overtime and let the user interact in between
+- chunk up work and use scheduling API's to distribute the work overtime and let the user interact in between.
 
-angular-scripting-time
-
-As often the work just can't get reduced so we have to schedule. 
+It is often the case that the work just can't get reduced so we have to schedule. 
 
 ![Render Strategies-Scheduling Detail View](https://user-images.githubusercontent.com/10064416/145210963-be6d2dc0-f4e3-4654-9f7f-f5221976ed0c.png)
 
@@ -75,17 +75,17 @@ function work(): viod {
 const asyncId = setTimeout(work);
 ```
 
-By calling `setTimeout` we can schedule the execution of the `work` function in the next tast.
+By calling `setTimeout` we can schedule the execution of the `work` function in the next task.
 
-As a return value we receive the so called "asyncId" a number that serves as reverence to the scheduled task.
+As a return value we receive the so called "asyncId" a number that serves as reference to the scheduled task.
 
 This is important for cancellation and cleanup logic.
 
-```
+```typescript
 clearTimeout(asyncId);
 ``` 
 
-If we pass the asyncId as parameter to the `clearTimeout` function we can cancle the scheduling and `work` will never get executed.
+If we pass the asyncId as parameter to the `clearTimeout` function we can cancel the scheduling and `work` will never get executed.
 
 
 ### Priority
@@ -101,15 +101,14 @@ Input handlers (tap, click etc.) often need to schedule a combination of differe
 
 To get the best user experience we should prioritize this tasks.
 
-There are a couple scheduling APIs mentioned under scheduling. 
+There are couple of scheduling APIs mentioned under scheduling. 
 They all help to prioritize the work and define the moment of execution differently.
 
 ![Render Strategies - scheduling techniques](https://user-images.githubusercontent.com/10064416/144139079-9f1d6ad7-ad7e-437c-95a2-8a794460f9c9.png)
 
-
 ### Chunking
 
-Chunking means using scheduling APIs to split work and distribute in over time to have less frame drops.
+Chunking means using scheduling APIs to split work and distribute it over time to have less frame drops.
 
 ![Render Strategies-chunking-example](https://user-images.githubusercontent.com/10064416/145215422-2b047199-d7fa-46ef-aa99-fab236875952.png)
 
@@ -133,8 +132,8 @@ This scenario gets to a problem depending on:
 
 ![concurrent scheduling - abstract diagram](https://user-images.githubusercontent.com/10064416/145228577-6b8f0bb7-6547-4835-aecc-13d7e07baf02.png)
 
-Concurrent scheduling is a marketing therm and simply means that there is a mechanism in place that knows how much time is spent in the current task.
-This number is called frame budget and measured in milliseconds. The other cool part of this technique is we get prioritization and user centric scheduling behaviours. 
+Concurrent scheduling is a marketing term and simply means that there is a mechanism in place that knows how much time is spent in the current task.
+This number is called frame budget and measured in milliseconds. As a result of this technique we're getting prioritized user-centric scheduling behaviours. 
 
 This enables:
 - scheduling
@@ -143,17 +142,17 @@ This enables:
 - works distribution based on the frame budget
 - render deadlines
 
-One of the first things to understand is the term frame budget.
-It means we have a maximum time (which is globally defined) a task can take before yealding to the main thread.  e.g. 60frames/1000ms=16.6666ms animations or 50ms long task
+One of the first things to understand is the term "frame budget".
+It means we have a maximum time (which is globally defined) a task can take before yielding to the main thread.  e.g. 60frames/1000ms=16.6666ms animations or 50ms long task.
 
-Scheduling with notion of the frame budget enables us to stop processing scheduled tasks whenever we are close to the budget.
- We then yeild to the main thread and are interactive again until the next batch of tasks will get processed. 
+Scheduling with notion of frame budget enables us to split work into individual browser tasks as soon as we exceed the budget.
+We then yield to the main thread and are interactive again until the next batch of tasks will get processed. 
 
 ![rx-angular-cdk-render-strategies__frame-budget](https://user-images.githubusercontent.com/10064416/115894224-4f098280-a459-11eb-9abf-9a902d66d380.png)
 
 The special thing about the set of concurrent strategies is they have a render deadline. 
-It means if the scheduled tasks in the global queue of work is not exhausted after a certain time window we stop the chunking prozess.
-Instead all remaining work will get executed as fast as possible. This means in one synchronouse block (that potentially can causes a frame drop).
+It means if the scheduled tasks in the global queue of work is not exhausted after a certain time window, we stop the chunking process.
+Instead all remaining work will get executed as fast as possible. This means in one synchronous block (that potentially can causes a frame drop).
 
 ![Render Strategies - concurrent anatomy png](https://user-images.githubusercontent.com/10064416/145231603-5e6e250d-7c8c-4e76-8872-8b01a3a65c24.png)
 
@@ -196,14 +195,18 @@ Tooltips should be displayed immediately on mouse over. Any delay will be very n
 
 ```typescript
 @Component({
-  selector: 'immediate',
+  selector: 'item-image',
   template: `
-    <button id="btn" (mouseenter)="showTooltip()" (mouseleave)="hideTooltip()">
-      Button with Tooltip
-    </button>
+    <img 
+      [src]="src" 
+      (mouseenter)="showTooltip()" 
+      (mouseleave)="hideTooltip()" 
+    />
   `,
 })
-export class TooltipComponent {
+export class ItemsListComponent {
+  @Input() src: string;
+
   constructor(private strategyProvider: RxStrategyProvider) {}
 
   showTooltip() {
@@ -212,7 +215,7 @@ export class TooltipComponent {
         // create tooltip
       },
       { strategy: 'immediate' }
-    );
+    ).subscribe();
   }
 
   hideTooltip() {
@@ -221,7 +224,7 @@ export class TooltipComponent {
         // destroy tooltip
       },
       { strategy: 'immediate' }
-    );
+    ).subscribe();
   }
 }
 ```
@@ -247,36 +250,38 @@ Dropdowns should be displayed right away on user interaction.
 
 ```typescript
 @Component({
-  selector: 'userBlocking',
+  selector: 'item-dropdown',
   template: `
     <div
       id="collapse"
-      (mouseenter)="showTooltip()"
-      (mouseleave)="hideTooltip()"
+      (mouseenter)="showDropdown()"
+      (mouseleave)="hideDropdown()"
     >
-      Button with Tooltip
+      {{ text }}
     </div>
   `,
 })
-export class TooltipComponent {
+export class DropdownComponent {
+  @Input() text: string;
+
   constructor(private strategyProvider: RxStrategyProvider) {}
 
-  showTooltip() {
+  showDropdown() {
     this.strategyProvider.schedule(
       () => {
-        // create tooltip
-      },
-      { strategy: 'immediate' }
-    );
-  }
-
-  hideTooltip() {
-    this.strategyProvider.schedule(
-      () => {
-        // destroy tooltip
+        // create dropdown
       },
       { strategy: 'userBlocking' }
     );
+  }
+
+  hideDropdown() {
+    this.strategyProvider.schedule(
+      () => {
+        // destroy dropdown
+      },
+      { strategy: 'userBlocking' }
+    ).subscribe();
   }
 }
 ```
@@ -296,13 +301,32 @@ Heavy work visible to the user. For example, since it has a higher timeout, it i
 
 **Usecase:**
 
-@TODO: List example
+For `normal` strategy a perfect example will be rendering of the items list. 
+
+It is often the case that rendering of big lists blocks user interactions. In combination with `rxFor` directive such operations become truly unblocking.
 
 ![rx-angular-cdk-render-strategies__normal_example](https://user-images.githubusercontent.com/10064416/115315848-7837c380-a178-11eb-985e-b639f034fcb4.PNG)
+```typescript
+@Component({
+  selector: 'items-list',
+  template: `
+    <div id="items-list">
+      <div *rxFor="let item of items$; strategy: 'normal'>
+        <item-image [src]="item.image"></item-image>
+        <item-dropdown [text]="item.text"></item-dropdown>
+      </div>
+    </div>
+  `,
+})
+export class ItemsListComponent {
+  items$ = this.state.items$;
+  constructor(private state: StateService) {}
+}
+```
 
 ### Low
 
-Work that is typically not visible to the user or initiated by the user. For example getting scrollbar position form `localStorage`.
+Work that is typically not visible to the user or initiated by the user.
 
 | Render Method     | Scheduling    | Render Deadline |
 | ----------------- | ------------- | --------------- |
@@ -310,17 +334,49 @@ Work that is typically not visible to the user or initiated by the user. For exa
 
 **Usecase:**
 
+Good use case for this strategy will be lazy loading of the components. For example popup.
+
+<!-- TODO: Add proper image -->
 ![low-example](https://user-images.githubusercontent.com/15088626/115315764-a7523300-a180-11eb-9231-1376bda540a4.png)
 
-@TODO: Get scrollbar position
+```typescript
+@Component({
+  selector: 'items-list',
+  template: `
+    <div id="items-list">
+      <div *rxFor="let item of items$; strategy: 'normal'>
+        <item-image [src]="item.image"></item-image>
+        <item-dropdown [text]="item.text"></item-dropdown>
+      </div>
+    </div>
+
+    <button id="addItem" (click)="openCreateItemPopup()">Create new item</button>
+  `,
+})
+export class ItemsListComponent {
+  items$ = this.state.items$;
+
+  constructor(
+    private state: StateService,
+    private strategyProvider: RxStrategyProvider
+  ) {}
+
+  openCreateItemPopup() {
+    this.strategyProvider.schedule(() => {
+      // logic to lazy load popup component
+    }, {strategy: 'low'}).subscribe();
+  }
+
+}
+```
 
 > **⚠ Notice:**  
-> This strategy is especially useful for sending request and and preprocessing their responses. As they are not directly visible a low priority is best.
+> This priority fits well for things that should happen but has lower priority. For any non-urgent background process `idle` is the best fit.
 
 ### Idle
 
 <!--
-- Descriptoin of the strategies behavior
+- Description of the strategies behavior
 - Table
   - no `Zone Agnostic` column just mention it
   - Render Method
@@ -332,13 +388,56 @@ Work that is typically not visible to the user or initiated by the user. For exa
 -
 -->
 
-Urgent work that should happen in the background and is not initiated but visible by the user. This occurs right after current task and has the lowest priority. For example background sync.
+Urgent work that should happen in the background and is not initiated but visible by the user. This occurs right after current task and has the lowest priority. 
 
 | Render Method     | Scheduling    | Render Deadline |
 | ----------------- | ------------- | --------------- |
 | 🠗 `detectChanges` | `postMessage` | ❌              |
 
+**Usecase:**
+
+This strategy is especially useful for logic meant to run in the background. Good example of such interaction is background sync.
+Good use case for this strategy will be lazy load of component. For example popup.
+
+<!-- TODO: Add proper image -->
 ![rx-angular-cdk-render-strategies__idle_example](https://user-images.githubusercontent.com/10064416/115316774-49225180-a17a-11eb-9045-3cdd38217b4d.PNG)
 
+```typescript
+@Component({
+  selector: 'items-list',
+  template: `
+    <div id="items-list">
+      <div *rxFor="let item of items$; strategy: 'normal'>
+        {{item.name}}
+      </div>
+    </div>
+
+    <button id="addItem" (click)="openCreateItemPopup()">Create new item</button>
+
+    <div id="background-indicator>Background sync</div>
+  `,
+})
+export class ItemsListComponent {
+  items$ = this.state.items$;
+
+  constructor(
+    private state: StateService,
+    private strategyProvider: RxStrategyProvider,
+    private webSocket: WebSocketService
+  ) {
+    this.items$.pipe(
+      this.strategyProvider.scheduleWith(items => this.webSocket.syncItems(items))
+    ).subscribe();
+  }
+
+  openCreateItemPopup() {
+    this.strategyProvider.schedule(() => {
+      // logic to lazy load popup component
+    }, {strategy: 'low'}).subscribe();
+  }
+
+}
+```
+
 > **⚠ Notice:**  
-> This strategy is especially useful for logic ment to run in the backgroung. As they are not directly visible a low priority is best.
+> This priority fits well for things that should happen but has lower priority. For any non-urgent background process `idle` is the best fit.

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -425,7 +425,7 @@ export class ItemsListComponent {
     private webSocket: WebSocketService
   ) {
     this.items$.pipe(
-      this.strategyProvider.scheduleWith(items => this.webSocket.syncItems(items))
+      this.strategyProvider.scheduleWith(items => this.webSocket.syncItems(items), {strategy: 'idle'})
     ).subscribe();
   }
 

--- a/libs/cdk/render-strategies/docs/concurrent-strategies.md
+++ b/libs/cdk/render-strategies/docs/concurrent-strategies.md
@@ -14,7 +14,7 @@ There are 5 core concepts of the concurrent strategies:
 
 The Browser has only one UI thread (main thread), meaning things happen one after another.
 
-Users constantly interract with out site and this means if our main thread is busy, they can't interact whit the page. The events like scroll or click will get delayed until the main thread is unblocked from work again and can process those interactions.
+Users constantly interract with our site and this means if our main thread is busy, they can't interact whit the page. The events like scroll or click will get delayed until the main thread is unblocked from work again and can process those interactions.
 
 ![Render Strategies - Frame Drop Overview](https://user-images.githubusercontent.com/10064416/145212039-b4b20fe5-19c9-4062-aba3-b5749cca978d.png)
 


### PR DESCRIPTION
Most important parts:
- `README.MD` - added snippet about `patchZone` and cross-links
- `basic-strategies.md` - `rxFor` uses `native` in the example
- `concurrent-strategies.md` - small text changes, updated frameBudget information (might be wrong, but that's from my experience), refactored code examples.