### PR TITLE
fix(cdk): make sure tasks queued by NgZone are also executed

### DIFF
--- a/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
@@ -219,65 +219,116 @@ describe('Scheduler', () => {
       runtime.assertLog([LogEvent.MessageEvent, 'B']);
     });
 
-    it('should run task with configured patch', () => {
-      const ngZone = getMockNgZone();
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('A');
-      }, { ngZone } );
-      runtime.assertLog([schedulingMessageEvent]);
-      runtime.fireMessageEvent();
-      expect(ngZone.run).toHaveBeenCalledTimes(1);
-      runtime.assertLog([LogEvent.MessageEvent, 'A']);
-    });
+    describe('NgZone', () => {
+      it('should run task with configured patch', () => {
+        const ngZone = getMockNgZone();
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('A');
+          },
+          { ngZone }
+        );
+        runtime.assertLog([schedulingMessageEvent]);
+        runtime.fireMessageEvent();
+        expect(ngZone.run).toHaveBeenCalledTimes(1);
+        runtime.assertLog([LogEvent.MessageEvent, 'A']);
+      });
 
-    it('should run multiple tasks with different patches', () => {
-      const ngZone = getMockNgZone();
-      const ngZone2 = getMockNgZone();
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('A');
-      }, { ngZone } );
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('B');
-      }, { ngZone: ngZone2 } );
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('C');
-      }, { ngZone: ngZone } );
-      runtime.assertLog([schedulingMessageEvent]);
-      runtime.fireMessageEvent();
-      expect(ngZone.run).toHaveBeenCalledTimes(2);
-      expect(ngZone2.run).toHaveBeenCalledTimes(1);
-      runtime.assertLog([LogEvent.MessageEvent, 'A', 'B', 'C']);
-    });
+      it('should run multiple tasks with different patches', () => {
+        const ngZone = getMockNgZone();
+        const ngZone2 = getMockNgZone();
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('A');
+          },
+          { ngZone }
+        );
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('B');
+          },
+          { ngZone: ngZone2 }
+        );
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('C');
+          },
+          { ngZone: ngZone }
+        );
+        runtime.assertLog([schedulingMessageEvent]);
+        runtime.fireMessageEvent();
+        expect(ngZone.run).toHaveBeenCalledTimes(2);
+        expect(ngZone2.run).toHaveBeenCalledTimes(1);
+        runtime.assertLog([LogEvent.MessageEvent, 'A', 'B', 'C']);
+      });
 
-    it('should work with multiple tasks with a yield in between', () => {
-      const ngZone = getMockNgZone();
-      const ngZone2 = getMockNgZone();
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('A');
-      }, { ngZone });
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('B');
-        runtime.advanceTime(4000);
-      }, { ngZone: ngZone2 });
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('C');
-      }, { ngZone });
-      runtime.assertLog([schedulingMessageEvent]);
-      runtime.fireMessageEvent();
-      runtime.assertLog([
-        LogEvent.MessageEvent,
-        'A',
-        'B',
-        // Ran out of time. Post a continuation event.
-        schedulingMessageEvent,
-      ]);
-      // expect(ngZone.run).toHaveBeenCalledTimes(1);
-      runtime.fireMessageEvent();
-      runtime.assertLog([LogEvent.MessageEvent, 'C']);
-      expect(ngZone2.run).toHaveBeenCalledTimes(1);
-      expect(ngZone.run).toHaveBeenCalledTimes(2);
-    });
+      it('should work with multiple tasks with a yield in between', () => {
+        const ngZone = getMockNgZone();
+        const ngZone2 = getMockNgZone();
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('A');
+          },
+          { ngZone }
+        );
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('B');
+            runtime.advanceTime(4000);
+          },
+          { ngZone: ngZone2 }
+        );
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('C');
+          },
+          { ngZone }
+        );
+        runtime.assertLog([schedulingMessageEvent]);
+        runtime.fireMessageEvent();
+        runtime.assertLog([
+          LogEvent.MessageEvent,
+          'A',
+          'B',
+          // Ran out of time. Post a continuation event.
+          schedulingMessageEvent,
+        ]);
+        // expect(ngZone.run).toHaveBeenCalledTimes(1);
+        runtime.fireMessageEvent();
+        runtime.assertLog([LogEvent.MessageEvent, 'C']);
+        expect(ngZone2.run).toHaveBeenCalledTimes(1);
+        expect(ngZone.run).toHaveBeenCalledTimes(2);
+      });
 
