### PR TITLE
feat(template): introduce RxStyle Directive

### DIFF
--- a/libs/template/style/ng-package.json
+++ b/libs/template/style/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/package.schema.json",
+  "lib": {
+    "entryFile": "src/index.ts",
+    "flatModuleFile": "template-style"
+  }
+}

--- a/libs/template/style/src/index.ts
+++ b/libs/template/style/src/index.ts
@@ -1,0 +1,2 @@
+export { RxStyleModule } from './lib/style.module';
+export { RxStyle } from './lib/style.directive';

--- a/libs/template/style/src/lib/style.directive.ts
+++ b/libs/template/style/src/lib/style.directive.ts
@@ -1,0 +1,165 @@
+import {
+  Directive,
+  DoCheck,
+  ElementRef,
+  Input,
+  KeyValueChanges,
+  KeyValueDiffer,
+  KeyValueDiffers,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Renderer2,
+  RendererStyleFlags2,
+  SimpleChanges,
+} from '@angular/core';
+import {
+  onStrategy,
+  RxStrategyNames,
+  RxStrategyProvider,
+} from '@rx-angular/cdk/render-strategies';
+import {
+  coerceObservableWith,
+} from '@rx-angular/cdk/coercing';
+import {
+  isObservable,
+  NextObserver,
+  Observable,
+  ObservableInput,
+  ReplaySubject,
+  Subscription,
+  switchMap,
+} from 'rxjs';
+import { map, shareReplay, switchAll } from 'rxjs/operators';
+type RxStyleValues = { [style: string]: any } | null | undefined;
+
+/* eslint-disable @angular-eslint/no-conflicting-lifecycle */
+@Directive({ selector: '[rxStyle]' })
+// eslint-disable-next-line @angular-eslint/directive-class-suffix
+export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
+  /** @internal */
+  private staticStyles: RxStyleValues;
+  /** @internal */
+  private renderOnCheck = false;
+  /** @internal */
+  private readonly values$ = new ReplaySubject<
+    Observable<RxStyleValues> | RxStyleValues
+  >(1);
+  /** @internal */
+  private readonly styles$ = this.values$.pipe(
+    coerceObservableWith(),
+    switchAll(),
+    shareReplay({ refCount: true, bufferSize: 1 })
+  );
+  /** @internal */
+  private differ: KeyValueDiffer<string, string | number> | null = null;
+
+  @Input('rxStyle') style: ObservableInput<RxStyleValues> | RxStyleValues;
+
+  @Input('rxStyleStrategy') strategy: RxStrategyNames<string>;
+
+  @Input('rxStyleRenderCallback')
+  renderObserver: NextObserver<RxStyleValues> | null = null;
+
+  private readonly subscription = new Subscription();
+
+  constructor(
+    private elementRef: ElementRef,
+    private differs: KeyValueDiffers,
+    private renderer: Renderer2,
+    private strategyProvider: RxStrategyProvider
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.style) {
+      if (!isObservable(this.style)) {
+        this.staticStyles = this.style;
+        this.renderOnCheck = true;
+      } else {
+        this.staticStyles = undefined;
+        this.renderOnCheck = false;
+        this.values$.next(this.style);
+      }
+    }
+  }
+
+  ngOnInit() {
+    this.subscription.add(
+      this.styles$
+        .pipe(
+          map((styles) => ({
+            styles,
+            changes: this.getDiffer(styles)?.diff(styles),
+          })),
+          switchMap(({ changes, styles }) =>
+            changes
+              ? onStrategy(
+                  styles,
+                  this.strategyProvider.strategies[this.strategy] ??
+                    this.strategyProvider.strategies[
+                      this.strategyProvider.config.primaryStrategy
+                    ],
+                  () => {
+                    this.applyChanges(changes);
+                  }
+                )
+              : [styles]
+          )
+        )
+        .subscribe((rendered) => this.renderObserver?.next(rendered))
+    );
+  }
+
+  ngDoCheck() {
+    if (this.renderOnCheck) {
+      this.values$.next(this.staticStyles);
+    }
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  private getDiffer(
+    values: RxStyleValues
+  ): KeyValueDiffer<string, string | number> {
+    if (!this.differ && values) {
+      this.differ = this.differs.find(values).create();
+    }
+    return this.differ;
+  }
+
+  private setStyle(
+    nameAndUnit: string,
+    value: string | number | null | undefined
+  ): void {
+    const [name, unit] = nameAndUnit.split('.');
+    const flags =
+      name.indexOf('-') === -1
+        ? undefined
+        : (RendererStyleFlags2.DashCase as number);
+
+    if (value != null) {
+      this.renderer.setStyle(
+        this.elementRef.nativeElement,
+        name,
+        unit ? `${value}${unit}` : value,
+        flags
+      );
+    } else {
+      this.renderer.removeStyle(this.elementRef.nativeElement, name, flags);
+    }
+  }
+
+  private applyChanges(
+    changes: KeyValueChanges<string, string | number>
+  ): void {
+    changes.forEachRemovedItem((record) => this.setStyle(record.key, null));
+    changes.forEachAddedItem((record) =>
+      this.setStyle(record.key, record.currentValue)
+    );
+    changes.forEachChangedItem((record) =>
+      this.setStyle(record.key, record.currentValue)
+    );
+  }
+}

