### PR TITLE
feat(template): introduce rxChunk

### DIFF
--- a/apps/demos/src/app/features/template/chunk/basic/rx-chunk-basic.component.ts
+++ b/apps/demos/src/app/features/template/chunk/basic/rx-chunk-basic.component.ts
@@ -1,0 +1,58 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'rx-chunk-basic',
+  template: `
+    <rxa-visualizer>
+      <ng-container visualizerHeader>
+        <h3>*rxChunk</h3>
+        <rxa-strategy-select
+          (strategyChange)="strategy = $event"
+        ></rxa-strategy-select>
+        <div>
+          Rendercallback:
+          <ng-container *rxLet="rendered$; let rendered">{{
+            rendered
+          }}</ng-container>
+        </div>
+        <div>
+          <button mat-button (click)="showContent = !showContent">
+            Toggle Content
+          </button>
+        </div>
+      </ng-container>
+      <div class="row w-100 mt-5">
+        <ng-container *ngIf="showContent">
+          <div class="col-6">
+            <div><strong>Non-Chunked</strong></div>
+            <rxa-work-visualizer
+              [reCreateContentOnCd]="false"
+              [work]="250"
+            ></rxa-work-visualizer>
+          </div>
+          <div class="col-6">
+            <div><strong>Chunked</strong></div>
+            <ng-container *rxChunk="strategy; renderCallback: renderCallback">
+              <rxa-work-visualizer
+                [reCreateContentOnCd]="false"
+                [work]="250"
+              ></rxa-work-visualizer>
+            </ng-container>
+          </div>
+        </ng-container>
+      </div>
+    </rxa-visualizer>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RxChunkBasicComponent {
+  strategy: string;
+
+  showContent = true;
+
+  renderCallback = new Subject<void>();
+  private _rendered = 1;
+  rendered$ = this.renderCallback.pipe(map(() => this._rendered++));
+}

--- a/apps/demos/src/app/features/template/chunk/basic/rx-chunk-basic.module.ts
+++ b/apps/demos/src/app/features/template/chunk/basic/rx-chunk-basic.module.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { RouterModule, Routes } from '@angular/router';
+import { RxChunk } from '@rx-angular/template/chunk';
+import { RxLet } from '@rx-angular/template/let';
+import { RenderingWorkModule } from '../../../../shared/debug-helper/rendering-work/rendering-work.module';
+import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select/index';
+import { VisualizerModule } from '../../../../shared/debug-helper/visualizer/index';
+import { WorkModule } from '../../../../shared/debug-helper/work/work.module';
+import { RxChunkBasicComponent } from './rx-chunk-basic.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: RxChunkBasicComponent,
+  },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes),
+    VisualizerModule,
+    StrategySelectModule,
+    RxChunk,
+    CommonModule,
+    RxLet,
+    RenderingWorkModule,
+    WorkModule,
+    MatButtonModule,
+  ],
+  exports: [],
+  declarations: [RxChunkBasicComponent],
+  providers: [],
+})
+export class RxChunkBasicModule {}

--- a/apps/demos/src/app/features/template/chunk/rx-chunk-demo.module.ts
+++ b/apps/demos/src/app/features/template/chunk/rx-chunk-demo.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { ROUTES } from './rx-chunk.routes';
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(ROUTES)],
+})
+export class RxChunkDemoModule {}

--- a/apps/demos/src/app/features/template/chunk/rx-chunk.menu.ts
+++ b/apps/demos/src/app/features/template/chunk/rx-chunk.menu.ts
@@ -1,0 +1,6 @@
+export const RX_CHUNK_MENU_ITEMS = [
+  {
+    label: 'Basic',
+    link: 'basic',
+  },
+];

--- a/apps/demos/src/app/features/template/chunk/rx-chunk.routes.ts
+++ b/apps/demos/src/app/features/template/chunk/rx-chunk.routes.ts
@@ -1,0 +1,14 @@
+import { Routes } from '@angular/router';
+
+export const ROUTES: Routes = [
+  {
+    path: '',
+    redirectTo: 'basic',
+    pathMatch: 'full',
+  },
+  {
+    path: 'basic',
+    loadChildren: () =>
+      import('./basic/rx-chunk-basic.module').then((m) => m.RxChunkBasicModule),
+  },
+];

--- a/apps/demos/src/app/features/template/template-shell.menu.ts
+++ b/apps/demos/src/app/features/template/template-shell.menu.ts
@@ -1,3 +1,4 @@
+import { RX_CHUNK_MENU_ITEMS } from './chunk/rx-chunk.menu';
 import { PUSH_PIPE_MENU } from './push/push.menu';
 import { MENU_ITEMS as RX_LET_MENU_ITEMS } from './rx-let/rx-let.menu';
 import { MENU_ITEMS as RX_IF_MENU_ITEMS } from './rx-if/rx-if.menu';
@@ -38,6 +39,11 @@ export const TEMPLATE_MENU = [
     label: '*rxFor',
     link: 'rx-for',
     children: RX_FOR_MENU_ITEMS,
+  },
+  {
+    label: '*rxChunk',
+    link: 'rx-chunk',
+    children: RX_CHUNK_MENU_ITEMS,
   },
   {
     label: 'Virtual Scrolling',

--- a/apps/demos/src/app/features/template/template-shell.module.ts
+++ b/apps/demos/src/app/features/template/template-shell.module.ts
@@ -18,6 +18,11 @@ const ROUTES: Routes = [
       import('./rx-let/rx-let-demo.module').then((m) => m.RxLetDemoModule),
   },
   {
+    path: 'rx-chunk',
+    loadChildren: () =>
+      import('./chunk/rx-chunk-demo.module').then((m) => m.RxChunkDemoModule),
+  },
+  {
     path: 'rx-if',
     loadChildren: () =>
       import('./rx-if/rx-if-demo.module').then((m) => m.RxIfDemoModule),
@@ -31,7 +36,7 @@ const ROUTES: Routes = [
     path: 'rx-virtual-for',
     loadChildren: () =>
       import('./rx-virtual-for/rx-virtual-for.module').then(
-        (m) => m.RxVirtualForDemoModule
+        (m) => m.RxVirtualForDemoModule,
       ),
   },
   {
@@ -48,7 +53,7 @@ const ROUTES: Routes = [
     path: 'rx-context',
     loadChildren: () =>
       import('./rx-context/rx-context.routed.module').then(
-        (m) => m.RxContextRoutedModule
+        (m) => m.RxContextRoutedModule,
       ),
   },
   {
@@ -60,14 +65,14 @@ const ROUTES: Routes = [
     path: 'view-port-prio',
     loadChildren: () =>
       import('./viewport-prio/viewport-prio-demo.module').then(
-        (m) => m.ViewportPrioModule
+        (m) => m.ViewportPrioModule,
       ),
   },
   {
     path: 'render-callback',
     loadChildren: () =>
       import('./render-callback/render-callback.module').then(
-        (m) => m.RenderCallbackModule
+        (m) => m.RenderCallbackModule,
       ),
   },
 ];

--- a/apps/demos/src/app/shared/debug-helper/visualizer/visualizer/work-visualizer.component.ts
+++ b/apps/demos/src/app/shared/debug-helper/visualizer/visualizer/work-visualizer.component.ts
@@ -81,6 +81,8 @@ export class WorkVisualizerComponent extends Hooks {
   @Input()
   renderingsOn = false;
 
+  @Input() reCreateContentOnCd = true;
+
   changeO$ = new ReplaySubject<Observable<any>>(1);
 
   @Input()
@@ -105,24 +107,30 @@ export class WorkVisualizerComponent extends Hooks {
         this.changeO$.pipe(
           distinctUntilChanged(),
           switchMap((o$) =>
-            !!this.key ? o$.pipe(map((s) => s[this.key])) : o$
+            !!this.key ? o$.pipe(map((s) => s[this.key])) : o$,
           ),
           distinctUntilChanged(),
-          tap((v) => console.log('value', v))
-        )
-      )
-    )
+          tap((v) => console.log('value', v)),
+        ),
+      ),
+    ),
   );
+
+  private items: any[];
 
   constructor() {
     super();
   }
 
   getChildren(): number[] {
+    if (!this.reCreateContentOnCd && this.items) {
+      return this.items;
+    }
     const items = [];
     for (let i = 0; i <= this.work * 10; i++) {
       items.push(Math.ceil(Math.random() * 100));
     }
-    return items;
+    this.items = items;
+    return this.items;
   }
 }

--- a/libs/template/chunk/ng-package.json
+++ b/libs/template/chunk/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/package.schema.json",
+  "lib": {
+    "entryFile": "src/index.ts",
+    "flatModuleFile": "template-chunk"
+  }
+}

--- a/libs/template/chunk/src/index.ts
+++ b/libs/template/chunk/src/index.ts
@@ -1,0 +1,1 @@
+export { RxChunk } from './lib/chunk.directive';

--- a/libs/template/chunk/src/lib/chunk.directive.ts
+++ b/libs/template/chunk/src/lib/chunk.directive.ts
@@ -1,0 +1,178 @@
+import {
+  Directive,
+  inject,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import { NextObserver, Subscription } from 'rxjs';
+
+/**
+ * @Directive ChunkDirective
+ *
+ * @description
+ *
+ * The `*rxChunk` directive serves as a convenient way for dividing template work into
+ * chunks. Applied to an element, it will schedule a task with the given RxRenderStrategy
+ * in order to postpone the template creation of this element.
+ *
+ * ### Features of `*rxChunk`
+ *
+ * - lightweight alternative to `*rxLet="[]"`
+ * - renderCallback
+ * - no value binding
+ * - no context variables
+ * - zone agnostic
+ * - suspense template
+ *
+ * @docsCategory ChunkDirective
+ * @docsPage ChunkDirective
+ * @publicApi
+ */
+@Directive({ selector: '[rxChunk]', standalone: true })
+export class RxChunk implements OnInit, OnDestroy {
+  #strategyProvider = inject<RxStrategyProvider<string>>(RxStrategyProvider);
+
+  /**
+   * @description
+   * The rendering strategy with which the chunk directive should schedule the view
+   * creation. If no strategy is defined, `*rxChunk` will use the configured
+   * `primaryStrategy` as fallback instead.
+   *
+   * @example
+   * \@Component({
+   *   selector: 'app-root',
+   *   template: `
+   *     <div *rxChunk="strategy">
+   *       chunked template
+   *     </div>
+   *   `
+   * })
+   * export class AppComponent {
+   *   strategy = 'low';
+   * }
+   *
+   * @param { RxStrategyNames<string> } strategy
+   */
+  @Input('rxChunk') strategy = this.#strategyProvider.primaryStrategy;
+
+  /**
+   * @description
+   * Setting the `patchZone` to a falsy value will cause the `*rxChunk` directive
+   * to create the `EmbeddedView` outside of `NgZone`.
+   *
+   * @example
+   * \@Component({
+   *   selector: 'app-root',
+   *   template: `
+   *     <div *rxChunk="patchZone: false">
+   *       chunked template out of NgZone
+   *     </div>
+   *   `
+   * })
+   * export class AppComponent { }
+   *
+   * @param { boolean } patchZone
+   */
+  @Input('rxChunkPatchZone') patchZone =
+    this.#strategyProvider.config.patchZone;
+
+  /**
+   * @description
+   * A template to show while the chunk directive is waiting for scheduled task
+   * with the given `RenderStrategy`.
+   * This can be useful in order to minimize layout shifts caused by the delayed
+   * view creation.
+   *
+   * @example
+   * <app-hero [hero]="hero"
+   *  *rxChunk="suspenseTpl: suspenseTemplate"></app-hero>
+   * <ng-template #suspenseTemplate>
+   *   <progress-spinner></progress-spinner>
+   * </ng-template>
+   *
+   * @param {TemplateRef<unknown>} suspense
+   */
+  @Input('rxChunkSuspense') suspense: TemplateRef<unknown>;
+
+  /** @internal */
+  private _renderObserver: NextObserver<void>;
+
+  /**
+   * @description
+   * A callback informing about when the template was actually created. This can
+   * be used when you need to know the exact timing when the template was
+   * added to the DOM, e.g. for height calculations and such.
+   *
+   * @example
+   * \@Component({
+   *   selector: 'app-root',
+   *   template: `
+   *     <div *rxChunk="renderCallback: renderCallback">
+   *       chunked template
+   *     </div>
+   *   `
+   * })
+   * export class AppComponent {
+   *   renderCallback = new Subject<void>();
+   *
+   *   constructor() {
+   *     this.renderCallback.subscribe(() => {
+   *       // the div is now accessible
+   *     })
+   *   }
+   * }
+   *
+   *
+   * @param {NextObserver<void>} renderCallback
+   */
+  @Input('rxChunkRenderCallback')
+  set renderCallback(renderCallback: NextObserver<void>) {
+    this._renderObserver = renderCallback;
+  }
+
+  /** @internal */
+  private subscription?: Subscription;
+
+  constructor(
+    private templateRef: TemplateRef<unknown>,
+    private viewContainer: ViewContainerRef,
+    private ngZone: NgZone,
+  ) {}
+
+  ngOnInit() {
+    this.subscription = this.#strategyProvider
+      .schedule(
+        () => {
+          this.viewContainer.clear();
+          this.createView();
+        },
+        {
+          strategy:
+            this.#strategyProvider.strategies[this.strategy]?.name || undefined,
+          patchZone: this.patchZone ? this.ngZone : false,
+        },
+      )
+      .subscribe(() => this._renderObserver?.next());
+    // do not create suspense template when strategy was sync and there already
+    // is a template
+    if (this.suspense && this.viewContainer.length === 0) {
+      this.createView(this.suspense);
+    }
+  }
+
+  ngOnDestroy() {
+    this.viewContainer.clear();
+    this.subscription?.unsubscribe();
+  }
+
+  private createView(template?: TemplateRef<unknown>): void {
+    const tpl = template || this.templateRef;
+    const view = this.viewContainer.createEmbeddedView(tpl);
+    view.detectChanges();
+  }
+}

--- a/libs/template/chunk/src/lib/tests/chunk.directive.spec.ts
+++ b/libs/template/chunk/src/lib/tests/chunk.directive.spec.ts
@@ -1,0 +1,110 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import { delay, Subject } from 'rxjs';
+import { RxChunk } from '../chunk.directive';
+
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'chunk-test',
+  template: `
+    <div
+      *rxChunk="
+        strategy;
+        renderCallback: renderCallback;
+        suspense: withSuspense ? suspense : null
+      "
+    >
+      chunked
+    </div>
+    <div>not-chunked</div>
+    <ng-template #suspense>suspended</ng-template>
+  `,
+})
+class ChunkTestComponent {
+  strategy? = undefined;
+  renderCallback = new Subject<void>();
+  withSuspense = false;
+}
+
+describe('ChunkDirective', () => {
+  let fixture: ComponentFixture<ChunkTestComponent>;
+  let componentInstance: ChunkTestComponent;
+  let nativeElement: HTMLElement;
+  let strategyProvider: RxStrategyProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RxChunk],
+      declarations: [ChunkTestComponent],
+    });
+    fixture = TestBed.createComponent(ChunkTestComponent);
+    componentInstance = fixture.componentInstance;
+    nativeElement = fixture.nativeElement;
+    strategyProvider = TestBed.inject(RxStrategyProvider);
+  });
+
+  describe.each([
+    [undefined, true] /* <- Invalid strategy should fallback. */,
+    ['', true] /* <- Same here. */,
+    ['invalid', true] /* <- Same here. */,
+    ['immediate', true],
+    ['userBlocking', true],
+    ['normal', true],
+    ['low', true],
+    ['idle', true],
+    ['local', true],
+    ['native', false],
+  ])('Strategy: %s', (strategy: string, scheduled: boolean) => {
+    it('should render with given strategy', (done) => {
+      componentInstance.strategy = strategy;
+      const expectedInitialTemplate = scheduled
+        ? 'not-chunked'
+        : 'chunked not-chunked';
+      componentInstance.renderCallback.subscribe(() => {
+        try {
+          expect(nativeElement.textContent.trim()).toBe('chunked not-chunked');
+          done();
+        } catch (e) {
+          done(e.message);
+        }
+      });
+      fixture.detectChanges();
+      expect(nativeElement.textContent.trim()).toBe(expectedInitialTemplate);
+    });
+    it('should render the suspense template sync', (done) => {
+      componentInstance.strategy = strategy;
+      componentInstance.withSuspense = true;
+      const expectedInitialTemplate = scheduled
+        ? 'suspendednot-chunked'
+        : 'chunked not-chunked';
+      componentInstance.renderCallback.subscribe(() => {
+        try {
+          expect(nativeElement.textContent.trim()).toBe('chunked not-chunked');
+          done();
+        } catch (e) {
+          done(e.message);
+        }
+      });
+      fixture.detectChanges();
+      expect(nativeElement.textContent.trim()).toBe(expectedInitialTemplate);
+    });
+  });
+
+  it('should not render with noop strategy', (done) => {
+    componentInstance.strategy = 'noop';
+    fixture.detectChanges();
+    expect(nativeElement.textContent).toBe('not-chunked');
+    strategyProvider
+      .schedule(() => {})
+      .pipe(delay(10)) // let's just wait a tiny bit to be sure nothing happens :)
+      .subscribe(() => {
+        try {
+          expect(nativeElement.textContent.trim()).toBe('not-chunked');
+          done();
+        } catch (e) {
+          done(e.message);
+        }
+      });
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -48,6 +48,7 @@
       "@rx-angular/state/effects": ["libs/state/effects/src/index.ts"],
       "@rx-angular/state/selections": ["libs/state/selections/src/index.ts"],
       "@rx-angular/template": ["libs/template/src/index.ts"],
+      "@rx-angular/template/chunk": ["libs/template/chunk/src/index.ts"],
       "@rx-angular/template/experimental/viewport-prio": [
         "libs/template/experimental/viewport-prio/src/index.ts"
       ],


### PR DESCRIPTION
# ChunkDirective

This PR introduces the `*rxChunk` structural directive.

the  `*rxChunk` directive serves as a convenient way for dividing template work into chunks.
Applied to an element, it will schedule a task with the given RxRenderStrategy in order to postpone the template creation of this element.

![rx-chunk](https://user-images.githubusercontent.com/4904455/180814988-14887411-9106-4ee7-9e0d-22a46e127b66.gif)

closes https://github.com/rx-angular/rx-angular/issues/1802

### PR Checklist

- [x] implementation
- [x] demo
- [x] unit tests
- [x] docs (jsdocs)

### Features of `*rxChunk`

* lightweight alternative to `*rxLet="[]"`
* renderCallback
* no value binding
* no context variables
* zone agnostic
* suspense template

![long task](https://user-images.githubusercontent.com/4904455/180815459-1d49aa72-97fa-42b4-bccb-437a42f8d9b0.png)

![distribute work](https://user-images.githubusercontent.com/4904455/180815471-cd31a234-1fa9-487e-bba2-60735bd9591e.png)


