### PR TITLE
fix(cdk): ensure `parentElement` is always defined

### DIFF
--- a/libs/cdk/template/src/lib/utils.ts
+++ b/libs/cdk/template/src/lib/utils.ts
@@ -85,7 +85,11 @@ export function extractProjectionParentViewSet(
       //  components. Maybe we should make the parent notification configurable regarding the level of `deepness`?
       // components.delete(idx);
       components.clear();
-      parentElements.add(injectingLView[idx][CONTEXT]);
+
+      const parentElement = injectingLView[idx][CONTEXT];
+      if (parentElement) {
+        parentElements.add(parentElement);
+      }
     }
     parent = parent['parent'];
   }
@@ -322,7 +326,6 @@ export function getVirtualParentNotifications$(
         strategy,
         // Here we CD the parent to update their projected views scenarios
         (value, work, options) => {
-          // console.log('parentComponent', parentComponent);
           detectChanges(parentComponent);
         },
         { scope: parentComponent }


### PR DESCRIPTION
When the scheduler flushes its work an error can be thrown:

```
// Error: ASSERTION ERROR: Target expected [Expected=> null != null <=Actual]
//     at throwError (core.mjs:335:1)
//     at assertDefined (core.mjs:331:1)
//     at readPatchedData (core.mjs:6327:1)
//     at getComponentViewByInstance (core.mjs:6294:1)
//     at detectChanges (core.mjs:11054:1)
//     at behaviors.push.scope (cdk-template.mjs:213:27)
//     at cdk-render-strategies.mjs:143:13
//     at task.delay (cdk-render-strategies.mjs:56:13)
//     at workLoop (cdk-internals-scheduler.mjs:197:1)
//     at flushWork (cdk-internals-scheduler.mjs:174:1)
```

The `extractProjectionParentViewSet` function can sometimes return a `Set` with a `null` element inside which break when the `detectChanges(parentElement)` function is called later with this null element passed.

```
// Set(0) {size: 0} SetIterator {}
// Set(0) {size: 0} SetIterator {}
// Set(0) {size: 0} SetIterator {}
// Set(1) {MatButton} SetIterator {MatButton}
// Set(1) {MatExpansionPanelHeader} SetIterator {MatExpansionPanelHeader}
// Set(1) {null} SetIterator {null} ❌ It breaks here, the Set is populated with a `null` element.
// Set(0) {size: 0} SetIterator {}
// Set(0) {size: 0} SetIterator {}
// Set(1) {MatSelect} SetIterator {MatSelect}
// Set(1) {MatFormField} SetIterator {MatFormField}
// Set(1) {MatSelect} SetIterator {MatSelect}
```