### PR TITLE
fix(template): Rxfor template typings

### DIFF
--- a/apps/demos/src/app/features/template/rx-context/rx-context.module.ts
+++ b/apps/demos/src/app/features/template/rx-context/rx-context.module.ts
@@ -1,4 +1,6 @@
 import { NgModule } from '@angular/core';
+import { ForModule } from '@rx-angular/template/experimental/for';
+import { LetModule } from '@rx-angular/template/let';
 import { VisualizerModule } from '../../../shared/debug-helper/visualizer';
 import { StrategySelectModule } from '../../../shared/debug-helper/strategy-select';
 import { ValueProvidersModule } from '../../../shared/debug-helper/value-provider';
@@ -11,18 +13,16 @@ import { MatInputModule } from '@angular/material/input';
 import { RouterModule } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { DirtyChecksModule } from '../../../shared/debug-helper/dirty-checks';
-import { RxContextModule, RxForModule, RxLetModule } from '../../../rx-angular-pocs';
+import { RxContextModule } from '../../../rx-angular-pocs';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
-const DECLARATIONS = [
-  RxContextComponent
-];
+const DECLARATIONS = [RxContextComponent];
 
 @NgModule({
   declarations: DECLARATIONS,
   imports: [
-    RxLetModule,
+    LetModule,
     VisualizerModule,
     ValueProvidersModule,
     StrategySelectModule,
@@ -34,7 +34,7 @@ const DECLARATIONS = [
     RouterModule,
     MatCardModule,
     DirtyChecksModule,
-    RxForModule,
+    ForModule,
     RxContextModule,
     MatIconModule,
     MatProgressSpinnerModule,

--- a/apps/demos/src/app/features/template/rx-for/error-handling/rx-for-error-handling.module.ts
+++ b/apps/demos/src/app/features/template/rx-for/error-handling/rx-for-error-handling.module.ts
@@ -1,18 +1,17 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { RxForModule } from '../../../../rx-angular-pocs/template/directives/for/rx-for.module';
+import { ForModule } from '@rx-angular/template/experimental/for';
 import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select/strategy-select.module';
 import { ValueProvidersModule } from '../../../../shared/debug-helper/value-provider/value-providers.module';
 import { ErrorHandlingParentComponent } from './error-handling-parent.component';
 import { ErrorHandlingChildComponent } from './error-handling-child.component';
 
-
 @NgModule({
   declarations: [ErrorHandlingParentComponent, ErrorHandlingChildComponent],
   imports: [
     CommonModule,
-    RxForModule,
+    ForModule,
     RouterModule.forChild([
       {
         path: '',

--- a/apps/demos/src/app/features/template/rx-for/list-actions/list-actions.module.ts
+++ b/apps/demos/src/app/features/template/rx-for/list-actions/list-actions.module.ts
@@ -7,7 +7,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { RouterModule } from '@angular/router';
-import { PushModule } from '@rx-angular/template';
+import { LetModule, PushModule } from '@rx-angular/template';
+import { ForModule } from '@rx-angular/template/experimental/for';
 import { UnpatchModule } from '@rx-angular/template/unpatch';
 import { DirtyChecksModule } from '../../../../shared/debug-helper/dirty-checks';
 import { ValueProvidersModule } from '../../../../shared/debug-helper/value-provider/value-providers.module';
@@ -15,7 +16,7 @@ import { VisualizerModule } from '../../../../shared/debug-helper/visualizer/vis
 import { RecursiveModule } from '../../../../shared/template-structures/recursive/recursive.module';
 import { ListActionsComponent } from './list-actions.component';
 import { ROUTES } from './list-actions.routes';
-import { RxForModule, RxIfModule, RxLetModule } from '../../../../rx-angular-pocs';
+import { RxIfModule } from '../../../../rx-angular-pocs';
 import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select';
 
 const DECLARATIONS = [ListActionsComponent];
@@ -38,8 +39,8 @@ const DECLARATIONS = [ListActionsComponent];
     ValueProvidersModule,
     MatIconModule,
     StrategySelectModule,
-    RxLetModule,
-    RxForModule,
+    LetModule,
+    ForModule,
     RxIfModule,
   ],
   exports: [DECLARATIONS],

--- a/apps/demos/src/app/features/template/rx-for/nested-lists/nested-lists.module.ts
+++ b/apps/demos/src/app/features/template/rx-for/nested-lists/nested-lists.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ForModule } from '@rx-angular/template/experimental/for';
+import { LetModule } from '@rx-angular/template/let';
+import { PushModule } from '@rx-angular/template/push';
 import { VisualizerModule } from '../../../../shared/debug-helper/visualizer';
 import { UnpatchModule } from '@rx-angular/template/unpatch';
 import { MatButtonModule } from '@angular/material/button';
@@ -13,14 +16,13 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select';
-import { PushModule, RxForModule, RxLetModule } from '../../../../rx-angular-pocs';
 import { RxForNormal } from './rx-for-normal.directive';
 
 const DECLARATIONS = [
   RxForNestedListsComponent,
   RxMinimalForOf,
   RxForNormal,
-  RxForValueComponent
+  RxForValueComponent,
 ];
 
 @NgModule({
@@ -36,12 +38,11 @@ const DECLARATIONS = [
     MatFormFieldModule,
     MatInputModule,
     MatIconModule,
-    RxLetModule,
-    RxForModule,
+    LetModule,
+    ForModule,
     StrategySelectModule,
-    PushModule
+    PushModule,
   ],
-  exports: DECLARATIONS
+  exports: DECLARATIONS,
 })
-export class NestedListsModule {
-}
+export class NestedListsModule {}

--- a/apps/demos/src/app/features/template/rx-for/route-change/route-change.module.ts
+++ b/apps/demos/src/app/features/template/rx-for/route-change/route-change.module.ts
@@ -5,8 +5,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule, Routes } from '@angular/router';
-import { RxForModule } from '../../../../rx-angular-pocs/template/directives/for/rx-for.module';
-import { RxLetModule } from '../../../../rx-angular-pocs/template/directives/let/let.module';
+import { ForModule } from '@rx-angular/template/experimental/for';
+import { LetModule } from '@rx-angular/template/let';
 import { RouteChangeComponent } from './route-change.component';
 import { RoutedNgForComponent } from './routed-ng-for.component';
 import { RoutedRxForComponent } from './routed-rx-for.component';
@@ -21,15 +21,15 @@ const routes: Routes = [
     children: [
       {
         path: 'native',
-        component: RoutedNgForComponent
+        component: RoutedNgForComponent,
       },
       {
         path: 'rx-for',
-        component: RoutedRxForComponent
-      }
-    ]
-  }
-]
+        component: RoutedRxForComponent,
+      },
+    ],
+  },
+];
 
 @NgModule({
   declarations: [
@@ -42,8 +42,8 @@ const routes: Routes = [
     CommonModule,
     RouterModule.forChild(routes),
     MatTabsModule,
-    RxForModule,
-    RxLetModule,
+    ForModule,
+    LetModule,
     FormsModule,
     MatButtonModule,
     MatIconModule,

--- a/libs/cdk/template/src/lib/list-view-context.ts
+++ b/libs/cdk/template/src/lib/list-view-context.ts
@@ -22,7 +22,8 @@ export class RxDefaultListViewContext<
   T,
   U extends NgIterable<T> = NgIterable<T>,
   K = keyof T
-> implements RxListViewContext<T> {
+> implements RxListViewContext<T>
+{
   readonly _item = new ReplaySubject<T>(1);
   item$ = this._item.asObservable();
   private _$implicit: T;
@@ -103,7 +104,7 @@ export class RxDefaultListViewContext<
     return this.even$.pipe(map((even) => !even));
   }
 
-  constructor(private item: T, customProps?: { count: number; index: number }) {
+  constructor(item: T, customProps?: { count: number; index: number }) {
     this.$implicit = item;
     if (customProps) {
       this.updateContext(customProps);

--- a/libs/template/experimental/for/src/index.ts
+++ b/libs/template/experimental/for/src/index.ts
@@ -1,2 +1,3 @@
 export { ForModule } from './lib/for.module';
 export { RxFor } from './lib/for.directive';
+export { RxForViewContext } from './lib/for-view-context';

--- a/libs/template/experimental/for/src/lib/for-view-context.ts
+++ b/libs/template/experimental/for/src/lib/for-view-context.ts
@@ -1,0 +1,16 @@
+import { NgIterable } from '@angular/core';
+import { RxDefaultListViewContext } from '@rx-angular/cdk/template';
+
+export class RxForViewContext<
+  T,
+  U extends NgIterable<T> = NgIterable<T>,
+  K = keyof T
+> extends RxDefaultListViewContext<T, U, K> {
+  constructor(
+    item: T,
+    public rxForOf: U,
+    customProps?: { count: number; index: number }
+  ) {
+    super(item, customProps);
+  }
+}

--- a/libs/template/experimental/for/src/lib/for.directive.ts
+++ b/libs/template/experimental/for/src/lib/for.directive.ts
@@ -1,4 +1,3 @@
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   ChangeDetectorRef,
   Directive,
@@ -17,7 +16,6 @@ import {
 } from '@angular/core';
 import {
   createListTemplateManager,
-  RxDefaultListViewContext,
   RxListManager,
   RxListViewComputedContext,
   RxListViewContext,
@@ -26,6 +24,7 @@ import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { coerceDistinctWith } from '@rx-angular/cdk/coercing';
 
 import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { RxForViewContext } from './for-view-context';
 
 /**
  * @Directive RxFor
@@ -279,7 +278,7 @@ import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
  * @publicApi
  */
 @Directive({
-  selector: '[rxFor]',
+  selector: '[rxFor][rxForOf]',
 })
 /* @todo: rename to ForDirective? */
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
@@ -289,38 +288,31 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   /** @internal */
   static ngTemplateGuard_rxFor: 'binding';
 
-  /**
-   * @description
-   * The iterable input
-   *
-   * @example
-   * <ng-container *rxFor="heroes$; let hero">
-   *   <app-hero [hero]="hero"></app-hero>
-   * </ng-container>
-   *
-   * @param potentialObservable
-   */
+  /** @internal */
   @Input()
-  set rxFor(
+  set rxForOf(
     potentialObservable:
-      | Observable<NgIterable<T>>
-      | NgIterable<T>
+      | Observable<(U & NgIterable<T>) | undefined | null>
+      | (U & NgIterable<T>)
       | null
       | undefined
   ) {
     this.observables$.next(potentialObservable);
   }
 
-  /** @internal */
+  /**
+   * @internal
+   * A reference to the template that is stamped out for each item in the iterable.
+   * @see [template reference variable](guide/template-reference-variables)
+   */
   @Input()
-  set rxForOf(
-    potentialObservable:
-      | Observable<NgIterable<T>>
-      | NgIterable<T>
-      | null
-      | undefined
-  ) {
-    this.observables$.next(potentialObservable);
+  set rxForTemplate(value: TemplateRef<RxForViewContext<T, U>>) {
+    // TODO(TS2.1): make TemplateRef<Partial<NgForRowOf<T>>> once we move to TS v2.1
+    // The current type is too restrictive; a template that just uses index, for example,
+    // should be acceptable.
+    if (value) {
+      this.templateRef = value;
+    }
   }
 
   /**
@@ -586,7 +578,7 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
     private cdRef: ChangeDetectorRef,
     private ngZone: NgZone,
     private eRef: ElementRef,
-    private readonly templateRef: TemplateRef<RxDefaultListViewContext<T>>,
+    private templateRef: TemplateRef<RxForViewContext<T, U>>,
     private readonly viewContainerRef: ViewContainerRef,
     private strategyProvider: RxStrategyProvider,
     private errorHandler: ErrorHandler
@@ -596,9 +588,7 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   private strategyInput$ = new ReplaySubject<string | Observable<string>>(1);
 
   /** @internal */
-  private observables$ = new ReplaySubject<
-    Observable<NgIterable<T>> | NgIterable<T>
-  >(1);
+  private observables$ = new ReplaySubject<Observable<U> | U>(1);
 
   /** @internal */
   private _renderCallback: Subject<any>;
@@ -607,19 +597,23 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   private readonly values$ = this.observables$.pipe(coerceDistinctWith());
 
   /** @internal */
+  private values: U | undefined | null = null;
+
+  /** @internal */
   private readonly strategy$ = this.strategyInput$.pipe(coerceDistinctWith());
 
   /** @internal */
   private listManager: RxListManager<T>;
 
   /** @internal */
-  private _subscription = Subscription.EMPTY;
+  private _subscription = new Subscription();
 
   /** @internal */
-  static ngTemplateContextGuard<U>(
-    dir: RxFor<U>,
-    ctx: unknown | null | undefined
-  ): ctx is RxDefaultListViewContext<U> {
+  static ngTemplateContextGuard<
+    T,
+    U extends NgIterable<T> = NgIterable<T>,
+    K = keyof T
+  >(dir: RxFor<T, U>, ctx: any): ctx is RxForViewContext<T, U, K> {
     return true;
   }
 
@@ -630,40 +624,40 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
 
   /** @internal */
   ngOnInit() {
-    this.listManager = createListTemplateManager<
-      T,
-      RxDefaultListViewContext<T>
-    >({
+    this._subscription.add(this.values$.subscribe((v) => (this.values = v)));
+    this.listManager = createListTemplateManager<T, RxForViewContext<T>>({
       iterableDiffers: this.iterableDiffers,
       renderSettings: {
         cdRef: this.cdRef,
         eRef: this.eRef,
         strategies: this.strategyProvider.strategies as any, // TODO: move strategyProvider
         defaultStrategyName: this.strategyProvider.primaryStrategy,
-        parent: coerceBooleanProperty(this.renderParent),
+        parent: !!this.renderParent,
         patchZone: this.patchZone ? this.ngZone : false,
         errorHandler: this.errorHandler,
       },
       templateSettings: {
         viewContainerRef: this.viewContainerRef,
         templateRef: this.templateRef,
-        createViewContext: this.createViewContext,
+        createViewContext: this.createViewContext.bind(this),
         updateViewContext: this.updateViewContext,
       },
       trackBy: this._trackBy,
     });
     this.listManager.nextStrategy(this.strategy$);
-    this._subscription = this.listManager
-      .render(this.values$)
-      .subscribe((v) => this._renderCallback?.next(v));
+    this._subscription.add(
+      this.listManager
+        .render(this.values$)
+        .subscribe((v) => this._renderCallback?.next(v))
+    );
   }
 
   /** @internal */
   createViewContext(
     item: T,
     computedContext: RxListViewComputedContext
-  ): RxDefaultListViewContext<T> {
-    return new RxDefaultListViewContext<T>(item, computedContext);
+  ): RxForViewContext<T, U> {
+    return new RxForViewContext<T, U>(item, this.values, computedContext);
   }
 
   /** @internal */

--- a/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
+++ b/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
@@ -1,9 +1,23 @@
-import { Directive, ElementRef, Inject, Input, OnDestroy, OnInit, Optional } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit,
+  Optional,
+} from '@angular/core';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { coerceObservableWith } from '@rx-angular/cdk/coercing';
 import { RxNotification } from '@rx-angular/cdk/notifications';
 import { LetDirective } from '@rx-angular/template/let';
-import { BehaviorSubject, combineLatest, Observable, of, Subject, tap } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  of,
+  Subject,
+} from 'rxjs';
 import { filter, map, mergeAll, withLatestFrom } from 'rxjs/operators';
 
 function intersectionObserver(options?: object): {
@@ -14,8 +28,8 @@ function intersectionObserver(options?: object): {
   const subject = new Subject();
   const observer = observerSupported()
     ? new IntersectionObserver((entries) => {
-      entries.forEach((entry) => subject.next(entry));
-    }, options)
+        entries.forEach((entry) => subject.next(entry));
+      }, options)
     : null;
 
   const entries$ = new Observable((subscriber) => {
@@ -30,7 +44,7 @@ function intersectionObserver(options?: object): {
   return {
     entries$,
     observe: observer.observe,
-    unobserve: observer.unobserve
+    unobserve: observer.unobserve,
   };
 }
 
@@ -45,12 +59,14 @@ const observerSupported = () =>
    * @todo: deprecate [viewport-prio] + add camelcase support.
    */
   // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: '[viewport-prio]'
+  selector: '[viewport-prio]',
 })
 export class ViewportPrioDirective implements OnInit, OnDestroy {
   // Note that we're picking only the `intersectionRatio` property
   // since this is the only property that we're intersted in.
-  entriesSubject = new Subject<Pick<IntersectionObserverEntry, 'intersectionRatio'>[]>();
+  entriesSubject = new Subject<
+    Pick<IntersectionObserverEntry, 'intersectionRatio'>[]
+  >();
 
   entries$: Observable<Pick<IntersectionObserverEntry, 'intersectionRatio'>> =
     this.entriesSubject.pipe(mergeAll());
@@ -70,13 +86,13 @@ export class ViewportPrioDirective implements OnInit, OnDestroy {
 
   private observer: IntersectionObserver | null = observerSupported()
     ? new IntersectionObserver(
-      (entries) => {
-        this.entriesSubject.next(entries);
-      },
-      {
-        threshold: 0
-      }
-    )
+        (entries) => {
+          this.entriesSubject.next(entries);
+        },
+        {
+          threshold: 0,
+        }
+      )
     : null;
 
   visibilityEvents$ = this.entries$.pipe(
@@ -95,8 +111,7 @@ export class ViewportPrioDirective implements OnInit, OnDestroy {
     @Inject(LetDirective)
     @Optional()
     private letDirective: LetDirective<any> | null
-  ) {
-  }
+  ) {}
 
   ngOnInit() {
     const letStrategyName$ = this.strategyProvider.primaryStrategy$.pipe(
@@ -111,18 +126,18 @@ export class ViewportPrioDirective implements OnInit, OnDestroy {
         lastValue = v;
       });
 
-
     this.visibilityEvents$
       .pipe(
         withLatestFrom(
           combineLatest(letStrategyName$, this._viewportPrio).pipe(
             filter(([newN, oldN]) => newN !== oldN)
-          )),
+          )
+        ),
         map(([visibility, strategyNames]) => {
-        const [inStrategyName, outStrategyName] = strategyNames
-         return visibility === 'visible'
+          const [inStrategyName, outStrategyName] = strategyNames;
+          return visibility === 'visible'
             ? [visibility, inStrategyName]
-            : [visibility, outStrategyName]
+            : [visibility, outStrategyName];
         })
       )
       .subscribe(([visibility, strategyName]) => {


### PR DESCRIPTION
# Description

closes #1195 

I've taken another look at the implementation of the template typings in rxFor. After comparing them against the original `ngFor`, i've noticed some differences.

`rxFor` now should be able to derive the correct typings in the template even without defining a `trackBy` function.

## ViewContext

First of all, the class `RxDefaultListViewContext` is missing a property which reflects the type of the actual `NgIterable`.
That's why I've introduced a new class `RxForViewContext` extending from the default one.

```ts
export class RxForViewContext<
  T,
  U extends NgIterable<T> = NgIterable<T>,
  K = keyof T
> extends RxDefaultListViewContext<T, U, K> {
  constructor(
    item: T,
    public rxForOf: U,
    customProps?: { count: number; index: number }
  ) {
    super(item, customProps);
  }
}

/** @internal */
  static ngTemplateContextGuard<
    T,
    U extends NgIterable<T> = NgIterable<T>,
    K = keyof T
  >(dir: RxFor<T, U>, ctx: any): ctx is RxForViewContext<T, U, K> {
    return true;
  }

```

## Input Typing

The input typing also was missing a hint to the `NgIterable`

```ts
/** @internal */
  @Input()
  set rxForOf(
    potentialObservable:
      | Observable<(U & NgIterable<T>) | undefined | null>
      | (U & NgIterable<T>)
      | null
      | undefined
  ) {
    this.observables$.next(potentialObservable);
  }
```

## Selector

I think defining the selector as `[rxFor][rxForOf]` finally solved the issue @exequiel09 was facing `Type '""' is not assignable to...`.
It also made it possible to get rid of the duplicated `@Input` property for `rxFor`.

## Template Reference Variables

based on the base implementation, i've introduced a new `@Input()` again reflecting the templateRef created for each attached element.

```ts

/**
   * @internal
   * A reference to the template that is created for each item in the iterable.
   * @see [template reference variable](guide/template-reference-variables)
   * (inspired by @angular/common `ng_for_of.ts`)
   */
  @Input()
  set rxForTemplate(value: TemplateRef<RxForViewContext<T, U>>) {
    if (value) {
      this.templateRef = value;
    }
  }

```
