### PR TITLE
fix(template): rxFor: only subscribe once to value input

### DIFF
--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -33,7 +33,7 @@ import {
   Subject,
   Subscription,
 } from 'rxjs';
-import { switchAll } from 'rxjs/operators';
+import { shareReplay, switchAll } from 'rxjs/operators';
 import { RxForViewContext } from './for-view-context';
 
 /**
@@ -400,7 +400,8 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   /** @internal */
   private readonly values$ = this.observables$.pipe(
     coerceObservableWith(),
-    switchAll()
+    switchAll(),
+    shareReplay({ refCount: true, bufferSize: 1 })
   );
 
   /** @internal */

--- a/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
@@ -3,6 +3,7 @@ import { ErrorHandler } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
+import { Observable } from 'rxjs';
 import { ForModule } from '../for.module';
 import {
   createErrorHandler,
@@ -64,6 +65,21 @@ describe('rxFor with observables', () => {
     });
     warnSpy.mockClear();
   });
+
+  it(
+    'should subscribe only once to the source',
+    waitForAsync(() => {
+      fixture = createTestComponent();
+      let subscriber = 0;
+      const observable = new Observable((observer) => {
+        subscriber++;
+        observer.next(['1']);
+      });
+      fixture.componentInstance.itemsHot$ = observable as never;
+      detectChangesAndExpectText('1;');
+      expect(subscriber).toBe(1);
+    })
+  );
 
   it(
     'should reflect initial elements',


### PR DESCRIPTION
# Description

just noticed we have a bug in rxFor that leads to multiple subscriptions being made to the incoming source value. That's definitely not what we want. Added `shareReplay` as a fix and implemented a test case to ensure we don't introduce the same bug again.