### PR TITLE
feat(template): use default strategy names type for template hint

### DIFF
--- a/apps/demos/src/app/rx-angular-pocs/template/directives/switch/rx-switch-case.directive.ts
+++ b/apps/demos/src/app/rx-angular-pocs/template/directives/switch/rx-switch-case.directive.ts
@@ -7,11 +7,21 @@ import {
   OnDestroy,
   OnInit,
   TemplateRef,
-  ViewContainerRef
+  ViewContainerRef,
 } from '@angular/core';
-import { onStrategy, RxRenderWork, RxStrategyProvider, RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import {
+  onStrategy,
+  RxRenderWork,
+  RxStrategyProvider,
+  RxStrategyNames,
+} from '@rx-angular/cdk/render-strategies';
 import { Subscription, Unsubscribable } from 'rxjs';
-import { distinctUntilChanged, map, switchMap, withLatestFrom } from 'rxjs/operators';
+import {
+  distinctUntilChanged,
+  map,
+  switchMap,
+  withLatestFrom,
+} from 'rxjs/operators';
 import { RxSwitch } from './rx-switch.directive';
 
 @Directive({ selector: '[rxSwitchCase]' })
@@ -35,7 +45,7 @@ export class RxSwitchCase implements OnInit, OnDestroy {
     private viewContainer: ViewContainerRef,
     public templateRef: TemplateRef<Object>,
     private cdRef: ChangeDetectorRef,
-    private strategyProvider: RxStrategyProvider<RxStrategyNames<string>>,
+    private strategyProvider: RxStrategyProvider<RxStrategyNames>,
     @Host() private rxSwitch: RxSwitch<any>
   ) {}
 
@@ -46,7 +56,13 @@ export class RxSwitchCase implements OnInit, OnDestroy {
         map((switchValue) => this.caseValue === switchValue),
         distinctUntilChanged(),
         withLatestFrom(this.rxSwitch.strategies$),
-        switchMap(([v, strategyName]) => onStrategy(v, this.strategyProvider.strategies[strategyName], this.rxSwitchCaseWorkFactory))
+        switchMap(([v, strategyName]) =>
+          onStrategy(
+            v,
+            this.strategyProvider.strategies[strategyName],
+            this.rxSwitchCaseWorkFactory
+          )
+        )
         // applyStrategy2(this.rxSwitch.strategy$, this.rxSwitchCaseWorkFactory, this._view)
       )
       .subscribe({ error: console.log });
@@ -81,6 +97,5 @@ export class RxSwitchCase implements OnInit, OnDestroy {
     this._view.context.$implicit = this.caseValue;
     work(this._view, this._view);
     work(this.cdRef, (this.cdRef as any)?.context || this.cdRef);
-  }
+  };
 }
-

