### PR TITLE
fix(template): typing of track by key as keyof T

### DIFF
--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -302,7 +302,8 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
    * @param trackByFnOrKey
    */
   @Input('rxForTrackBy')
-  set trackBy(trackByFnOrKey: string | ((idx: number, i: T) => any)) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  set trackBy(trackByFnOrKey: keyof T | ((idx: number, i: T) => any)) {
     if (
       (typeof ngDevMode === 'undefined' || ngDevMode) &&
       trackByFnOrKey != null &&


### PR DESCRIPTION
Type hint for object keys and inferred values is now shown.


![image](https://user-images.githubusercontent.com/7274335/212140614-1218737a-7288-43dd-a4ac-b3cf3688061b.png)
