### PR TITLE
chore: build docs on PR run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       # don't run build in parallel, can cause dead locks
       - name: Run Affected build
-        run: yarn nx affected:build --exclude=docs --parallel=false
+        run: yarn nx affected:build --parallel=false
 
       - run: yarn nx-cloud stop-all-agents
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,14 +55,14 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-            token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build-docs:
     runs-on: ubuntu-latest
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:
@@ -105,7 +105,6 @@ jobs:
 
       # @Notice: temporary skip Nx cloud for this job as it's hanging indefinitely in the CI.
       # - run: yarn nx-cloud stop-all-agents
-
 #      - uses: EndBug/add-and-commit@v4
 #        with:
 #          add: 'docs/dist/*'


### PR DESCRIPTION
Build `docs` project on PR runs to force compilation errors and broken links to break the build before being merged.

*Most changes are because of formatting.*