### PR TITLE
Add overloads to select for more concise state projections

### DIFF
--- a/libs/state/selections/docs/operators/select.md
+++ b/libs/state/selections/docs/operators/select.md
@@ -1,6 +1,28 @@
 ## select
 
-returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
+### Signature
+
+```typescript
+function select<T>(): MonoTypeOperatorFunction<T>;
+```
+
+Returns the state as shared, replayed and distinct `Observable<T>`. This way you don't have to think about late
+subscribers, multiple subscribers or multiple emissions of the same value.
+
+_Example_
+
+```typescript
+const state$ = state.pipe(select());
+state$.subscribe((state) => doStuff(state));
+```
+
+### Signature
+
+```typescript
+function select<T, A>(op: OperatorFunction<T, A>): OperatorFunction<T, A>;
+```
+
+Returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
 [rxjs operators](https://rxjs-dev.firebaseapp.com/guide/operators) to enrich the selection with reactive composition.
 
 _Example_
@@ -17,11 +39,62 @@ const profilePicture$ = state.pipe(
 ### Signature
 
 ```typescript
-function select<T, A>(op: OperatorFunction<T, A>): OperatorFunction<T, A>;
+function select<T, K1 extends keyof T>(k1: K1): OperatorFunction<T, T[K1]>;
 ```
 
-### Parameters
+Access a single property of the state by providing keys.
+Returns a single property of the state as cached and distinct `Observable<T[K1]>`.
 
-#### op
+_Example_
 
-##### typeof: OperatorFunction&#60;T, A&#62;
+```typescript
+// Access a single property
+const bar$ = state$.pipe(select('bar'));
+
+// Access a nested property
+const foo$ = state$.pipe(select('bar', 'foo'));
+```
+
+### Signature
+
+```typescript
+function select<T, K extends keyof T, R>(
+  k: K,
+  fn: (val: T[K]) => R
+): OperatorFunction<T, R>;
+```
+
+Transform a single property of the state by providing a key and map function.
+Returns result of applying function to state property as cached and distinct `Observable<T[R]>`.
+
+_Example_
+
+```typescript
+// Project state based on single property
+const foo$ = state$.pipe(select('bar', (bar) => `bar equals ${bar}`));
+```
+
+### Signature
+
+```typescript
+function select<T extends object, K extends keyof T, R>(
+  keys: K[],
+  fn: (slice: PickSlice<T, K>) => R,
+  keyCompareMap?: KeyCompareMap<Pick<T, K>>
+): OperatorFunction<T, R>;
+```
+
+Transform a slice of the state by providing keys and map function.
+Returns result of applying function to state slice as cached and distinct `Observable<R>`.
+
+_Example_
+
+```typescript
+// Project state slice
+const text$ = state$.pipe(
+  select(
+    ['query', 'results'],
+    ({ query, results }) => `${results.length} results found for "${query}"`
+  )
+);
+```

--- a/libs/state/selections/spec/select.spec.ts
+++ b/libs/state/selections/spec/select.spec.ts
@@ -128,6 +128,24 @@ describe('select', () => {
     });
   });
 
