### PR TITLE
fix: add missing peerDependencies

### DIFF
--- a/libs/cdk/package.json
+++ b/libs/cdk/package.json
@@ -48,7 +48,8 @@
     "url": "https://github.com/rx-angular/rx-angular.git"
   },
   "peerDependencies": {
-    "@angular/core": ">10.1.1"
+    "@angular/core": ">=12.0.0",
+    "rxjs": ">=6.5.5"
   },
   "dependencies": {
     "tslib": "^2.0.0",

--- a/libs/state/package.json
+++ b/libs/state/package.json
@@ -48,7 +48,9 @@
     "url": "https://github.com/rx-angular/rx-angular.git"
   },
   "peerDependencies": {
-    "@angular/core": ">8.0.0"
+    "@angular/core": ">=12.0.0",
+    "@angular/platform-browser": ">=12.0.0",
+    "rxjs": ">=6.5.5"
   },
   "dependencies": {
     "tslib": "^2.0.0",

--- a/libs/template/package.json
+++ b/libs/template/package.json
@@ -49,8 +49,10 @@
     "url": "https://github.com/rx-angular/rx-angular.git"
   },
   "peerDependencies": {
-    "@angular/core": ">10.1.1",
-    "@rx-angular/cdk": ">=1.0.0-beta.2"
+    "@angular/core": ">=12.0.0",
+    "@angular/platform-browser": ">=12.0.0",
+    "@rx-angular/cdk": ">=1.0.0-beta.2",
+    "rxjs": ">=6.5.5"
   },
   "dependencies": {
     "tslib": "^2.0.0",


### PR DESCRIPTION
Resolves https://github.com/rx-angular/rx-angular/issues/1261. Under the hood, ng-packagr adds multiple peer dependencies to the distribution package.json with an incorrect version range. This fix ensures versions are well defined to deal with npm 7.