### PR TITLE
docs: correct base URL for *Edit this page* links

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -35,7 +35,7 @@ module.exports = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: `https://github.com/${organizationName}/${projectName}/edit/main`,
+          editUrl: `https://github.com/${organizationName}/${projectName}/edit/main/apps/docs`,
         },
         // Disable the blog plugin
         blog: false,


### PR DESCRIPTION
# Current behavior
When I click *Edit this page* on for example https://www.rx-angular.io/docs/state, I navigate to https://github.com/rx-angular/rx-angular/edit/main/docs/state/state.mdx

# Expected behavior
When I click *Edit this page* on for example https://www.rx-angular.io/docs/state (or locally at http://localhost:3000/docs/state), I navigate to https://github.com/rx-angular/rx-angular/edit/main/apps/docs/docs/state/state.mdx