### PR TITLE
fix(cdk): list-template-manager should always emit latest value

### DIFF
--- a/libs/cdk/template/src/lib/list-template-manager.ts
+++ b/libs/cdk/template/src/lib/list-template-manager.ts
@@ -7,7 +7,13 @@ import {
   TemplateRef,
   TrackByFunction,
 } from '@angular/core';
-import { combineLatest, MonoTypeOperatorFunction, Observable, of } from 'rxjs';
+import {
+  combineLatest,
+  MonoTypeOperatorFunction,
+  NEVER,
+  Observable,
+  of,
+} from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -119,8 +125,9 @@ export function createListTemplateManager<
           let changes: IterableChanges<T>;
           if (differ) {
             if (partiallyFinished) {
-              const currentIterable = [];
-              for (let i = 0, ilen = viewContainerRef.length; i < ilen; i++) {
+              const length = viewContainerRef.length;
+              const currentIterable = new Array<T>(viewContainerRef.length);
+              for (let i = 0; i < length; i++) {
                 const viewRef = <EmbeddedViewRef<C>>viewContainerRef.get(i);
                 currentIterable[i] = viewRef.context.$implicit;
               }
@@ -137,7 +144,7 @@ export function createListTemplateManager<
         // Cancel old renders
         switchMap(({ changes, iterable, strategy }) => {
           if (!changes) {
-            return of([]);
+            return of(iterable);
           }
           const values = iterable || [];
           // TODO: we might want to treat other iterables in a more performant way than Array.from()


### PR DESCRIPTION
## Bug

The list template manager emits an empty array after it received a value and detected no changes to render. This leads to unexpected value emissions through `rxFor`s rendercallback.

## Fix

The list template manager should always emit the latest set of data, even if no change was detected on new value input.
This is e.g. useful in scenarios where you rely on the renderCallback in order to hide a loading spinner after an asynchronous operation.
I'm thinking about a search bar triggering an http request and returning the same data as before. `rxFor` wouldn't render any new change, but the renderCallback should still indicate the change got processed.