### PR TITLE
fix(cdk): requestPaint should force a paint

### DIFF
--- a/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
@@ -17,6 +17,7 @@ describe('Scheduler', () => {
 
   const NormalPriority = 3;
   let scheduleCallback: typeof import('./scheduler').scheduleCallback;
+  let requestPaint: typeof import('./scheduler').requestPaint;
   let cancelCallback: typeof import('./scheduler').cancelCallback;
   let shouldYield: typeof import('./scheduler').shouldYield;
 
@@ -42,6 +43,7 @@ describe('Scheduler', () => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const Scheduler = require('./scheduler');
       scheduleCallback = Scheduler.scheduleCallback;
+      requestPaint = Scheduler.requestPaint;
       cancelCallback = Scheduler.cancelCallback;
       shouldYield = Scheduler.shouldYield;
     });
@@ -109,6 +111,26 @@ describe('Scheduler', () => {
       runtime.assertLog([schedulingMessageEvent]);
       runtime.fireMessageEvent();
       runtime.assertLog([LogEvent.MessageEvent, 'A', 'B']);
+    });
+
+    it('request paint ', () => {
+      scheduleCallback(NormalPriority, () => {
+        runtime.log('A');
+        requestPaint();
+      });
+      scheduleCallback(NormalPriority, () => {
+        runtime.log('B');
+      });
+      runtime.assertLog([schedulingMessageEvent]);
+      runtime.fireMessageEvent();
+      runtime.assertLog([
+        LogEvent.MessageEvent,
+        'A',
+        // A forced paint
+        schedulingMessageEvent,
+      ]);
+      runtime.fireMessageEvent();
+      runtime.assertLog([LogEvent.MessageEvent, 'B']);
     });
 
     it('multiple tasks with a yield in between', () => {

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.ts
@@ -381,6 +381,10 @@ let needsPaint = false;
 let queueStartTime = -1;
 
 function shouldYieldToHost() {
+  if (needsPaint) {
+    // There's a pending paint (signaled by `requestPaint`). Yield now.
+    return true;
+  }
   const timeElapsed = getCurrentTime() - queueStartTime;
   if (timeElapsed < yieldInterval) {
     // The main thread has only been blocked for a really short amount of time;
@@ -428,16 +432,16 @@ function shouldYieldToHost() {
 }
 
 function requestPaint() {
-  if (
+  needsPaint = true;
+  // we don't support isInputPending currently
+  /*if (
     enableIsInputPending &&
     navigator !== undefined &&
     (navigator as any).scheduling !== undefined &&
     (navigator as any).scheduling.isInputPending !== undefined
   ) {
     needsPaint = true;
-  }
-
-  // Since we yield every frame regardless, `requestPaint` has no effect.
+  }*/
 }
 
 function forceFrameRate(fps) {


### PR DESCRIPTION
# Description

requestPaint is exposed publicly by CDK as part of the internal scheduler. However, it is without any effect - it seems to be broken since 20c4197784fa83092a97e6c76060ab07e80e18fd. This PR fixes the functionality of requestPaint. Calling requestPaint will force the scheduler to 'yield to host'. 

### Example use-case for requestPaint:
Having two chunks of the UI one small one (~5ms, e.g. a side-bar) and a large one (~100ms, e.g. the main-content). Usually both chunks would be scheduled into the some frame and blocking the main thread. As an improvement one could call requestPaint in the smaller chunk and forcing the browser to render this part earlier.