### PR TITLE
fix(template): don't override primary strategy 

### DIFF
--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -18,9 +18,12 @@ import {
   createTemplateManager,
   RxTemplateManager,
   RxBaseTemplateNames,
-  RxViewContext
+  RxViewContext,
 } from '@rx-angular/cdk/template';
-import { RxStrategyProvider, RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import {
+  RxStrategyProvider,
+  RxStrategyNames,
+} from '@rx-angular/cdk/render-strategies';
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
 import {
   createTemplateNotifier,
@@ -29,13 +32,14 @@ import {
 } from '@rx-angular/cdk/notifications';
 
 import {
-  defer, merge,
+  defer,
+  merge,
   NextObserver,
   Observable,
   ObservableInput,
   ReplaySubject,
   Subject,
-  Subscription
+  Subscription,
 } from 'rxjs';
 import { mergeAll } from 'rxjs/operators';
 
@@ -367,8 +371,6 @@ export class LetDirective<U> implements OnInit, OnDestroy, OnChanges {
 
   /** @internal */
   readonly values$ = this.observablesHandler.values$;
-
-
 
   @Output() readonly rendered = defer(() => this.rendered$);
 

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -382,12 +382,6 @@ export class LetDirective<U> implements OnInit, OnDestroy, OnChanges {
 
   /** @internal */
   ngOnInit() {
-    this.subscription.add(this.strategyHandler.values$
-      .subscribe(strategy => {
-      if(strategy) {
-        this.strategyProvider.primaryStrategy = strategy
-      }
-    }));
     this.subscription.add(
       this.templateManager
         .render(merge(this.values$, this.templateNotification$))

--- a/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
@@ -1,14 +1,21 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { Observable, of, Subject } from 'rxjs';
 
 import { LetDirective } from '../let.directive';
 
 @Component({
   template: `
-    <ng-container *rxLet="value$; let value; strategy: strategy; renderCallback:renderedValue$">{{
-      (value | json) || 'undefined'
-    }}</ng-container>
+    <ng-container
+      *rxLet="
+        value$;
+        let value;
+        strategy: strategy;
+        renderCallback: renderedValue$
+      "
+      >{{ (value | json) || 'undefined' }}</ng-container
+    >
   `,
 })
 class LetDirectiveTestStrategyComponent {
@@ -20,6 +27,8 @@ class LetDirectiveTestStrategyComponent {
 let fixture: ComponentFixture<LetDirectiveTestStrategyComponent>;
 let componentInstance: LetDirectiveTestStrategyComponent;
 let componentNativeElement: HTMLElement;
+let primaryStrategy: string;
+let strategyProvider: RxStrategyProvider;
 
 describe('LetDirective strategies', () => {
   beforeEach(() => {
@@ -33,6 +42,8 @@ describe('LetDirective strategies', () => {
     fixture = TestBed.createComponent(LetDirectiveTestStrategyComponent);
     componentInstance = fixture.componentInstance;
     componentNativeElement = fixture.nativeElement;
+    strategyProvider = TestBed.inject(RxStrategyProvider);
+    primaryStrategy = strategyProvider.primaryStrategy;
   });
 
   describe.each([
@@ -46,10 +57,19 @@ describe('LetDirective strategies', () => {
     ['idle'],
     ['native'],
   ])('Strategy: %p', (strategy) => {
-    it('should render with given strategy', done => {
+    it('should render with given strategy', (done) => {
       componentInstance.strategy = strategy;
-      componentInstance.renderedValue$.subscribe(v => {
+      componentInstance.renderedValue$.subscribe((v) => {
         expect(v).toBe(42);
+        done();
+      });
+      fixture.detectChanges();
+    });
+    it('should not affect primary strategy', (done) => {
+      componentInstance.strategy = strategy;
+      componentInstance.renderedValue$.subscribe((v) => {
+        expect(v).toBe(42);
+        expect(strategyProvider.primaryStrategy).toBe(primaryStrategy);
         done();
       });
       fixture.detectChanges();


### PR DESCRIPTION
# Description

somehow the let directive is resetting the primary strategy of the global `StrategyProvider` on init.
I guess this is a leftover of times where each letdirective provided its very own `StrategyProvider`.

This PR removes the piece of code, because now each let directive has impact on a global scope which is not what we actually want