+      it('should execute work that was added by NgZone', () => {
+        const ngZone = {
+          run: jest.fn((fn: (...args: any[]) => any) => {
+            const result = fn();
+            scheduleCallback(NormalPriority, () => {
+              runtime.log('B');
+            });
+            return result;
+          }),
+        };
+        scheduleCallback(
+          NormalPriority,
+          () => {
+            runtime.log('A');
+          },
+          { ngZone }
+        );
+        runtime.assertLog([schedulingMessageEvent]);
+        runtime.fireMessageEvent();
+        runtime.assertLog([LogEvent.MessageEvent, 'A', 'B']);
+      });
+    });
   });
 
   const enum LogEvent {
@@ -304,7 +355,7 @@ describe('Scheduler', () => {
 
     ɵglobal.performance.now = () => {
       return currentTime;
-    }
+    };
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     ɵglobal.requestAnimationFrame = ɵglobal.cancelAnimationFrame = () => {};

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.ts
@@ -196,8 +196,13 @@ function workLoop(
   // left.
   // Otherwise, newly added tasks won't run as `performingWork` is still `true`
   currentTask = currentTask ?? peek(taskQueue);
+  // We should also re-calculate the currentTime, as we need to account for the execution
+  // time of the NgZone tasks as well.
+  // If there is still a task in the queue, but no time is left for executing it,
+  // the scheduler will re-schedule the next tick anyway
+  currentTime = getCurrentTime();
   if (zoneChanged || (currentTask && !hitDeadline())) {
-    return workLoop(hasTimeRemaining, getCurrentTime(), currentTask);
+    return workLoop(hasTimeRemaining, currentTime, currentTask);
   }
   // Return whether there's additional work
   if (currentTask !== null) {

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.ts
@@ -2,7 +2,13 @@
 
 import { ɵglobal } from '@angular/core';
 import { enableIsInputPending } from './schedulerFeatureFlags';
-import { peek, pop, push, ReactSchedulerTask, SchedulerTaskZone } from './schedulerMinHeap';
+import {
+  peek,
+  pop,
+  push,
+  ReactSchedulerTask,
+  SchedulerTaskZone,
+} from './schedulerMinHeap';
 
 import { PriorityLevel } from './schedulerPriorities';
 
@@ -14,7 +20,8 @@ declare const ngDevMode: boolean;
 
 let getCurrentTime: () => number;
 const hasPerformanceNow =
-  typeof ɵglobal.performance === 'object' && typeof ɵglobal.performance.now === 'function';
+  typeof ɵglobal.performance === 'object' &&
+  typeof ɵglobal.performance.now === 'function';
 
 if (hasPerformanceNow) {
   const localPerformance = ɵglobal.performance;
@@ -68,11 +75,13 @@ const isInputPending =
   typeof ɵglobal.navigator !== 'undefined' &&
   ɵglobal.navigator.scheduling !== undefined &&
   ɵglobal.navigator.scheduling.isInputPending !== undefined
-  ? ɵglobal.navigator.scheduling.isInputPending.bind(ɵglobal.navigator.scheduling)
-  : null;
+    ? ɵglobal.navigator.scheduling.isInputPending.bind(
+        ɵglobal.navigator.scheduling
+      )
+    : null;
 
 const defaultZone = {
-  run: fn => fn()
+  run: (fn) => fn(),
 };
 function advanceTimers(currentTime) {
   // Check for tasks that are no longer delayed and add them to the queue.
@@ -131,7 +140,11 @@ function flushWork(hasTimeRemaining, initialTime) {
   }
 }
 
-function workLoop(hasTimeRemaining: boolean, initialTime: number, _currentTask?: ReactSchedulerTask) {
+function workLoop(
+  hasTimeRemaining: boolean,
+  initialTime: number,
+  _currentTask?: ReactSchedulerTask
+) {
   let currentTime = initialTime;
   if (_currentTask) {
     currentTask = _currentTask;
@@ -141,7 +154,8 @@ function workLoop(hasTimeRemaining: boolean, initialTime: number, _currentTask?:
   }
   let zoneChanged = false;
   const hitDeadline = () =>
-    currentTask && currentTask.expirationTime > currentTime &&
+    currentTask &&
+    currentTask.expirationTime > currentTime &&
     (!hasTimeRemaining || shouldYieldToHost());
 
   if (!hitDeadline()) {
@@ -155,7 +169,8 @@ function workLoop(hasTimeRemaining: boolean, initialTime: number, _currentTask?:
         if (typeof callback === 'function') {
           currentTask.callback = null;
           currentPriorityLevel = currentTask.priorityLevel;
-          const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
+          const didUserCallbackTimeout =
+            currentTask.expirationTime <= currentTime;
           const continuationCallback = callback(didUserCallbackTimeout);
           currentTime = getCurrentTime();
           if (typeof continuationCallback === 'function') {
@@ -170,12 +185,19 @@ function workLoop(hasTimeRemaining: boolean, initialTime: number, _currentTask?:
           pop(taskQueue);
         }
         currentTask = peek(taskQueue);
-        zoneChanged = currentTask?.ngZone != null && currentTask.ngZone !== ngZone;
+        zoneChanged =
+          currentTask?.ngZone != null && currentTask.ngZone !== ngZone;
       }
     });
   }
-  if (zoneChanged) {
-    return workLoop(hasTimeRemaining, currentTime, currentTask);
+  // we need to check if leaving `NgZone` (tick => detectChanges) caused other
+  // directives to add tasks to the queue. If there is one and we still didn't
+  // hit the deadline, run the workLoop again in order to flush everything thats
+  // left.
+  // Otherwise, newly added tasks won't run as `performingWork` is still `true`
+  currentTask = currentTask ?? peek(taskQueue);
+  if (zoneChanged || (currentTask && !hitDeadline())) {
+    return workLoop(hasTimeRemaining, getCurrentTime(), currentTask);
   }
   // Return whether there's additional work
   if (currentTask !== null) {
@@ -305,7 +327,7 @@ function scheduleCallback(
     startTime,
     expirationTime,
     sortIndex: -1,
-    ngZone: options?.ngZone || null
+    ngZone: options?.ngZone || null,
   };
 
   if (startTime > currentTime) {


### PR DESCRIPTION
# Description

closing #1385 

as described in the linked issue, the scheduler was missing tasks added to the queue by NgZone. This PR fixes that behavior and makes sure we are not missing out cd events.

* [x] fix missing cd
* [x] add unit test