+  it('should accept array of strings keyof T and one map function', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const primitiveState: PrimitiveState = {
+        bol: true,
+        str: 'string',
+        num: 42,
+      };
+      const source: Observable<PrimitiveState> = cold('a|', {
+        a: primitiveState,
+      });
+      expectObservable(
+        source.pipe(select(['num', 'str'], ({ num, str }) => `${str} (${num})`))
+      ).toBe('a|', {
+        a: 'string (42)',
+      });
+    });
+  });
+
   it('should accept one operator', () => {
     testScheduler.run(({ cold, expectObservable }) => {
       const source: Observable<PrimitiveState> = cold('a|', {

--- a/libs/state/selections/spec/select.spec.ts
+++ b/libs/state/selections/spec/select.spec.ts
@@ -1,6 +1,4 @@
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
-import { select } from '@rx-angular/state/selections';
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import {
   initialNestedState,
   initialPrimitiveState,
@@ -11,6 +9,7 @@ import {
 import { EMPTY, NEVER, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
+import { select } from '../src/lib/operators/select';
 
 let testScheduler: TestScheduler;
 

--- a/libs/state/selections/spec/select.spec.ts
+++ b/libs/state/selections/spec/select.spec.ts
@@ -1,16 +1,16 @@
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import { select } from '@rx-angular/state/selections';
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import {
-  jestMatcher,
   initialNestedState,
   initialPrimitiveState,
+  jestMatcher,
   NestedState,
   PrimitiveState,
 } from '@test-helpers';
 import { EMPTY, NEVER, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
-import { select } from '@rx-angular/state/selections';
 
 let testScheduler: TestScheduler;
 
@@ -109,6 +109,22 @@ describe('select', () => {
       expectObservable(
         source.pipe(select('obj', 'key1', 'key11', 'key111'))
       ).toBe('a|', { a: 'test' });
+    });
+  });
+
+  it('should accept one string keyof T and one map function', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const primitiveState: PrimitiveState = {
+        bol: true,
+        str: 'string',
+        num: 42,
+      };
+      const source: Observable<PrimitiveState> = cold('a|', {
+        a: primitiveState,
+      });
+      expectObservable(source.pipe(select('num', (x) => x / 2))).toBe('a|', {
+        a: 21,
+      });
     });
   });
 

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -1,19 +1,20 @@
+export { createAccumulationObservable } from './lib/accumulation-observable';
+export { CompareFn, KeyCompareMap, PickSlice } from './lib/interfaces/index';
 export { AccumulationFn, Accumulator } from './lib/model';
 export {
-  select,
-  stateful,
   distinctUntilSomeChanged,
+  select,
   selectSlice,
+  stateful,
 } from './lib/operators/index';
+export { createSideEffectObservable } from './lib/side-effect-observable';
 export {
-  isKeyOf,
-  isOperateFnArrayGuard,
-  isStringArrayGuard,
-  isObjectGuard,
   isDefined,
+  isKeyOf,
+  isObjectGuard,
+  isOperateFnArrayGuard,
+  isStringAndFunctionTupleGuard,
+  isStringArrayGuard,
 } from './lib/utils/guards';
 export { pipeFromArray } from './lib/utils/pipe-from-array';
 export { safePluck } from './lib/utils/safe-pluck';
-export { KeyCompareMap, CompareFn, PickSlice } from './lib/interfaces/index';
-export { createAccumulationObservable } from './lib/accumulation-observable';
-export { createSideEffectObservable } from './lib/side-effect-observable';

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -15,6 +15,7 @@ export {
   isOperateFnArrayGuard,
   isStringAndFunctionTupleGuard,
   isStringArrayGuard,
+  isStringsArrayAndFunctionTupleGuard,
 } from './lib/utils/guards';
 export { pipeFromArray } from './lib/utils/pipe-from-array';
 export { safePluck } from './lib/utils/safe-pluck';

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -14,8 +14,8 @@ export {
   isObjectGuard,
   isOperateFnArrayGuard,
   isStringAndFunctionTupleGuard,
+  isStringArrayFunctionAndOptionalObjectTupleGuard,
   isStringArrayGuard,
-  isStringsArrayAndFunctionTupleGuard,
 } from './lib/utils/guards';
 export { pipeFromArray } from './lib/utils/pipe-from-array';
 export { safePluck } from './lib/utils/safe-pluck';

--- a/libs/state/selections/src/lib/operators/select.ts
+++ b/libs/state/selections/src/lib/operators/select.ts
@@ -203,19 +203,16 @@ export function select<
  */
 export function select<T>(
   ...opOrMapFn:
-    | OperatorFunction<T, any>[]
+    | OperatorFunction<T, unknown>[]
     | string[]
-    | [string, (val: any) => any]
-    | [string[], (slice: any) => any]
-): OperatorFunction<T, any> {
+    | [string, (val: unknown) => unknown]
+    | [string[], (slice: unknown) => unknown]
+): OperatorFunction<T, unknown> {
   return (state$: Observable<T>) => {
     if (!opOrMapFn || opOrMapFn.length === 0) {
       return state$.pipe(stateful());
     } else if (isStringAndFunctionTupleGuard(opOrMapFn)) {
-      return state$.pipe(
-        stateful(pluck(opOrMapFn[0])),
-        stateful(map(opOrMapFn[1]))
-      );
+      return state$.pipe(stateful(map((s) => opOrMapFn[1](s[opOrMapFn[0]]))));
     } else if (isStringsArrayAndFunctionTupleGuard(opOrMapFn)) {
       return state$.pipe(
         selectSlice<T & object, keyof T>(opOrMapFn[0] as (keyof T)[]),

--- a/libs/state/selections/src/lib/operators/select.ts
+++ b/libs/state/selections/src/lib/operators/select.ts
@@ -27,43 +27,6 @@ export function select<T>(): MonoTypeOperatorFunction<T>;
 
 /**
  * @description
- * Transform a slice of the state by providing keys and map function.
- * Returns result of applying function to state slice as cached and distinct `Observable<R>`.
- *
- * @example
- * // Project state slice
- * const text$ = state$.pipe(
- *   select(
- *     ['query', 'results'],
- *     ({ query, results }) => `${results.length} results found for "${query}"`
- *   )
- * );
- *
- * @return Observable<R>
- */
-export function select<T extends object, K extends keyof T, R>(
-  keys: K[],
-  fn: (slice: PickSlice<T, K>) => R
-): OperatorFunction<T, R>;
-
-/**
- * @description
- * Transform a single property of the state by providing a key and map function.
- * Returns result of applying function to state property as cached and distinct `Observable<T[R]>`.
- *
- * @example
- *  // Project state based on single property
- * const foo$ = state$.pipe(select('bar', bar => `bar equals ${bar}`));
- *
- * @return Observable<R>
- */
-export function select<T, K extends keyof T, R>(
-  k: K,
-  fn: (val: T[K]) => R
-): OperatorFunction<T, R>;
-
-/**
- * @description
  * returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
  * [rxjs operators](https://rxjs-dev.firebaseapp.com/guide/operators) to enrich the selection with reactive composition.
  *
@@ -117,6 +80,43 @@ export function select<T, A, B, C, D, E>(
   op4: OperatorFunction<C, D>,
   op5: OperatorFunction<D, E>
 ): OperatorFunction<T, E>;
+
+/**
+ * @description
+ * Transform a slice of the state by providing keys and map function.
+ * Returns result of applying function to state slice as cached and distinct `Observable<R>`.
+ *
+ * @example
+ * // Project state slice
+ * const text$ = state$.pipe(
+ *   select(
+ *     ['query', 'results'],
+ *     ({ query, results }) => `${results.length} results found for "${query}"`
+ *   )
+ * );
+ *
+ * @return Observable<R>
+ */
+export function select<T extends object, K extends keyof T, R>(
+  keys: K[],
+  fn: (slice: PickSlice<T, K>) => R
+): OperatorFunction<T, R>;
+
+/**
+ * @description
+ * Transform a single property of the state by providing a key and map function.
+ * Returns result of applying function to state property as cached and distinct `Observable<T[R]>`.
+ *
+ * @example
+ *  // Project state based on single property
+ * const foo$ = state$.pipe(select('bar', bar => `bar equals ${bar}`));
+ *
+ * @return Observable<R>
+ */
+export function select<T, K extends keyof T, R>(
+  k: K,
+  fn: (val: T[K]) => R
+): OperatorFunction<T, R>;
 
 /**
  * @description

--- a/libs/state/selections/src/lib/operators/select.ts
+++ b/libs/state/selections/src/lib/operators/select.ts
@@ -201,7 +201,7 @@ export function select<
 /**
  * @internal
  */
-export function select<T>(
+export function select<T extends Record<string, unknown>>(
   ...opOrMapFn:
     | OperatorFunction<T, unknown>[]
     | string[]

--- a/libs/state/selections/src/lib/operators/select.ts
+++ b/libs/state/selections/src/lib/operators/select.ts
@@ -13,7 +13,7 @@ import { stateful } from './stateful';
 
 /**
  * @description
- * returns the state as shared, replayed and distinct `Observable<T>`. This way you don't have to think about late
+ * Returns the state as shared, replayed and distinct `Observable<T>`. This way you don't have to think about late
  * subscribers, multiple subscribers or multiple emissions of the same value.
  *
  * @example
@@ -27,7 +27,7 @@ export function select<T>(): MonoTypeOperatorFunction<T>;
 
 /**
  * @description
- * returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
+ * Returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
  * [rxjs operators](https://rxjs-dev.firebaseapp.com/guide/operators) to enrich the selection with reactive composition.
  *
  * @example
@@ -109,7 +109,7 @@ export function select<T extends object, K extends keyof T, R>(
  * Returns result of applying function to state property as cached and distinct `Observable<T[R]>`.
  *
  * @example
- *  // Project state based on single property
+ * // Project state based on single property
  * const foo$ = state$.pipe(select('bar', bar => `bar equals ${bar}`));
  *
  * @return Observable<R>
@@ -125,7 +125,7 @@ export function select<T, K extends keyof T, R>(
  * Returns a single property of the state as cached and distinct `Observable<T[K1]>`.
  *
  * @example
- *  // Access a single property
+ * // Access a single property
  * const bar$ = state$.pipe(select('bar'));
  *
  * // Access a nested property

--- a/libs/state/selections/src/lib/utils/guards.ts
+++ b/libs/state/selections/src/lib/utils/guards.ts
@@ -59,3 +59,9 @@ export function isStringAndFunctionTupleGuard<R>(
 ): op is [string, (val: any) => R] {
   return typeof op[0] === 'string' && typeof op[1] === 'function';
 }
+
+export function isStringsArrayAndFunctionTupleGuard<R>(
+  op: unknown[]
+): op is [string[], (val: any) => R] {
+  return isStringArrayGuard(op[0] as any) && typeof op[1] === 'function';
+}

--- a/libs/state/selections/src/lib/utils/guards.ts
+++ b/libs/state/selections/src/lib/utils/guards.ts
@@ -53,3 +53,9 @@ export function isObjectGuard(obj: unknown): obj is object {
 export function isDefined(val: unknown): val is NonNullable<any> {
   return val !== null && val !== undefined;
 }
+
+export function isStringAndFunctionTupleGuard<R>(
+  op: unknown[]
+): op is [string, (val: any) => R] {
+  return typeof op[0] === 'string' && typeof op[1] === 'function';
+}

--- a/libs/state/selections/src/lib/utils/guards.ts
+++ b/libs/state/selections/src/lib/utils/guards.ts
@@ -60,8 +60,12 @@ export function isStringAndFunctionTupleGuard<R>(
   return typeof op[0] === 'string' && typeof op[1] === 'function';
 }
 
-export function isStringsArrayAndFunctionTupleGuard<R>(
+export function isStringArrayFunctionAndOptionalObjectTupleGuard<R>(
   op: unknown[]
-): op is [string[], (val: any) => R] {
-  return isStringArrayGuard(op[0] as any) && typeof op[1] === 'function';
+): op is [strs: string[], fn: (val: any) => R, obj?: object] {
+  return (
+    isStringArrayGuard(op[0] as any) &&
+    typeof op[1] === 'function' &&
+    (op[2] === undefined || typeof op[2] === 'object')
+  );
 }

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -240,6 +240,17 @@ describe('RxStateService', () => {
           });
         });
       });
+
+      it('should return mapped slice on select with keys and function', () => {
+        testScheduler.run(({ expectObservable }) => {
+          const state = setupState({ initialState: initialPrimitiveState });
+          expectObservable(
+            state.select(['num', 'str'], ({ num, str }) => `${str}: ${num}`)
+          ).toBe('s', {
+            s: `${initialPrimitiveState.str}: ${initialPrimitiveState.num}`,
+          });
+        });
+      });
     });
   });
 

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -1,14 +1,15 @@
-import { initialPrimitiveState, jestMatcher, PrimitiveState } from '@test-helpers';
 import { fakeAsync, TestBed } from '@angular/core/testing';
-import {
-  createStateChecker,
-} from './fixtures';
-
-import { TestScheduler } from 'rxjs/testing';
 import { RxState } from '@rx-angular/state';
 import { select } from '@rx-angular/state/selections';
-import { map, pluck, switchMap, take, takeUntil } from 'rxjs/operators';
+import {
+  initialPrimitiveState,
+  jestMatcher,
+  PrimitiveState,
+} from '@test-helpers';
 import { of, scheduled, Subject } from 'rxjs';
+import { map, pluck, switchMap, take, takeUntil } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { createStateChecker } from './fixtures';
 
 function setupState<T extends object>(cfg: { initialState?: T }) {
   const { initialState } = { ...cfg };
@@ -230,6 +231,15 @@ describe('RxStateService', () => {
           });
         });
       });
+
+      it('should return mapped slice on select with key and function', () => {
+        testScheduler.run(({ expectObservable }) => {
+          const state = setupState({ initialState: initialPrimitiveState });
+          expectObservable(state.select('num', (x) => x * 2)).toBe('s', {
+            s: initialPrimitiveState.num * 2,
+          });
+        });
+      });
     });
   });
 
@@ -308,7 +318,9 @@ describe('RxStateService', () => {
           c: 44,
         });
 
-        state.connect(scheduled([{ num: 42 }, { num: 43 }, { num: 44 }], testScheduler));
+        state.connect(
+          scheduled([{ num: 42 }, { num: 43 }, { num: 44 }], testScheduler)
+        );
       });
     });
 
@@ -323,7 +335,10 @@ describe('RxStateService', () => {
 
         state.connect(
           'num',
-          scheduled([{ num: 42 }, { num: 43 }, { num: 44 }], testScheduler).pipe(map((s) => s.num))
+          scheduled(
+            [{ num: 42 }, { num: 43 }, { num: 44 }],
+            testScheduler
+          ).pipe(map((s) => s.num))
         );
       });
     });
@@ -373,7 +388,10 @@ describe('RxStateService', () => {
         });
 
         state.connect(
-          scheduled([{ num: undefined }, { num: 43 }, { num: undefined }], testScheduler),
+          scheduled(
+            [{ num: undefined }, { num: 43 }, { num: undefined }],
+            testScheduler
+          ),
           (o, n) => n
         );
       });
@@ -390,7 +408,11 @@ describe('RxStateService', () => {
           c: undefined,
         });
 
-        state.connect('num', scheduled([undefined, 43, undefined], testScheduler), (o, n) => n);
+        state.connect(
+          'num',
+          scheduled([undefined, 43, undefined], testScheduler),
+          (o, n) => n
+        );
       });
     });
 
@@ -405,7 +427,10 @@ describe('RxStateService', () => {
           c: undefined,
         });
 
-        state.connect('num', scheduled([undefined, 43, undefined], testScheduler));
+        state.connect(
+          'num',
+          scheduled([undefined, 43, undefined], testScheduler)
+        );
       });
     });
 
@@ -421,7 +446,10 @@ describe('RxStateService', () => {
         });
 
         state.connect(
-          scheduled([{ num: undefined }, { num: 43 }, { num: undefined }], testScheduler),
+          scheduled(
+            [{ num: undefined }, { num: 43 }, { num: undefined }],
+            testScheduler
+          ),
           (sta, newVal) => newVal
         );
       });
@@ -438,7 +466,7 @@ describe('RxStateService', () => {
     it('should stop from connect observable', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
         const state = setupState({});
-        const tick$ = hot('aaaaaaaaaaaaaaa|', {a : 1});
+        const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect(tick$.pipe(map((num) => ({ num }))));
         state.ngOnDestroy();
@@ -450,7 +478,7 @@ describe('RxStateService', () => {
     it('should stop from connect key & observable', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
         const state = setupState<any>({});
-        const tick$ = hot('aaaaaaaaaaaaaaa|', {a : 1});
+        const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect('num' as any, tick$);
         state.ngOnDestroy();
@@ -461,8 +489,8 @@ describe('RxStateService', () => {
 
     it('should stop from connect observable & projectFn', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
-        const state = setupState({ });
-        const tick$ = hot('aaaaaaaaaaaaaaa|', {a : 1});
+        const state = setupState({});
+        const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect(tick$, (s, v) => ({ num: v * 42 }));
         state.ngOnDestroy();
@@ -473,8 +501,8 @@ describe('RxStateService', () => {
 
     it('should stop from connect key & observable & projectFn', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
-        const state = setupState<any>({ });
-        const tick$ = hot('aaaaaaaaaaaaaaa|', {a : 1});
+        const state = setupState<any>({});
+        const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect('num', tick$, (s, v) => v * 42);
         state.ngOnDestroy();
@@ -485,8 +513,8 @@ describe('RxStateService', () => {
 
     it('should stop in selects with HOOs', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
-        const state = setupState({ });
-        const interval$ = hot('aaaaaaaaaaaaaaa|', {a : 1});
+        const state = setupState({});
+        const interval$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '';
         expectObservable(
           state.select(
@@ -549,7 +577,7 @@ describe('RxStateService', () => {
       const state = setupState({ initialState: initialPrimitiveState });
       testScheduler.run(({ expectObservable }) => {
         expectObservable(state.select('num')).toBe('(a)', {
-          a: 44
+          a: 44,
         });
 
         state.set({ num: 42 });

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -2,6 +2,7 @@ import { fakeAsync, TestBed } from '@angular/core/testing';
 import { RxState } from '@rx-angular/state';
 import { select } from '@rx-angular/state/selections';
 import {
+  initialNestedState,
   initialPrimitiveState,
   jestMatcher,
   PrimitiveState,
@@ -248,6 +249,23 @@ describe('RxStateService', () => {
             state.select(['num', 'str'], ({ num, str }) => `${str}: ${num}`)
           ).toBe('s', {
             s: `${initialPrimitiveState.str}: ${initialPrimitiveState.num}`,
+          });
+        });
+      });
+
+      it('should return mapped slice on select with keys, function and key compare map', () => {
+        testScheduler.run(({ expectObservable }) => {
+          const state = setupState({
+            initialState: { ...initialPrimitiveState, ...initialNestedState },
+          });
+          expectObservable(
+            state.select(
+              ['num', 'obj'],
+              ({ num, obj }) => `${num}: ${obj.key1.key11.key111}`,
+              { obj: (a, b) => a.key1.key11.key111 === b.key1.key11.key111 }
+            )
+          ).toBe('s', {
+            s: `${initialPrimitiveState.num}: ${initialNestedState.obj.key1.key11.key111}`,
           });
         });
       });

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -431,38 +431,6 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
 
   /**
    * @description
-   * Transform a slice of the state by providing keys and map function.
-   * Returns result of applying function to state slice as cached and distinct `Observable<V>`.
-   *
-   * @example
-   * // Project state slice
-   * const text$ = state.select(
-   *   ['query', 'results'],
-   *   ({ query, results }) => `${results.length} results found for "${query}"`
-   * );
-   *
-   * @return Observable<V>
-   */
-  select<K extends keyof T, V>(
-    keys: K[],
-    fn: (slice: PickSlice<T, K>) => V
-  ): Observable<V>;
-
-  /**
-   * @description
-   * Transform a single property of the state by providing a key and map function.
-   * Returns result of applying function to state property as cached and distinct `Observable<V>`.
-   *
-   * @example
-   * // Project state based on single property
-   * const foo$ = state.select('bar', bar => `bar equals ${bar}`);
-   *
-   * @return Observable<V>
-   */
-  select<K extends keyof T, V>(k: K, fn: (val: T[K]) => V): Observable<V>;
-
-  /**
-   * @description
    * returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
    * [rxjs operators](https://rxjs-dev.firebaseapp.com/guide/operators) to enrich the selection with reactive
    *   composition.
@@ -510,6 +478,36 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
     op4: OperatorFunction<C, D>,
     op5: OperatorFunction<D, E>
   ): Observable<E>;
+  /**
+   * @description
+   * Transform a slice of the state by providing keys and map function.
+   * Returns result of applying function to state slice as cached and distinct `Observable<V>`.
+   *
+   * @example
+   * // Project state slice
+   * const text$ = state.select(
+   *   ['query', 'results'],
+   *   ({ query, results }) => `${results.length} results found for "${query}"`
+   * );
+   *
+   * @return Observable<V>
+   */
+  select<K extends keyof T, V>(
+    keys: K[],
+    fn: (slice: PickSlice<T, K>) => V
+  ): Observable<V>;
+  /**
+   * @description
+   * Transform a single property of the state by providing a key and map function.
+   * Returns result of applying function to state property as cached and distinct `Observable<V>`.
+   *
+   * @example
+   * // Project state based on single property
+   * const foo$ = state.select('bar', bar => `bar equals ${bar}`);
+   *
+   * @return Observable<V>
+   */
+  select<K extends keyof T, V>(k: K, fn: (val: T[K]) => V): Observable<V>;
   /**
    * @description
    * Access a single property of the state by providing keys.

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -584,15 +584,14 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
     ...opOrMapFn:
       | OperatorFunction<T, R>[]
       | string[]
-      | [string, (val: any) => R]
-      | [string[], (slice: any) => R]
+      | [string, (val: unknown) => R]
+      | [string[], (slice: unknown) => R]
   ): Observable<T | R> {
     if (!opOrMapFn || opOrMapFn.length === 0) {
       return this.accumulator.state$.pipe(stateful());
     } else if (isStringAndFunctionTupleGuard(opOrMapFn)) {
       return this.accumulator.state$.pipe(
-        stateful(pluck(opOrMapFn[0])),
-        stateful(map(opOrMapFn[1]))
+        stateful(map((s) => opOrMapFn[1](s[opOrMapFn[0]])))
       );
     } else if (isStringsArrayAndFunctionTupleGuard(opOrMapFn)) {
       return this.accumulator.state$.pipe(

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -591,7 +591,9 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
       return this.accumulator.state$.pipe(stateful());
     } else if (isStringAndFunctionTupleGuard(opOrMapFn)) {
       return this.accumulator.state$.pipe(
-        stateful(map((s) => opOrMapFn[1](s[opOrMapFn[0]])))
+        stateful(
+          map((s) => opOrMapFn[1]((s as Record<string, unknown>)[opOrMapFn[0]]))
+        )
       );
     } else if (isStringsArrayAndFunctionTupleGuard(opOrMapFn)) {
       return this.accumulator.state$.pipe(

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -5,6 +5,7 @@ import {
   createAccumulationObservable,
   createSideEffectObservable,
   isKeyOf,
+  KeyCompareMap,
   PickSlice,
   safePluck,
   select,
@@ -488,7 +489,8 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
    */
   select<K extends keyof T, V>(
     keys: K[],
-    fn: (slice: PickSlice<T, K>) => V
+    fn: (slice: PickSlice<T, K>) => V,
+    keyCompareMap?: KeyCompareMap<Pick<T, K>>
   ): Observable<V>;
   /**
    * @description
@@ -578,8 +580,12 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
     ...args:
       | OperatorFunction<T, unknown>[]
       | string[]
-      | [string, (val: unknown) => unknown]
-      | [string[], (slice: unknown) => unknown]
+      | [k: string, fn: (val: unknown) => unknown]
+      | [
+          keys: string[],
+          fn: (slice: unknown) => unknown,
+          keyCompareMap?: KeyCompareMap<T>
+        ]
   ): Observable<T | R> {
     return this.accumulator.state$.pipe(
       select(...(args as Parameters<typeof select>))

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -412,7 +412,7 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
 
   /**
    * @description
-   * returns the state as cached and distinct `Observable<T>`. This way you don't have to think about **late
+   * Returns the state as cached and distinct `Observable<T>`. This way you don't have to think about **late
    * subscribers**,
    * **multiple subscribers** or **multiple emissions** of the same value
    *
@@ -426,7 +426,7 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
 
   /**
    * @description
-   * returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
+   * Returns the state as cached and distinct `Observable<A>`. Accepts arbitrary
    * [rxjs operators](https://rxjs-dev.firebaseapp.com/guide/operators) to enrich the selection with reactive
    *   composition.
    *


### PR DESCRIPTION
This PR adds two overloads to RxState's `select` method (and operator), which I think would make state projections more concise.

What I use `select` for most frequently is transforming one or more state properties reactively into the shape I need for my template. In other words, to project state using the declarative `f(state) = UI` approach. I often need a custom projection function for this (=> `map` operator), and also want the automatic optimization of only emitting changes to state props it depends on (=> `select` operator if single key, or `selectSlice` operator if multiple keys). This means I often write code like this:

```ts
isLoaded$ = this.state.select(
  select('loading'),
  map(loading => !loading),
);

filteredItems$ = this.state.select(
  selectSlice(['items', 'textFilter']),
  map(({ items, textFilter }) => items.filter(item => item.title.includes(textFilter))),
);
```

Due to how common projecting state is, I feel like the syntax for this could be shorter. So in this PR, I'd like to add two overloads to `select` that would enable this code to be more concise:

```ts
isLoaded$ = this.state.select('loading', loading => !loading);

filteredItems$ = this.state.select(
  ['items', 'textFilter'],
  ({ items, textFilter }) => items.filter(item => item.title.includes(textFilter)),
);
```

I'd say the pros of adding these overloads are:
- makes state projections more concise and therefore more declarative,
- non-breaking changes to `select`'s API,
- performance optimizations under the hood,
- feels similar to NgRx's `createSelector` (projector function + memoization),
- less reason to use `state.select(...).pipe(...)` pattern I've noticed with others (possibly related to #311).

I guess the main con would be that `select` already has many overloads, so this might complicate the interface. (There's an older discussion in #263 about changes to `select` or `selectSlice` which seems relevant.)