### PR TITLE
Fix template context API docs

### DIFF
--- a/libs/template/docs/api/let-directive.md
+++ b/libs/template/docs/api/let-directive.md
@@ -87,9 +87,9 @@ You can also use template anchors and display template's content for different o
   *rxLet="
     observableNumber$;
     let n;
-    rxError: error;
-    rxSuspense: suspense;
-    rxComplete: complete;
+    error: error;
+    suspense: suspense;
+    complete: complete;
   "
 >
   <app-number [number]="n"></app-number>


### PR DESCRIPTION
Suspense, Error, Complete should not have rx prefix in the template