### PR TITLE
docs(state): remove coverage status badge

### DIFF
--- a/apps/docs/docs/state/state.mdx
+++ b/apps/docs/docs/state/state.mdx
@@ -9,7 +9,6 @@ hide_title: true
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
 ![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
-[![Coverage Status](https://raw.githubusercontent.com/rx-angular/rx-angular/github-pages/docs/test-coverage/state/jest-coverage-badge.svg)](https://rx-angular.github.io/rx-angular/test-coverage/state/lcov-report/index.html)
 
 > Reactive Component State for Angular
 


### PR DESCRIPTION
I guess this badge is by accident still there (in all other packages this has been removed)