--- a/libs/template/style/src/lib/style.directive.ts
+++ b/libs/template/style/src/lib/style.directive.ts
@@ -9,6 +9,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  Output,
   Renderer2,
   RendererStyleFlags2,
   SimpleChanges,
@@ -102,6 +103,9 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
   @Input('rxStyleRenderCallback')
   renderObserver: NextObserver<RxStyleValues> | null = null;
 
+  @Output('rxStyleRenderCallback')
+  renderCallback = new Subject<RxStyleValues>();
+
   /** @internal */
   private readonly subscription = new Subscription();
 
@@ -150,10 +154,13 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
                     this.applyChanges(changes);
                   }
                 )
-              : [styles]
+              : NEVER
           )
         )
-        .subscribe((rendered) => this.renderObserver?.next(rendered))
+        .subscribe((rendered) => {
+          this.renderObserver?.next(rendered);
+          this.renderCallback.next(rendered);
+        })
     );
   }
 

--- a/libs/template/style/src/lib/style.directive.ts
+++ b/libs/template/style/src/lib/style.directive.ts
@@ -18,9 +18,7 @@ import {
   RxStrategyNames,
   RxStrategyProvider,
 } from '@rx-angular/cdk/render-strategies';
-import {
-  coerceObservableWith,
-} from '@rx-angular/cdk/coercing';
+import { coerceObservableWith } from '@rx-angular/cdk/coercing';
 import {
   isObservable,
   NextObserver,
@@ -31,6 +29,7 @@ import {
   switchMap,
 } from 'rxjs';
 import { map, shareReplay, switchAll } from 'rxjs/operators';
+
 type RxStyleValues = { [style: string]: any } | null | undefined;
 
 /* eslint-disable @angular-eslint/no-conflicting-lifecycle */
@@ -61,6 +60,7 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
   @Input('rxStyleRenderCallback')
   renderObserver: NextObserver<RxStyleValues> | null = null;
 
+  /** @internal */
   private readonly subscription = new Subscription();
 
   constructor(
@@ -120,6 +120,7 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
     this.subscription.unsubscribe();
   }
 
+  /** @internal */
   private getDiffer(
     values: RxStyleValues
   ): KeyValueDiffer<string, string | number> {
@@ -129,6 +130,7 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
     return this.differ;
   }
 
+  /** @internal */
   private setStyle(
     nameAndUnit: string,
     value: string | number | null | undefined
@@ -151,6 +153,7 @@ export class RxStyle implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
   }
 
+  /** @internal */
   private applyChanges(
     changes: KeyValueChanges<string, string | number>
   ): void {

--- a/libs/template/style/src/lib/style.directive.ts
+++ b/libs/template/style/src/lib/style.directive.ts
@@ -38,8 +38,12 @@ type RxStyleMap = {
   [style: string]: string | number | Observable<number | string>;
 };
 function isRxStyleMap(v: unknown): v is RxStyleMap {
-  const keys = Object.keys(v);
-  return typeof v === 'object' && keys.some((key) => isObservable(v[key]));
+  return (
+    v != null &&
+    typeof v === 'object' &&
+    !isObservable(v) &&
+    Object.keys(v).some((key) => isObservable(v[key]))
+  );
 }
 type RxStyleValues = { [style: string]: number | string } | null | undefined;
 type RxStyleInput = Observable<RxStyleValues> | RxStyleValues | RxStyleMap;

--- a/libs/template/style/src/lib/style.module.ts
+++ b/libs/template/style/src/lib/style.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { RxStyle } from './style.directive';
+
+@NgModule({
+  imports: [],
+  exports: [RxStyle],
+  declarations: [RxStyle],
+  providers: [],
+})
+export class RxStyleModule {}

--- a/libs/template/style/src/lib/tests/fixtures.ts
+++ b/libs/template/style/src/lib/tests/fixtures.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// eslint-disable-next-line @angular-eslint/component-selector
+@Component({ selector: 'test-cmp', template: '' })
+export class TestComponent {
+  expr: any;
+}
+
+export function createTestComponent(
+  template: string
+): ComponentFixture<TestComponent> {
+  return TestBed.overrideComponent(TestComponent, {
+    set: { template: template },
+  }).createComponent(TestComponent);
+}

--- a/libs/template/style/src/lib/tests/fixtures.ts
+++ b/libs/template/style/src/lib/tests/fixtures.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
 
 // eslint-disable-next-line @angular-eslint/component-selector
 @Component({ selector: 'test-cmp', template: '' })
 export class TestComponent {
   expr: any;
+  strategy: any;
+  renderedValue$: Observable<any>;
+  renderCallback: (v: any) => void;
 }
 
 export function createTestComponent(

--- a/libs/template/style/src/lib/tests/style.directive.observable.spec.ts
+++ b/libs/template/style/src/lib/tests/style.directive.observable.spec.ts
@@ -279,7 +279,7 @@ describe('RxStyle Observable values', () => {
     expect(getElement().styles).toEqual({ width: '400px' });
   });
 
-  it('should accept a mix of reactive and observable values', () => {
+  it('should accept a mix of static and observable values', () => {
     const template = `<div [rxStyle]="expr"></div>`;
     fixture = createTestComponent(template);
     fixture.componentInstance.expr = { 'width.px': of(400), 'height.px': 20 };
@@ -287,7 +287,7 @@ describe('RxStyle Observable values', () => {
     expect(getElement().styles).toEqual({ width: '400px', height: '20px' });
   });
 
-  xit('should react to changes of a mix of reactive and observable values', () => {
+  xit('should react to changes of a mix of static and observable values', () => {
     // TODO: clarify if we want to support this feature. It would increase the complexity of a lot
     const template = `<div [rxStyle]="expr"></div>`;
     fixture = createTestComponent(template);

--- a/libs/template/style/src/lib/tests/style.directive.rendercallback.spec.ts
+++ b/libs/template/style/src/lib/tests/style.directive.rendercallback.spec.ts
@@ -1,0 +1,117 @@
+import { DebugElement, NgZone } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { firstValueFrom, of, ReplaySubject, Subject } from 'rxjs';
+import { RxStyleModule } from '../style.module';
+import { createTestComponent, TestComponent } from './fixtures';
+
+describe('RxStyle renderCallback', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
+
+  function getElement(): DebugElement {
+    return fixture.debugElement.children[0];
+  }
+
+  afterEach(() => {
+    fixture = null;
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [RxStyleModule],
+    });
+    fixture = createTestComponent(
+      `<div [rxStyle]="expr" (rxStyleRenderCallback)="renderCallback($event)" [rxStyleRenderCallback]="renderedValue$" [rxStyleStrategy]="strategy"></div>`
+    );
+    getComponent().renderedValue$ = new Subject();
+    getComponent().strategy = new ReplaySubject(1);
+    getComponent().expr = new ReplaySubject(1);
+    getComponent().renderCallback = jest.fn();
+    fixture.detectChanges();
+  });
+
+  describe.each([
+    [''] /* <- Invalid strategy should fallback. */,
+    ['invalid'] /* <- Same here. */,
+
+    ['immediate'],
+    ['userBlocking'],
+    ['normal'],
+    ['low'],
+    ['idle'],
+    ['native'],
+  ])('Strategy: %p', (strategy) => {
+    it(
+      'should output rendered value',
+      waitForAsync(async () => {
+        getComponent().strategy.next(strategy);
+        getComponent().expr.next({ 'width.px': 40 });
+        const renderedValue = await firstValueFrom(
+          getComponent().renderedValue$
+        );
+        expect(renderedValue).toEqual({ 'width.px': 40 });
+        expect(getElement().styles).toEqual({ width: '40px' });
+        expect(getComponent().renderCallback).toHaveBeenCalledTimes(1);
+        expect(getComponent().renderCallback).toHaveBeenCalledWith({
+          'width.px': 40,
+        });
+      })
+    );
+
+    it(
+      'should output rendered value on update',
+      waitForAsync(async () => {
+        getComponent().strategy.next(strategy);
+        getComponent().expr.next({ 'width.px': 40 });
+        const renderedValue = await firstValueFrom(
+          getComponent().renderedValue$
+        );
+        expect(renderedValue).toEqual({ 'width.px': 40 });
+        expect(getElement().styles).toEqual({ width: '40px' });
+        expect(getComponent().renderCallback).toHaveBeenCalledTimes(1);
+        expect(getComponent().renderCallback).toHaveBeenCalledWith({
+          'width.px': 40,
+        });
+
+        const updatedPromise = firstValueFrom(getComponent().renderedValue$);
+
+        getComponent().expr.next({ 'width.px': 60 });
+
+        expect(await updatedPromise).toEqual({ 'width.px': 60 });
+
+        expect(getElement().styles).toEqual({ width: '60px' });
+        expect(getComponent().renderCallback).toHaveBeenCalledTimes(2);
+        expect(getComponent().renderCallback).toHaveBeenCalledWith({
+          'width.px': 60,
+        });
+      })
+    );
+
+    it(
+      'should not output rendered value when there is no change',
+      waitForAsync(async () => {
+        getComponent().strategy.next(strategy);
+        getComponent().expr.next({ 'width.px': 40 });
+        await firstValueFrom(getComponent().renderedValue$);
+        expect(getElement().styles).toEqual({ width: '40px' });
+        expect(getComponent().renderCallback).toHaveBeenCalledWith({
+          'width.px': 40,
+        });
+
+        const updatedValuePromise = Promise.race([
+          firstValueFrom(getComponent().renderedValue$),
+          new Promise((resolve) => setTimeout(() => resolve(false), 20)),
+        ]);
+
+        getComponent().expr.next({ 'width.px': 40 });
+
+        expect(await updatedValuePromise).toBe(false);
+        expect(getComponent().renderCallback).toHaveBeenCalledTimes(1);
+      })
+    );
+  });
+});

--- a/libs/template/style/src/lib/tests/style.directive.spec.ts
+++ b/libs/template/style/src/lib/tests/style.directive.spec.ts
@@ -1,0 +1,312 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
+import { RxStyle } from '../style.directive';
+import { RxStyleModule } from '../style.module';
+
+describe('RxStyle', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  const supportsCssVariables =
+    typeof getComputedStyle !== 'undefined' &&
+    typeof CSS !== 'undefined' &&
+    typeof CSS.supports !== 'undefined' &&
+    CSS.supports('color', 'var(--fake-var)');
+
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
+
+  function getElement(): DebugElement {
+    return fixture.debugElement.children[0];
+  }
+
+  function expectNativeEl(fixture: ComponentFixture<any>): any {
+    return expect(fixture.debugElement.children[0].nativeElement);
+  }
+
+  afterEach(() => {
+    fixture = null!;
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [RxStyleModule],
+      providers: [
+        {
+          provide: RX_RENDER_STRATEGIES_CONFIG,
+          useValue: {
+            primaryStrategy: 'native',
+          },
+        },
+      ],
+    });
+  });
+
+  it(
+    'should add styles specified in an object literal',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="{'max-width': '40px'}"></div>`;
+      fixture = createTestComponent(template);
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({
+        'max-width': '40px',
+      });
+    })
+  );
+
+  it(
+    'should add and change styles specified in an object expression',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      const expr = getComponent().expr;
+      expr['max-width'] = '30%';
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '30%' });
+    })
+  );
+
+  it(
+    'should remove styles with a null expression',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      getComponent().expr = null;
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+    })
+  );
+
+  it(
+    'should remove styles with an undefined expression',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      getComponent().expr = undefined;
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+    })
+  );
+
+  it(
+    'should add and remove styles specified using style.unit notation',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="{'max-width.px': expr}"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = '40';
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      getComponent().expr = null;
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+    })
+  );
+
+  // https://github.com/angular/angular/issues/21064
+  it(
+    'should add and remove styles which names are not dash-cased',
+    waitForAsync(() => {
+      fixture = createTestComponent(`<div [rxStyle]="{'color': expr}"></div>`);
+
+      getComponent().expr = 'green';
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ color: 'green' });
+
+      getComponent().expr = null;
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('color');
+    })
+  );
+
+  it(
+    'should update styles using style.unit notation when unit changes',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width.px': '40' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      getComponent().expr = { 'max-width.em': '40' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40em' });
+    })
+  );
+
+  // keyValueDiffer is sensitive to key order #9115
+  it(
+    'should change styles specified in an object expression',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = {
+        // height, width order is important here
+        height: '10px',
+        width: '10px',
+      };
+
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ height: '10px', width: '10px' });
+
+      getComponent().expr = {
+        // width, height order is important here
+        width: '5px',
+        height: '5px',
+      };
+
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ height: '5px', width: '5px' });
+    })
+  );
+
+  it(
+    'should remove styles when deleting a key in an object expression',
+    waitForAsync(() => {
+      const template = `<div [rxStyle]="expr"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({ 'max-width': '40px' });
+
+      delete getComponent().expr['max-width'];
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+    })
+  );
+
+  it(
+    'should co-operate with the style attribute',
+    waitForAsync(() => {
+      const template = `<div style="font-size: 12px" [rxStyle]="expr"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect((getElement().nativeElement as HTMLElement).style.fontSize).toBe(
+        '12px'
+      );
+      expect((getElement().nativeElement as HTMLElement).style.maxWidth).toBe(
+        '40px'
+      );
+      delete getComponent().expr['max-width'];
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+      expect((getElement().nativeElement as HTMLElement).style.fontSize).toBe(
+        '12px'
+      );
+    })
+  );
+
+  it(
+    'should co-operate with the style.[styleName]="expr" special-case in the compiler',
+    waitForAsync(() => {
+      const template = `<div [style.font-size.px]="12" [rxStyle]="expr"></div>`;
+
+      fixture = createTestComponent(template);
+
+      getComponent().expr = { 'max-width': '40px' };
+      fixture.detectChanges();
+      expect(getElement().styles).toEqual({
+        'max-width': '40px',
+        'font-size': '12px',
+      });
+
+      delete getComponent().expr['max-width'];
+      fixture.detectChanges();
+      expect(getElement().styles).not.toContain('max-width');
+      expect(getElement().styles).toEqual({
+        'font-size': '12px',
+        'max-width': null,
+      });
+    })
+  );
+
+  it('should not write to the native node unless the bound expression has changed', () => {
+    const template = `<div [rxStyle]="{'color': expr}"></div>`;
+
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = 'red';
+
+    fixture.detectChanges();
+    expect(getElement().styles).toEqual({ color: 'red' });
+
+    // Overwrite native styles so that we can check if rxStyle has performed DOM manupulation to
+    // update it.
+    fixture.debugElement.children[0].nativeElement.style.color = 'blue';
+    fixture.detectChanges();
+    // Assert that the style hasn't been updated
+    expect(getElement().styles).toEqual({ color: 'red' });
+    expect((getElement().nativeElement as HTMLElement).style.color).toBe(
+      'blue'
+    );
+
+    fixture.componentInstance.expr = 'yellow';
+    fixture.detectChanges();
+    // Assert that the style has changed now that the model has changed
+    expect(getElement().styles).toEqual({ color: 'yellow' });
+  });
+
+  it('should correctly update style with units (.px) when the model is set to number', () => {
+    const template = `<div [rxStyle]="{'width.px': expr}"></div>`;
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = 400;
+
+    fixture.detectChanges();
+    expect(getElement().styles).toEqual({ width: '400px' });
+  });
+
+  it('should handle CSS variables', () => {
+    if (!supportsCssVariables) {
+      return;
+    }
+
+    const template = `<div style="width: var(--width)" [rxStyle]="{'--width': expr}"></div>`;
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = '100px';
+    fixture.detectChanges();
+
+    const target: HTMLElement = fixture.nativeElement.querySelector('div');
+    expect(getComputedStyle(target).getPropertyValue('width')).toEqual('100px');
+  });
+});
+
+// eslint-disable-next-line @angular-eslint/component-selector
+@Component({ selector: 'test-cmp', template: '' })
+class TestComponent {
+  expr: any;
+}
+
+function createTestComponent(
+  template: string
+): ComponentFixture<TestComponent> {
+  return TestBed.overrideComponent(TestComponent, {
+    set: { template: template },
+  }).createComponent(TestComponent);
+}

--- a/libs/template/style/src/lib/tests/style.directive.strategies.spec.ts
+++ b/libs/template/style/src/lib/tests/style.directive.strategies.spec.ts
@@ -1,0 +1,75 @@
+import { DebugElement, NgZone } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { firstValueFrom, of, Subject } from 'rxjs';
+import { RxStyleModule } from '../style.module';
+import { createTestComponent, TestComponent } from './fixtures';
+
+describe('RxStyle strategies', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
+
+  function getElement(): DebugElement {
+    return fixture.debugElement.children[0];
+  }
+
+  afterEach(() => {
+    fixture = null;
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [RxStyleModule],
+    });
+    fixture = createTestComponent(
+      `<div [rxStyle]="expr" [rxStyleRenderCallback]="renderedValue$" [rxStyleStrategy]="strategy"></div>`
+    );
+    getComponent().expr = { 'width.px': of(40) };
+    getComponent().renderedValue$ = new Subject();
+  });
+
+  describe('ngZone', () => {
+    let ngZone: NgZone;
+
+    beforeEach(() => {
+      ngZone = TestBed.inject(NgZone);
+    });
+
+    it('should run outside ngZone', async () => {
+      getComponent().strategy = 'normal';
+      fixture.detectChanges();
+      const ngZoneSpy = jest.spyOn(ngZone, 'run');
+      const renderedValue = await firstValueFrom(getComponent().renderedValue$);
+      expect(renderedValue).toEqual({ 'width.px': 40 });
+      expect(ngZoneSpy).toHaveBeenCalledTimes(1);
+      ngZoneSpy.mockReset();
+    });
+  });
+
+  describe.each([
+    [''] /* <- Invalid strategy should fallback. */,
+    ['invalid'] /* <- Same here. */,
+
+    ['immediate'],
+    ['userBlocking'],
+    ['normal'],
+    ['low'],
+    ['idle'],
+    ['native'],
+  ])('Strategy: %p', (strategy) => {
+    it(
+      'should render with given strategy',
+      waitForAsync(async () => {
+        getComponent().strategy = strategy;
+        const promise = firstValueFrom(getComponent().renderedValue$);
+        fixture.detectChanges();
+        const renderedValue = await promise;
+        expect(renderedValue).toEqual({ 'width.px': 40 });
+        expect(getElement().styles).toEqual({ width: '40px' });
+      })
+    );
+  });
+});

--- a/libs/template/style/src/lib/tests/style.directive.strategies.spec.ts
+++ b/libs/template/style/src/lib/tests/style.directive.strategies.spec.ts
@@ -38,6 +38,10 @@ describe('RxStyle strategies', () => {
       ngZone = TestBed.inject(NgZone);
     });
 
+    afterEach(() => {
+      ngZone = null;
+    });
+
     it('should run outside ngZone', async () => {
       getComponent().strategy = 'normal';
       fixture.detectChanges();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -55,6 +55,7 @@
       "@rx-angular/template/experimental/viewport-prio": [
         "libs/template/experimental/viewport-prio/src/index.ts"
       ],
+      "@rx-angular/template/style": ["libs/template/style/src/index.ts"],
       "@rx-angular/template/for": ["libs/template/for/src/index.ts"],
       "@rx-angular/template/if": ["libs/template/if/src/index.ts"],
       "@rx-angular/template/let": ["libs/template/let/src/index.ts"],


### PR DESCRIPTION
# Description

Introducing `rxStyle` directive. It serves as a drop-in replacement for `ngStyle`, but with more features.

- [x] Implement tests (again, the directive is in line with the original ngStyle spec)
- [x] Implement tests for strategies and renderCallback behavior
- [ ] Discuss issue with mixed Input Values
- [ ] Web Docs
- [ ] JSDocs

## Basic Usage

**Static Values**

```html
<div [rxStyle]="{
   'width.px': 50
}"></div>
```

**Observable Values**

```ts
styles$ = new BehaviorSubject({
  'max-width.px': 50
});

height$ = new BehaviorSubject(50);

styleMap$ = {
  color: color$,
  'background-color: backgroundColor$
}
```

```html
<div [rxStyle]="styles$"></div>

<div [rxStyle]="{
   'height.px': height$
}"></div>

<div [rxStyle]="styleMap$"></div>
```

**Mixed Values**

```html
<div [rxStyle]="{
   'width.px': 50,
   'height.px': height$
}"></div>
```

> Mixed Values (Observable & Static) do not behave the same way as static only values

Changes to the static values of the object won't be picked up as the directive has no idea when to update them. This is described in the following spec:

https://github.com/rx-angular/rx-angular/pull/1465/files#diff-6c3b0985a2f785d2b2f9c33d956c67e83541b7a4c84d51d7709f574aba2246e9R290-R301


## Usage as reactive HostBinding 

One of the major benefits of `rxStyle` is its usage as **reactive HostBinding**! With the new directive composition API, something like this is possible:

```ts
@Component({
  providers: [RxState],
  hostDirectives: [RxStyle]
})
export class Comp {

  constructor(
      private rxStyle: RxStyle,
      private state: RxState
   ) {
    // HostBinding for stylings are now reactive, work with renderStrategies and don't need ChangeDetection at all
    rxStyle.styles = state.select('componentStyles');
  }
}
```