### PR TITLE
refactor(cdk): return T or Observable<T> in coerceObservable

### DIFF
--- a/libs/cdk/coercing/src/lib/coerceObservable.ts
+++ b/libs/cdk/coercing/src/lib/coerceObservable.ts
@@ -6,7 +6,7 @@ import { isObservable, Observable, ObservableInput, of } from 'rxjs';
  * @param o - the value to coerce
  */
 export function coerceObservable<T>(
-  o: ObservableInput<T | null | undefined> | T | null | undefined
-): Observable<T | null | undefined> {
-  return isObservable(o) ? o : of(o as T | null | undefined);
+  o: ObservableInput<T> | T
+): Observable<T> {
+  return isObservable(o) ? o : of(o as T);
 }


### PR DESCRIPTION
Currently when using coerceObservable in the app you need to typecast it which results in not a good DX. This PR makes coerceObservable always return T or Observable<T>;

Was

```
@Input() set card(card: Card | Observable<Card>) {
  this.connect(coerceObservable(card) as Observable<Card>);
}
```

Will be

```
@Input() set card(card: Card | Observable<Card>) {
  this.connect(coerceObservable(card));
}
```