--- a/apps/docs/docs/template/api/rx-if-directive.md
+++ b/apps/docs/docs/template/api/rx-if-directive.md
@@ -69,9 +69,9 @@ export class SomeComponent {
 
 **Value**
 
-| Input  | Type                                 | description                                                       |
-| ------ | ------------------------------------ | ----------------------------------------------------------------- |
-| `rxIf` | `boolean \ ObservableInput<boolean>` | The Observable or value to be bound to the context of a template. |
+| Input  | Type                                    | description                                                       |
+| ------ | --------------------------------------- | ----------------------------------------------------------------- |
+| `rxIf` | `boolean` or `ObservableInput<boolean>` | The Observable or value to be bound to the context of a template. |
 
 **Contextual state**
 
@@ -88,14 +88,14 @@ export class SomeComponent {
 
 **Rendering**
 
-| Input            | Type                                                            | description                                                                                                                                                                                                                                                                                     |
-| ---------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `then`           | `TemplateRef<RxIfViewContext>`                                  | defines the template for when the bound condition is true                                                                                                                                                                                                                                       |
-| `else`           | `TemplateRef<RxIfViewContext>`                                  | defines the template for when the bound condition is false                                                                                                                                                                                                                                      |
-| `patchZone`      | `boolean`                                                       | _default: `true`_ if set to `false`, the `RxIf` will operate out of `NgZone`. See [NgZone optimizations](../performance-issues/ngzone-optimizations.md)                                                                                                                                         |
-| `parent`         | `boolean`                                                       | _default: `true`_ if set to `false`, the `RxIf` won't inform its host component about changes being made to the template. More performant, `@ViewChild` and `@ContentChild` queries won't work. [Handling view and content queries](../performance-issues/handling-view-and-content-queries.md) |
-| `strategy`       | `Observable<RxStrategyNames<string>> \ RxStrategyNames<string>` | _default: `normal`_ configure the `RxStrategyRenderStrategy` used to detect changes.                                                                                                                                                                                                            |
-| `renderCallback` | `Subject<boolean>`                                              | giving the developer the exact timing when the `LetDirective` created, updated, removed its template. Useful for situations where you need to know when rendering is done.                                                                                                                      |
+| Input            | Type                                               | description                                                                                                                                                                                                                                                                                     |
+| ---------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `then`           | `TemplateRef<RxIfViewContext>`                     | defines the template for when the bound condition is true                                                                                                                                                                                                                                       |
+| `else`           | `TemplateRef<RxIfViewContext>`                     | defines the template for when the bound condition is false                                                                                                                                                                                                                                      |
+| `patchZone`      | `boolean`                                          | _default: `true`_ if set to `false`, the `RxIf` will operate out of `NgZone`. See [NgZone optimizations](../performance-issues/ngzone-optimizations.md)                                                                                                                                         |
+| `parent`         | `boolean`                                          | _default: `true`_ if set to `false`, the `RxIf` won't inform its host component about changes being made to the template. More performant, `@ViewChild` and `@ContentChild` queries won't work. [Handling view and content queries](../performance-issues/handling-view-and-content-queries.md) |
+| `strategy`       | `Observable<RxStrategyNames>` or `RxStrategyNames` | _default: `normal`_ configure the `RxStrategyRenderStrategy` used to detect changes.                                                                                                                                                                                                            |
+| `renderCallback` | `Subject<boolean>`                                 | giving the developer the exact timing when the `LetDirective` created, updated, removed its template. Useful for situations where you need to know when rendering is done.                                                                                                                      |
 
 ### Outputs
 

--- a/libs/cdk/render-strategies/src/lib/model.ts
+++ b/libs/cdk/render-strategies/src/lib/model.ts
@@ -49,7 +49,9 @@ export type RxConcurrentStrategyNames =
 export type RxDefaultStrategyNames =
   | RxNativeStrategyNames
   | RxConcurrentStrategyNames;
-export type RxStrategyNames<T> = RxDefaultStrategyNames | T;
+export type RxStrategyNames<T extends string = string> =
+  | RxDefaultStrategyNames
+  | T;
 export type RxStrategies<T extends string> = RxCustomStrategyCredentials<
   RxStrategyNames<T>
 >;

--- a/libs/cdk/render-strategies/src/lib/strategy-handling.ts
+++ b/libs/cdk/render-strategies/src/lib/strategy-handling.ts
@@ -2,11 +2,16 @@ import { Observable, ReplaySubject } from 'rxjs';
 import { map, share, startWith, switchAll } from 'rxjs/operators';
 
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
-import { RxCustomStrategyCredentials, RxStrategyCredentials } from './model';
+import {
+  RxCustomStrategyCredentials,
+  RxStrategies,
+  RxStrategyCredentials,
+  RxStrategyNames,
+} from './model';
 
 export interface RxStrategyHandler {
   strategy$: Observable<RxStrategyCredentials>;
-  next(name: string | Observable<string>): void;
+  next(name: RxStrategyNames | Observable<RxStrategyNames>): void;
 }
 
 /**
@@ -23,7 +28,7 @@ export function strategyHandling(
   strategies: RxCustomStrategyCredentials<string>
 ): RxStrategyHandler {
   const hotFlattened = coerceAllFactory<string>(
-    () => new ReplaySubject<string | Observable<string>>(1),
+    () => new ReplaySubject<RxStrategyNames | Observable<RxStrategyNames>>(1),
     switchAll()
   );
   return {
@@ -32,7 +37,7 @@ export function strategyHandling(
       nameToStrategyCredentials(strategies, defaultStrategyName),
       share()
     ) as Observable<RxStrategyCredentials>,
-    next(name: string | Observable<string>) {
+    next(name: RxStrategyNames | Observable<RxStrategyNames>) {
       hotFlattened.next(name);
     },
   };

--- a/libs/cdk/template/src/lib/list-template-manager.ts
+++ b/libs/cdk/template/src/lib/list-template-manager.ts
@@ -19,6 +19,7 @@ import {
   RxStrategyCredentials,
   onStrategy,
   strategyHandling,
+  RxStrategyNames,
 } from '@rx-angular/cdk/render-strategies';
 import {
   RxListViewComputedContext,
@@ -35,7 +36,7 @@ import { createErrorHandler } from './render-error';
 import { notifyAllParentsIfNeeded } from './utils';
 
 export interface RxListManager<T> {
-  nextStrategy: (config: string | Observable<string>) => void;
+  nextStrategy: (config: RxStrategyNames | Observable<RxStrategyNames>) => void;
 
   render(changes$: Observable<NgIterable<T>>): Observable<NgIterable<T> | null>;
 }
@@ -87,7 +88,7 @@ export function createListTemplateManager<
   let partiallyFinished = false;
 
   return {
-    nextStrategy(nextConfig: Observable<string>): void {
+    nextStrategy(nextConfig: Observable<RxStrategyNames>): void {
       strategyHandling$.next(nextConfig);
     },
     render(

--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -19,7 +19,10 @@ import {
   coerceDistinctWith,
   coerceObservableWith,
 } from '@rx-angular/cdk/coercing';
-import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import {
+  RxStrategyNames,
+  RxStrategyProvider,
+} from '@rx-angular/cdk/render-strategies';
 import {
   createListTemplateManager,
   RxListManager,
@@ -162,7 +165,9 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
    * @see {@link strategies}
    */
   @Input()
-  set rxForStrategy(strategyName: string | Observable<string> | undefined) {
+  set rxForStrategy(
+    strategyName: RxStrategyNames | Observable<RxStrategyNames> | undefined
+  ) {
     this.strategyInput$.next(strategyName);
   }
 
@@ -389,7 +394,9 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   ) {}
 
   /** @internal */
-  private strategyInput$ = new ReplaySubject<string | Observable<string>>(1);
+  private strategyInput$ = new ReplaySubject<
+    RxStrategyNames | Observable<RxStrategyNames>
+  >(1);
 
   /** @internal */
   private observables$ = new ReplaySubject<Observable<U> | U>(1);

--- a/libs/template/if/src/lib/if.directive.ts
+++ b/libs/template/if/src/lib/if.directive.ts
@@ -134,9 +134,7 @@ export class RxIf<T = unknown>
    * @see {@link RxStrategyNames}
    */
   @Input('rxIfStrategy')
-  set strategy(
-    strategyName: Observable<RxStrategyNames<string>> | RxStrategyNames<string>
-  ) {
+  set strategy(strategyName: Observable<RxStrategyNames> | RxStrategyNames) {
     this.strategyHandler.next(strategyName);
   }
 
@@ -467,11 +465,8 @@ export class RxIf<T = unknown>
   private templateNotifier = createTemplateNotifier<T>();
 
   /** @internal */
-  private readonly strategyHandler = coerceAllFactory<RxStrategyNames<string>>(
-    () =>
-      new ReplaySubject<
-        RxStrategyNames<string> | Observable<RxStrategyNames<string>>
-      >(1),
+  private readonly strategyHandler = coerceAllFactory<RxStrategyNames>(
+    () => new ReplaySubject<RxStrategyNames | Observable<RxStrategyNames>>(1),
     mergeAll()
   );
   /** @internal */

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -481,7 +481,7 @@ export class LetDirective<U> implements OnInit, OnDestroy, OnChanges {
   private observablesHandler = createTemplateNotifier<U>();
   /** @internal */
   private strategyHandler = coerceAllFactory<string>(
-    () => new ReplaySubject<RxStrategyNames<string>>(1)
+    () => new ReplaySubject<RxStrategyNames>(1)
   );
   /** @internal */
   private triggerHandler = new ReplaySubject<RxNotificationKind>(1);

--- a/libs/template/push/src/lib/push.pipe.ts
+++ b/libs/template/push/src/lib/push.pipe.ts
@@ -85,9 +85,7 @@ import {
  * @publicApi
  */
 @Pipe({ name: 'push', pure: false })
-export class PushPipe<S extends string = string>
-  implements PipeTransform, OnDestroy
-{
+export class PushPipe implements PipeTransform, OnDestroy {
   /**
    * @internal
    * This is typed as `any` because the type cannot be inferred
@@ -121,29 +119,29 @@ export class PushPipe<S extends string = string>
 
   transform<U>(
     potentialObservable: null,
-    config?: RxStrategyNames<S> | Observable<RxStrategyNames<S>>,
+    config?: RxStrategyNames | Observable<RxStrategyNames>,
     renderCallback?: NextObserver<U>
   ): null;
   transform<U>(
     potentialObservable: undefined,
-    config?: RxStrategyNames<S> | Observable<RxStrategyNames<S>>,
+    config?: RxStrategyNames | Observable<RxStrategyNames>,
     renderCallback?: NextObserver<U>
   ): undefined;
   transform<U>(
     potentialObservable: ObservableInput<U> | U,
-    config?: RxStrategyNames<S> | Observable<RxStrategyNames<S>>,
+    config?: RxStrategyNames | Observable<RxStrategyNames>,
     renderCallback?: NextObserver<U>
   ): U;
   transform<U>(
     potentialObservable: ObservableInput<U>,
-    config?: PushInput<U, S>
+    config?: PushInput<U>
   ): U;
   transform<U>(
     potentialObservable: ObservableInput<U> | U | null | undefined,
     config:
-      | PushInput<U, S>
-      | RxStrategyNames<S>
-      | Observable<RxStrategyNames<S>>
+      | PushInput<U>
+      | RxStrategyNames
+      | Observable<RxStrategyNames>
       | undefined,
     renderCallback?: NextObserver<U>
   ): U | null | undefined {
@@ -241,8 +239,8 @@ export class PushPipe<S extends string = string>
   }
 }
 
-interface PushInput<T, S> {
-  strategy?: RxStrategyNames<S> | Observable<RxStrategyNames<S>>;
+interface PushInput<T> {
+  strategy?: RxStrategyNames | Observable<RxStrategyNames>;
   renderCallback?: NextObserver<T>;
   patchZone?: boolean;
 }
@@ -261,7 +259,7 @@ function onlyValues<T>(): MonoTypeOperatorFunction<RxNotification<T>> {
     );
 }
 
-function isRxComponentInput<U, S>(value: any): value is PushInput<U, S> {
+function isRxComponentInput<U>(value: any): value is PushInput<U> {
   return (
     value != null &&
     (hasOwnProperty.call(value, 'strategy') ||


### PR DESCRIPTION
Use `RxStrategyNames` for proper strategy input typing to achieve hinting of default strategies in template.


![image](https://user-images.githubusercontent.com/7274335/212150722-b160c712-049e-4949-8aa7-17d6c40a0dbf.png)
