### PR TITLE
feat(template): migrate to standalone API

### DIFF
--- a/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
+++ b/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
@@ -11,13 +11,7 @@ import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { coerceObservableWith } from '@rx-angular/cdk/coercing';
 import { RxNotification } from '@rx-angular/cdk/notifications';
 import { LetDirective } from '@rx-angular/template/let';
-import {
-  BehaviorSubject,
-  combineLatest,
-  Observable,
-  of,
-  Subject,
-} from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
 import { filter, map, mergeAll, withLatestFrom } from 'rxjs/operators';
 
 function intersectionObserver(options?: object): {
@@ -60,6 +54,7 @@ const observerSupported = () =>
    */
   // eslint-disable-next-line @angular-eslint/directive-selector
   selector: '[viewport-prio]',
+  standalone: true,
 })
 export class ViewportPrioDirective implements OnInit, OnDestroy {
   // Note that we're picking only the `intersectionRatio` property

--- a/libs/template/experimental/viewport-prio/src/lib/viewport-prio.module.ts
+++ b/libs/template/experimental/viewport-prio/src/lib/viewport-prio.module.ts
@@ -1,11 +1,9 @@
 import { NgModule } from '@angular/core';
 import { ViewportPrioDirective } from './viewport-prio.directive';
 
-const DECLARATIONS = [ViewportPrioDirective];
-
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: DECLARATIONS,
-  exports: DECLARATIONS
+  imports: [ViewportPrioDirective],
+  exports: [ViewportPrioDirective],
 })
-export class ViewportPrioModule {
-}
+export class ViewportPrioModule {}

--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -76,6 +76,7 @@ declare const ngDevMode: boolean;
  */
 @Directive({
   selector: '[rxFor][rxForOf]',
+  standalone: true,
 })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>

--- a/libs/template/for/src/lib/for.module.ts
+++ b/libs/template/for/src/lib/for.module.ts
@@ -1,14 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RxFor } from './for.directive';
 
-const DECLARATIONS = [
-  RxFor
-];
+const EXPORTS = [RxFor];
 
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: DECLARATIONS,
-  imports: [],
-  exports: DECLARATIONS
+  imports: EXPORTS,
+  exports: EXPORTS,
 })
-export class ForModule {
-}
+export class ForModule {}

--- a/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { Observable } from 'rxjs';
+import { RxFor } from '../for.directive';
 import { ForModule } from '../for.module';
 import {
   createErrorHandler,
@@ -49,7 +50,7 @@ describe('rxFor with observables', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [CommonModule, ForModule],
+      imports: [CommonModule, RxFor],
       providers: [
         {
           provide: ErrorHandler,

--- a/libs/template/for/src/lib/tests/for.directive.parent-notification.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.parent-notification.spec.ts
@@ -79,7 +79,7 @@ describe('rxFor parent-notifications', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ParentNotifyTestComponent],
-      imports: [ForModule],
+      imports: [RxFor],
       teardown: { destroyAfterEach: true },
     });
     fixture = TestBed.createComponent(ParentNotifyTestComponent);

--- a/libs/template/for/src/lib/tests/for.directive.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.spec.ts
@@ -2,6 +2,7 @@ import { ErrorHandler } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
+import { RxFor } from '../for.directive';
 import { ForModule } from '../for.module';
 import {
   createErrorHandler,
@@ -37,7 +38,7 @@ describe('rxFor', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [ForModule],
+      imports: [RxFor],
       providers: [
         {
           provide: ErrorHandler,

--- a/libs/template/for/src/lib/tests/for.directive.strategy.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.strategy.spec.ts
@@ -1,6 +1,7 @@
 import { ErrorHandler } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import { RxFor } from '../for.directive';
 import { ForModule } from '../for.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -24,7 +25,7 @@ describe('rxFor strategies', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [ForModule],
+      imports: [RxFor],
     });
     fixture = createTestComponent(
       `<div><span *rxFor="let item of items; strategy: strategy; renderCallback: renderedValue$">{{item.toString()}};</span></div>`

--- a/libs/template/if/src/lib/if.directive.ts
+++ b/libs/template/if/src/lib/if.directive.ts
@@ -63,6 +63,7 @@ import {
  */
 @Directive({
   selector: '[rxIf]',
+  standalone: true,
 })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class RxIf<T = unknown>

--- a/libs/template/if/src/lib/if.module.ts
+++ b/libs/template/if/src/lib/if.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RxIf } from './if.directive';
 
-const DECLARATIONS = [RxIf];
+const EXPORTS = [RxIf];
 
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: DECLARATIONS,
-  imports: [],
-  exports: DECLARATIONS,
+  imports: EXPORTS,
+  exports: EXPORTS,
 })
 export class IfModule {}

--- a/libs/template/if/src/lib/tests/if.directive.context-templates.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.context-templates.spec.ts
@@ -17,6 +17,7 @@ import {
   throwError,
 } from 'rxjs';
 import { map, take, tap } from 'rxjs/operators';
+import { RxIf } from '../if.directive';
 import { IfModule } from '../if.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -70,7 +71,7 @@ const setupTestComponent = () => {
         },
       },
     ],
-    imports: [IfModule],
+    imports: [RxIf],
   });
 };
 

--- a/libs/template/if/src/lib/tests/if.directive.context.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.context.spec.ts
@@ -18,6 +18,7 @@ import {
   throwError,
 } from 'rxjs';
 import { map, take, tap } from 'rxjs/operators';
+import { RxIf } from '../if.directive';
 import { IfModule } from '../if.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -77,7 +78,7 @@ const setupTestComponent = () => {
         },
       },
     ],
-    imports: [IfModule],
+    imports: [RxIf],
   });
 };
 

--- a/libs/template/if/src/lib/tests/if.directive.observable.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.observable.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { BehaviorSubject, of, startWith, throwError, tap } from 'rxjs';
+import { RxIf } from '../if.directive';
 import { IfModule } from '../if.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -19,7 +20,7 @@ describe('rxIf directive observable values', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [IfModule],
+      imports: [RxIf],
       providers: [
         {
           provide: RX_RENDER_STRATEGIES_CONFIG,
@@ -43,160 +44,136 @@ describe('rxIf directive observable values', () => {
     });
   });
 
-  it(
-    'should work in a template attribute',
-    waitForAsync(() => {
-      const template = '<span *rxIf="booleanCondition$">hello</span>';
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelectorAll('span').length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
-    })
-  );
+  it('should work in a template attribute', waitForAsync(() => {
+    const template = '<span *rxIf="booleanCondition$">hello</span>';
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('span').length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
+  }));
 
-  it(
-    'should work on a template element',
-    waitForAsync(() => {
-      const template =
-        '<ng-template [rxIf]="booleanCondition$">hello2</ng-template>';
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('hello2');
-    })
-  );
+  it('should work on a template element', waitForAsync(() => {
+    const template =
+      '<ng-template [rxIf]="booleanCondition$">hello2</ng-template>';
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('hello2');
+  }));
 
-  it(
-    'should toggle node when condition changes',
-    waitForAsync(() => {
-      const template = '<span *rxIf="booleanCondition$">hello</span>';
-      fixture = createTestComponent(template);
-      getComponent().booleanCondition$.next(false);
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+  it('should toggle node when condition changes', waitForAsync(() => {
+    const template = '<span *rxIf="booleanCondition$">hello</span>';
+    fixture = createTestComponent(template);
+    getComponent().booleanCondition$.next(false);
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().booleanCondition$.next(true);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().booleanCondition$.next(true);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().booleanCondition$.next(false);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
-    })
-  );
+    getComponent().booleanCondition$.next(false);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
+  }));
 
-  it(
-    'should handle nested if correctly',
-    waitForAsync(() => {
-      const template =
-        '<div *rxIf="booleanCondition$"><span *rxIf="nestedBooleanCondition$">hello</span></div>';
+  it('should handle nested if correctly', waitForAsync(() => {
+    const template =
+      '<div *rxIf="booleanCondition$"><span *rxIf="nestedBooleanCondition$">hello</span></div>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      getComponent().booleanCondition$.next(false);
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+    getComponent().booleanCondition$.next(false);
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().booleanCondition$.next(true);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().booleanCondition$.next(true);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().nestedBooleanCondition$.next(false);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+    getComponent().nestedBooleanCondition$.next(false);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().nestedBooleanCondition$.next(true);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().nestedBooleanCondition$.next(true);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().booleanCondition$.next(false);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
-    })
-  );
+    getComponent().booleanCondition$.next(false);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
+  }));
 
-  it(
-    'should update several nodes with if',
-    waitForAsync(() => {
-      const template =
-        '<span *rxIf="booleanCondition$">hello1</span>' +
-        '<span *rxIf="nestedBooleanCondition$">hello2</span>';
+  it('should update several nodes with if', waitForAsync(() => {
+    const template =
+      '<span *rxIf="booleanCondition$">hello1</span>' +
+      '<span *rxIf="nestedBooleanCondition$">hello2</span>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(2);
-      expect(fixture.nativeElement.textContent).toEqual('hello1hello2');
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(2);
+    expect(fixture.nativeElement.textContent).toEqual('hello1hello2');
 
-      getComponent().booleanCondition$.next(false);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello2');
+    getComponent().booleanCondition$.next(false);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello2');
 
-      getComponent().booleanCondition$.next(true);
-      getComponent().nestedBooleanCondition$.next(false);
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello1');
-    })
-  );
+    getComponent().booleanCondition$.next(true);
+    getComponent().nestedBooleanCondition$.next(false);
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello1');
+  }));
 
-  it(
-    'should not add the element twice if the condition goes from truthy to truthy',
-    waitForAsync(() => {
-      const template = '<span *rxIf="numberCondition$">hello</span>';
+  it('should not add the element twice if the condition goes from truthy to truthy', waitForAsync(() => {
+    const template = '<span *rxIf="numberCondition$">hello</span>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      fixture.detectChanges();
-      let els = fixture.debugElement.queryAll(By.css('span'));
-      expect(els.length).toEqual(1);
-      els[0].nativeElement.classList.add('marker');
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    fixture.detectChanges();
+    let els = fixture.debugElement.queryAll(By.css('span'));
+    expect(els.length).toEqual(1);
+    els[0].nativeElement.classList.add('marker');
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().numberCondition$.next(2);
-      els = fixture.debugElement.queryAll(By.css('span'));
-      expect(els.length).toEqual(1);
-      expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
+    getComponent().numberCondition$.next(2);
+    els = fixture.debugElement.queryAll(By.css('span'));
+    expect(els.length).toEqual(1);
+    expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
 
-      expect(fixture.nativeElement.textContent).toBe('hello');
-    })
-  );
+    expect(fixture.nativeElement.textContent).toBe('hello');
+  }));
 
   describe('then/else templates', () => {
-    it(
-      'should support else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; else elseBlock">TRUE</span>' +
-          '<ng-template #elseBlock>FALSE</ng-template>';
+    it('should support else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; else elseBlock">TRUE</span>' +
+        '<ng-template #elseBlock>FALSE</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('TRUE');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('TRUE');
 
-        getComponent().booleanCondition$.next(false);
-        expect(fixture.nativeElement.textContent).toBe('FALSE');
-      })
-    );
+      getComponent().booleanCondition$.next(false);
+      expect(fixture.nativeElement.textContent).toBe('FALSE');
+    }));
 
-    it(
-      'should support then and else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; then: thenBlock; else: elseBlock">IGNORE</span>' +
-          '<ng-template #thenBlock>THEN</ng-template>' +
-          '<ng-template #elseBlock>ELSE</ng-template>';
+    it('should support then and else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; then: thenBlock; else: elseBlock">IGNORE</span>' +
+        '<ng-template #thenBlock>THEN</ng-template>' +
+        '<ng-template #elseBlock>ELSE</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('THEN');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('THEN');
 
-        getComponent().booleanCondition$.next(false);
-        expect(fixture.nativeElement.textContent).toBe('ELSE');
-      })
-    );
+      getComponent().booleanCondition$.next(false);
+      expect(fixture.nativeElement.textContent).toBe('ELSE');
+    }));
 
     it('should support removing the then/else templates', () => {
       const template = `<span *rxIf="booleanCondition$;
@@ -229,251 +206,209 @@ describe('rxIf directive observable values', () => {
       expect(fixture.nativeElement.textContent).toBe('');
     });
 
-    it(
-      'should support dynamic else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; else: nestedBooleanCondition ? b1 : b2">TRUE</span>' +
-          '<ng-template #b1>FALSE1</ng-template>' +
-          '<ng-template #b2>FALSE2</ng-template>';
+    it('should support dynamic else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; else: nestedBooleanCondition ? b1 : b2">TRUE</span>' +
+        '<ng-template #b1>FALSE1</ng-template>' +
+        '<ng-template #b2>FALSE2</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('TRUE');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('TRUE');
 
-        getComponent().booleanCondition$.next(false);
-        expect(fixture.nativeElement.textContent).toBe('FALSE1');
+      getComponent().booleanCondition$.next(false);
+      expect(fixture.nativeElement.textContent).toBe('FALSE1');
 
-        getComponent().nestedBooleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('FALSE2');
-      })
-    );
+      getComponent().nestedBooleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('FALSE2');
+    }));
 
-    it(
-      'should support binding to variable using let',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; else: elseBlock; let v">{{v}}</span>' +
-          '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using let', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; else: elseBlock; let v">{{v}}</span>' +
+        '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition$.next(false);
-        expect(fixture.nativeElement.textContent).toBe('false');
-      })
-    );
+      getComponent().booleanCondition$.next(false);
+      expect(fixture.nativeElement.textContent).toBe('false');
+    }));
 
-    it(
-      'should support binding to variable using as',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$ as v; else: elseBlock">{{v}}</span>' +
-          '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using as', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$ as v; else: elseBlock">{{v}}</span>' +
+        '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition$.next(false);
-        expect(fixture.nativeElement.textContent).toBe('false');
-      })
-    );
+      getComponent().booleanCondition$.next(false);
+      expect(fixture.nativeElement.textContent).toBe('false');
+    }));
   });
 
   describe('Type guarding', () => {
-    it(
-      'should throw when then block is not template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; then thenBlock">IGNORE</span>' +
-          '<div #thenBlock>THEN</div>';
+    it('should throw when then block is not template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; then thenBlock">IGNORE</span>' +
+        '<div #thenBlock>THEN</div>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        expect(() => fixture.detectChanges()).toThrowError(
-          /rxThen must be a TemplateRef, but received/
-        );
-      })
-    );
+      expect(() => fixture.detectChanges()).toThrowError(
+        /rxThen must be a TemplateRef, but received/
+      );
+    }));
 
-    it(
-      'should throw when else block is not template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; else elseBlock">IGNORE</span>' +
-          '<div #elseBlock>ELSE</div>';
+    it('should throw when else block is not template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; else elseBlock">IGNORE</span>' +
+        '<div #elseBlock>ELSE</div>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        expect(() => fixture.detectChanges()).toThrowError(
-          /rxElse must be a TemplateRef, but received/
-        );
-      })
-    );
+      expect(() => fixture.detectChanges()).toThrowError(
+        /rxElse must be a TemplateRef, but received/
+      );
+    }));
   });
 
   describe('Templates & Context', () => {
-    it(
-      'should render suspense template when value is undefined',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; suspense: suspense; let v">{{v}}</span>' +
-          '<ng-template #suspense let-v>suspended</ng-template>';
+    it('should render suspense template when value is undefined', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; suspense: suspense; let v">{{v}}</span>' +
+        '<ng-template #suspense let-v>suspended</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$.next(undefined);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('suspended');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$.next(undefined);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('suspended');
 
-        getComponent().booleanCondition$.next(true);
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition$.next(true);
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should not have suspense context',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; let suspense = suspense">{{suspense}}</span>';
+    it('should not have suspense context', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; let suspense = suspense">{{suspense}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$.next(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$.next(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
 
-        getComponent().booleanCondition$.next(undefined);
-        expect(fixture.nativeElement.textContent).toBe('');
-      })
-    );
+      getComponent().booleanCondition$.next(undefined);
+      expect(fixture.nativeElement.textContent).toBe('');
+    }));
 
-    it(
-      'should not have suspense context',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; let suspense = suspense">{{suspense}}</span>';
+    it('should not have suspense context', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; let suspense = suspense">{{suspense}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$.next(false);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$.next(false);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('');
 
-        getComponent().booleanCondition$.next(undefined);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('');
-      })
-    );
+      getComponent().booleanCondition$.next(undefined);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('');
+    }));
 
-    it(
-      'should render complete template when source completes',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; complete: complete; let v">{{v}}</span>' +
-          '<ng-template #complete let-v>completed</ng-template>';
+    it('should render complete template when source completes', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; complete: complete; let v">{{v}}</span>' +
+        '<ng-template #complete let-v>completed</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = of(undefined) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('completed');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = of(undefined) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('completed');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should have complete context when source completes',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; let complete = complete">{{complete}}</span>';
+    it('should have complete context when source completes', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; let complete = complete">{{complete}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = of(true) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = of(true) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should have complete context on else template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; else: elseTpl">then</span>' +
-          '<ng-template #elseTpl let-c="complete">else{{c}}</ng-template>';
+    it('should have complete context on else template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; else: elseTpl">then</span>' +
+        '<ng-template #elseTpl let-c="complete">else{{c}}</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = of(false) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('elsetrue');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = of(false) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('elsetrue');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('then');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('then');
+    }));
 
-    it(
-      'should render error template when source throws',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; error: error; let v">{{v}}</span>' +
-          '<ng-template #error let-v>error</ng-template>';
+    it('should render error template when source throws', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; error: error; let v">{{v}}</span>' +
+        '<ng-template #error let-v>error</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = throwError(() => null) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('error');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = throwError(() => null) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('error');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should have error context when source throws',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; let error = error">{{error}}</span>';
+    it('should have error context when source throws', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; let error = error">{{error}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = throwError(() => null).pipe(
-          startWith(true)
-        ) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = throwError(() => null).pipe(
+        startWith(true)
+      ) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
+    }));
 
-    it(
-      'should have error context on else template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition$; let v; else: elseTpl">then</span>' +
-          '<ng-template #elseTpl let-e="error">else{{e}}</ng-template>';
+    it('should have error context on else template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition$; let v; else: elseTpl">then</span>' +
+        '<ng-template #elseTpl let-e="error">else{{e}}</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition$ = throwError(() => null) as any;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('elsetrue');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition$ = throwError(() => null) as any;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('elsetrue');
 
-        getComponent().booleanCondition$ = new BehaviorSubject(true);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('then');
-      })
-    );
+      getComponent().booleanCondition$ = new BehaviorSubject(true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('then');
+    }));
   });
 });

--- a/libs/template/if/src/lib/tests/if.directive.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
+import { RxIf } from '../if.directive';
 import { IfModule } from '../if.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -18,7 +19,7 @@ describe('rxIf directive', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [IfModule],
+      imports: [RxIf],
       providers: [
         {
           provide: RX_RENDER_STRATEGIES_CONFIG,
@@ -30,174 +31,150 @@ describe('rxIf directive', () => {
     });
   });
 
-  it(
-    'should work in a template attribute',
-    waitForAsync(() => {
-      const template = '<span *rxIf="booleanCondition">hello</span>';
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelectorAll('span').length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
-    })
-  );
+  it('should work in a template attribute', waitForAsync(() => {
+    const template = '<span *rxIf="booleanCondition">hello</span>';
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('span').length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
+  }));
 
-  it(
-    'should work on a template element',
-    waitForAsync(() => {
-      const template =
-        '<ng-template [rxIf]="booleanCondition">hello2</ng-template>';
-      fixture = createTestComponent(template);
-      fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('hello2');
-    })
-  );
+  it('should work on a template element', waitForAsync(() => {
+    const template =
+      '<ng-template [rxIf]="booleanCondition">hello2</ng-template>';
+    fixture = createTestComponent(template);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('hello2');
+  }));
 
-  it(
-    'should toggle node when condition changes',
-    waitForAsync(() => {
-      const template = '<span *rxIf="booleanCondition">hello</span>';
-      fixture = createTestComponent(template);
-      getComponent().booleanCondition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+  it('should toggle node when condition changes', waitForAsync(() => {
+    const template = '<span *rxIf="booleanCondition">hello</span>';
+    fixture = createTestComponent(template);
+    getComponent().booleanCondition = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().booleanCondition = true;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().booleanCondition = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().booleanCondition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
-    })
-  );
+    getComponent().booleanCondition = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
+  }));
 
-  it(
-    'should handle nested if correctly',
-    waitForAsync(() => {
-      const template =
-        '<div *rxIf="booleanCondition"><span *rxIf="nestedBooleanCondition">hello</span></div>';
+  it('should handle nested if correctly', waitForAsync(() => {
+    const template =
+      '<div *rxIf="booleanCondition"><span *rxIf="nestedBooleanCondition">hello</span></div>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      getComponent().booleanCondition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+    getComponent().booleanCondition = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().booleanCondition = true;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().booleanCondition = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().nestedBooleanCondition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
+    getComponent().nestedBooleanCondition = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
 
-      getComponent().nestedBooleanCondition = true;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    getComponent().nestedBooleanCondition = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().booleanCondition = false;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-      expect(fixture.nativeElement.textContent).toBe('');
-    })
-  );
+    getComponent().booleanCondition = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+    expect(fixture.nativeElement.textContent).toBe('');
+  }));
 
-  it(
-    'should update several nodes with if',
-    waitForAsync(() => {
-      const template =
-        '<span *rxIf="numberCondition + 1 >= 2">helloNumber</span>' +
-        '<span *rxIf="stringCondition == \'foo\'">helloString</span>' +
-        '<span *rxIf="functionCondition(stringCondition, numberCondition)">helloFunction</span>';
+  it('should update several nodes with if', waitForAsync(() => {
+    const template =
+      '<span *rxIf="numberCondition + 1 >= 2">helloNumber</span>' +
+      '<span *rxIf="stringCondition == \'foo\'">helloString</span>' +
+      '<span *rxIf="functionCondition(stringCondition, numberCondition)">helloFunction</span>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(3);
-      expect(fixture.nativeElement.textContent).toEqual(
-        'helloNumberhelloStringhelloFunction'
-      );
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(3);
+    expect(fixture.nativeElement.textContent).toEqual(
+      'helloNumberhelloStringhelloFunction'
+    );
 
-      getComponent().numberCondition = 0;
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('helloString');
+    getComponent().numberCondition = 0;
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('helloString');
 
-      getComponent().numberCondition = 1;
-      getComponent().stringCondition = 'bar';
-      fixture.detectChanges();
-      expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-      expect(fixture.nativeElement.textContent).toBe('helloNumber');
-    })
-  );
+    getComponent().numberCondition = 1;
+    getComponent().stringCondition = 'bar';
+    fixture.detectChanges();
+    expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+    expect(fixture.nativeElement.textContent).toBe('helloNumber');
+  }));
 
-  it(
-    'should not add the element twice if the condition goes from truthy to truthy',
-    waitForAsync(() => {
-      const template = '<span *rxIf="numberCondition">hello</span>';
+  it('should not add the element twice if the condition goes from truthy to truthy', waitForAsync(() => {
+    const template = '<span *rxIf="numberCondition">hello</span>';
 
-      fixture = createTestComponent(template);
+    fixture = createTestComponent(template);
 
-      fixture.detectChanges();
-      let els = fixture.debugElement.queryAll(By.css('span'));
-      expect(els.length).toEqual(1);
-      els[0].nativeElement.classList.add('marker');
-      expect(fixture.nativeElement.textContent).toBe('hello');
+    fixture.detectChanges();
+    let els = fixture.debugElement.queryAll(By.css('span'));
+    expect(els.length).toEqual(1);
+    els[0].nativeElement.classList.add('marker');
+    expect(fixture.nativeElement.textContent).toBe('hello');
 
-      getComponent().numberCondition = 2;
-      fixture.detectChanges();
-      els = fixture.debugElement.queryAll(By.css('span'));
-      expect(els.length).toEqual(1);
-      expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
+    getComponent().numberCondition = 2;
+    fixture.detectChanges();
+    els = fixture.debugElement.queryAll(By.css('span'));
+    expect(els.length).toEqual(1);
+    expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
 
-      expect(fixture.nativeElement.textContent).toBe('hello');
-    })
-  );
+    expect(fixture.nativeElement.textContent).toBe('hello');
+  }));
 
   describe('then/else templates', () => {
-    it(
-      'should support else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; else elseBlock">TRUE</span>' +
-          '<ng-template #elseBlock>FALSE</ng-template>';
+    it('should support else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; else elseBlock">TRUE</span>' +
+        '<ng-template #elseBlock>FALSE</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('TRUE');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('TRUE');
 
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('FALSE');
-      })
-    );
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('FALSE');
+    }));
 
-    it(
-      'should support then and else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; then: thenBlock; else: elseBlock">IGNORE</span>' +
-          '<ng-template #thenBlock>THEN</ng-template>' +
-          '<ng-template #elseBlock>ELSE</ng-template>';
+    it('should support then and else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; then: thenBlock; else: elseBlock">IGNORE</span>' +
+        '<ng-template #thenBlock>THEN</ng-template>' +
+        '<ng-template #elseBlock>ELSE</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('THEN');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('THEN');
 
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('ELSE');
-      })
-    );
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('ELSE');
+    }));
 
     it('should support removing the then/else templates', () => {
       const template = `<span *rxIf="booleanCondition;
@@ -230,167 +207,140 @@ describe('rxIf directive', () => {
       expect(fixture.nativeElement.textContent).toBe('');
     });
 
-    it(
-      'should support dynamic else',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; else: nestedBooleanCondition ? b1 : b2">TRUE</span>' +
-          '<ng-template #b1>FALSE1</ng-template>' +
-          '<ng-template #b2>FALSE2</ng-template>';
+    it('should support dynamic else', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; else: nestedBooleanCondition ? b1 : b2">TRUE</span>' +
+        '<ng-template #b1>FALSE1</ng-template>' +
+        '<ng-template #b2>FALSE2</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('TRUE');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('TRUE');
 
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('FALSE1');
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('FALSE1');
 
-        getComponent().nestedBooleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('FALSE2');
-      })
-    );
+      getComponent().nestedBooleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('FALSE2');
+    }));
 
-    it(
-      'should support binding to variable using let',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; else: elseBlock; let v">{{v}}</span>' +
-          '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using let', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; else: elseBlock; let v">{{v}}</span>' +
+        '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
-      })
-    );
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
+    }));
 
-    it(
-      'should support binding to variable using as',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition as v; else: elseBlock">{{v}}</span>' +
-          '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using as', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition as v; else: elseBlock">{{v}}</span>' +
+        '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
 
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
-      })
-    );
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
+    }));
   });
 
   describe('Type guarding', () => {
-    it(
-      'should throw when then block is not template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; then thenBlock">IGNORE</span>' +
-          '<div #thenBlock>THEN</div>';
+    it('should throw when then block is not template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; then thenBlock">IGNORE</span>' +
+        '<div #thenBlock>THEN</div>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        expect(() => fixture.detectChanges()).toThrowError(
-          /rxThen must be a TemplateRef, but received/
-        );
-      })
-    );
+      expect(() => fixture.detectChanges()).toThrowError(
+        /rxThen must be a TemplateRef, but received/
+      );
+    }));
 
-    it(
-      'should throw when else block is not template',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; else elseBlock">IGNORE</span>' +
-          '<div #elseBlock>ELSE</div>';
+    it('should throw when else block is not template', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; else elseBlock">IGNORE</span>' +
+        '<div #elseBlock>ELSE</div>';
 
-        fixture = createTestComponent(template);
+      fixture = createTestComponent(template);
 
-        expect(() => fixture.detectChanges()).toThrowError(
-          /rxElse must be a TemplateRef, but received/
-        );
-      })
-    );
+      expect(() => fixture.detectChanges()).toThrowError(
+        /rxElse must be a TemplateRef, but received/
+      );
+    }));
   });
 
   describe('Templates & Context', () => {
-    it(
-      'should render suspense template when value is undefined',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; suspense: suspense; let v">{{v}}</span>' +
-          '<ng-template #suspense let-v>suspended</ng-template>';
+    it('should render suspense template when value is undefined', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; suspense: suspense; let v">{{v}}</span>' +
+        '<ng-template #suspense let-v>suspended</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition = undefined;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('suspended');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition = undefined;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('suspended');
 
-        getComponent().booleanCondition = true;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should have suspense context',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; let v; let suspense = suspense; else:' +
-          ' falsy">{{suspense}}</span><ng-template #falsy let-s="suspense">{{s}}</ng-template>';
+    it('should have suspense context', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; let v; let suspense = suspense; else:' +
+        ' falsy">{{suspense}}</span><ng-template #falsy let-s="suspense">{{s}}</ng-template>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition = true;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
 
-        getComponent().booleanCondition = undefined;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('true');
-      })
-    );
+      getComponent().booleanCondition = undefined;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('true');
+    }));
 
-    it(
-      'should have not have suspense context when no else template is provided',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; let v; let suspense = suspense">{{suspense}}</span>';
+    it('should have not have suspense context when no else template is provided', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; let v; let suspense = suspense">{{suspense}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition = true;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('false');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('false');
 
-        getComponent().booleanCondition = undefined;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('');
-      })
-    );
+      getComponent().booleanCondition = undefined;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('');
+    }));
 
-    it(
-      'should not have suspense context',
-      waitForAsync(() => {
-        const template =
-          '<span *rxIf="booleanCondition; let v; let suspense = suspense">{{suspense}}</span>';
+    it('should not have suspense context', waitForAsync(() => {
+      const template =
+        '<span *rxIf="booleanCondition; let v; let suspense = suspense">{{suspense}}</span>';
 
-        fixture = createTestComponent(template);
-        getComponent().booleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('');
+      fixture = createTestComponent(template);
+      getComponent().booleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('');
 
-        getComponent().booleanCondition = undefined;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('');
-      })
-    );
+      getComponent().booleanCondition = undefined;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('');
+    }));
   });
 });

--- a/libs/template/if/src/lib/tests/if.directive.strategy.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.strategy.spec.ts
@@ -1,6 +1,7 @@
 import { ErrorHandler } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import { RxIf } from '../if.directive';
 import { IfModule } from '../if.module';
 import { createTestComponent, TestComponent } from './fixtures';
 
@@ -24,7 +25,7 @@ describe('rxIf strategies', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
-      imports: [IfModule],
+      imports: [RxIf],
     });
     fixture = createTestComponent(
       `<div><span *rxIf="booleanCondition$; let v; strategy: strategy; renderCallback: renderedValue$">{{v}}</span></div>`

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -92,7 +92,7 @@ export interface RxLetViewContext<T> extends RxViewContext<T> {
  * @docsPage LetDirective
  * @publicApi
  */
-@Directive({ selector: '[rxLet]' })
+@Directive({ selector: '[rxLet]', standalone: true })
 export class LetDirective<U> implements OnInit, OnDestroy, OnChanges {
   static ngTemplateGuard_rxLet: 'binding';
 

--- a/libs/template/let/src/lib/let.module.ts
+++ b/libs/template/let/src/lib/let.module.ts
@@ -2,8 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { LetDirective } from './let.directive';
 
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: [LetDirective],
+  imports: [LetDirective],
   exports: [LetDirective],
 })
 export class LetModule {}

--- a/libs/template/let/src/lib/tests/let.directive.complete.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.complete.spec.ts
@@ -32,7 +32,8 @@ let componentNativeElement: any;
 
 const setupLetDirectiveTestComponentComplete = (): void => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveTestCompleteComponent, LetDirective],
+    declarations: [LetDirectiveTestCompleteComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.context.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.context.spec.ts
@@ -65,7 +65,8 @@ const contentElement = (): HTMLElement => nativeElement.querySelector('.value');
 
 const setupTestComponent = () => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveTestComponent, LetDirective],
+    declarations: [LetDirectiveTestComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.error.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.error.spec.ts
@@ -25,7 +25,8 @@ class LetDirectiveTestErrorComponent {
 
 const setupLetDirectiveTestComponentError = (): void => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveTestErrorComponent, LetDirective],
+    declarations: [LetDirectiveTestErrorComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.next.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.next.spec.ts
@@ -36,7 +36,8 @@ let componentNativeElement: any;
 
 const setupLetDirectiveTestComponent = (): void => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveTestComponent, LetDirective],
+    declarations: [LetDirectiveTestComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
@@ -59,7 +59,8 @@ describe('LetDirective parent notification', () => {
   // beforeAll(() => mockConsole());
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LetDirectiveTestStrategyComponent, LetDirective],
+      declarations: [LetDirectiveTestStrategyComponent],
+      imports: [LetDirective],
       teardown: { destroyAfterEach: true },
     });
   });

--- a/libs/template/let/src/lib/tests/let.directive.rendered.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.rendered.spec.ts
@@ -34,7 +34,8 @@ let componentNativeElement: any;
 
 const setupLetDirectiveTestComponent = (): void => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveTestComponent, LetDirective],
+    declarations: [LetDirectiveTestComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
@@ -37,7 +37,8 @@ let strategyProvider: RxStrategyProvider;
 describe('LetDirective strategies', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [LetDirectiveTestStrategyComponent, LetDirective],
+      declarations: [LetDirectiveTestStrategyComponent],
+      imports: [LetDirective],
       teardown: { destroyAfterEach: true },
     });
   });

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.all.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.all.spec.ts
@@ -71,7 +71,8 @@ let nativeElement: HTMLElement;
 
 const setupTestComponent = () => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveAllTemplatesTestComponent, LetDirective],
+    declarations: [LetDirectiveAllTemplatesTestComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-complete.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-complete.spec.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectorRef, Component, TemplateRef, ViewContainerRef } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers';
@@ -28,7 +33,8 @@ let nativeElement: HTMLElement;
 
 const setupTestComponent = () => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveNoCompleteTemplateTestComponent, LetDirective],
+    declarations: [LetDirectiveNoCompleteTemplateTestComponent],
+    imports: [LetDirective],
     providers: [
       { provide: ChangeDetectorRef, useClass: MockChangeDetectorRef },
       TemplateRef,

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-error.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-error.spec.ts
@@ -40,7 +40,8 @@ const setupTestComponent = () => {
         },
       },
     ],
-    declarations: [LetDirectiveNoErrorTemplateTestComponent, LetDirective],
+    declarations: [LetDirectiveNoErrorTemplateTestComponent],
+    imports: [LetDirective],
     teardown: { destroyAfterEach: true },
   });
 };

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-suspense.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-suspense.spec.ts
@@ -5,7 +5,6 @@ import { mockConsole } from '@test-helpers';
 import { Observable, of, Subject } from 'rxjs';
 import { LetDirective } from '../let.directive';
 
-
 @Component({
   template: `
     <ng-container
@@ -33,7 +32,8 @@ let nativeElement: HTMLElement;
 
 const setupTestComponent = () => {
   TestBed.configureTestingModule({
-    declarations: [LetDirectiveNoSuspenseTemplateTestComponent, LetDirective],
+    declarations: [LetDirectiveNoSuspenseTemplateTestComponent],
+    imports: [LetDirective],
     providers: [
       {
         provide: RX_RENDER_STRATEGIES_CONFIG,

--- a/libs/template/push/src/lib/push.module.ts
+++ b/libs/template/push/src/lib/push.module.ts
@@ -2,8 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { PushPipe } from './push.pipe';
 
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: [PushPipe],
+  imports: [PushPipe],
   exports: [PushPipe],
 })
 export class PushModule {}

--- a/libs/template/push/src/lib/push.pipe.ts
+++ b/libs/template/push/src/lib/push.pipe.ts
@@ -84,7 +84,7 @@ import {
  *
  * @publicApi
  */
-@Pipe({ name: 'push', pure: false })
+@Pipe({ name: 'push', pure: false, standalone: true })
 export class PushPipe implements PipeTransform, OnDestroy {
   /**
    * @internal

--- a/libs/template/push/src/lib/tests/push.pipe.spec.ts
+++ b/libs/template/push/src/lib/tests/push.pipe.spec.ts
@@ -1,8 +1,7 @@
-
 import {
   RX_RENDER_STRATEGIES_CONFIG,
   RxStrategyCredentials,
-  RxStrategyProvider
+  RxStrategyProvider,
 } from '@rx-angular/cdk/render-strategies';
 import { map, tap } from 'rxjs/operators';
 import { Promise as unpatchedPromise } from '@rx-angular/cdk/zone-less/browser';
@@ -10,7 +9,18 @@ import { PushModule } from '../push.module';
 import { PushPipe } from '../push.pipe';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChangeDetectorRef, Component } from '@angular/core';
-import { asapScheduler, EMPTY, from, NEVER, Observable, of, scheduled, share, shareReplay, timer } from 'rxjs';
+import {
+  asapScheduler,
+  EMPTY,
+  from,
+  NEVER,
+  Observable,
+  of,
+  scheduled,
+  share,
+  shareReplay,
+  timer,
+} from 'rxjs';
 import { mockConsole } from '@test-helpers';
 
 function wrapWithSpace(str: string): string {
@@ -18,7 +28,7 @@ function wrapWithSpace(str: string): string {
 }
 
 @Component({
-  template: ` {{ (value$ | push: strategy | json) || 'undefined' }} `,
+  template: ` {{ (value$ | push : strategy | json) || 'undefined' }} `,
 })
 class PushPipeTestComponent {
   value$: Observable<number> = of(42);
@@ -36,7 +46,7 @@ let strategyProvider: RxStrategyProvider;
 const setupPushPipeComponent = () => {
   TestBed.configureTestingModule({
     declarations: [PushPipeTestComponent],
-    imports: [PushModule],
+    imports: [PushPipe],
     providers: [
       ChangeDetectorRef,
       {
@@ -44,14 +54,17 @@ const setupPushPipeComponent = () => {
         useValue: {
           primaryStrategy: 'native',
           customStrategies: {
-            'custom': {
+            custom: {
               name: 'custom',
-              work: cdRef => {
+              work: (cdRef) => {
                 cdRef.detectChanges();
               },
-              behavior: ({ work }) => o$ => o$.pipe(tap(() => work()))
-            }
-          }
+              behavior:
+                ({ work }) =>
+                (o$) =>
+                  o$.pipe(tap(() => work())),
+            },
+          },
         },
       },
     ],
@@ -138,7 +151,7 @@ describe('PushPipe used as pipe in the template', () => {
       const strategy = strategyProvider.strategies['custom'];
       pushPipeTestComponent.strategy = 'custom';
       cdSpy = jest.spyOn(strategy, 'work');
-    })
+    });
 
     it('should not detect changes with sync value', () => {
       fixturePushPipeTestComponent.detectChanges();
@@ -147,36 +160,40 @@ describe('PushPipe used as pipe in the template', () => {
     });
 
     it('should detect changes with async value', async () => {
-      const value$ = new Observable(sub => {
+      const value$ = new Observable((sub) => {
         Promise.resolve().then(() => {
           sub.next(44);
           sub.complete();
         });
         return () => {
           sub.complete();
-        }
+        };
       });
       pushPipeTestComponent.value$ = value$;
       fixturePushPipeTestComponent.detectChanges();
-      expect(componentNativeElement.textContent).toBe(wrapWithSpace('undefined'));
+      expect(componentNativeElement.textContent).toBe(
+        wrapWithSpace('undefined')
+      );
       await Promise.resolve();
       expect(cdSpy).toBeCalledTimes(1);
       expect(componentNativeElement.textContent).toBe(wrapWithSpace('44'));
     });
 
     it('should detect changes with unpatched Promise', async () => {
-      const value$ = new Observable(sub => {
+      const value$ = new Observable((sub) => {
         unpatchedPromise.resolve().then(() => {
           sub.next(44);
           sub.complete();
         });
         return () => {
           sub.complete();
-        }
+        };
       });
       pushPipeTestComponent.value$ = value$;
       fixturePushPipeTestComponent.detectChanges();
-      expect(componentNativeElement.textContent).toBe(wrapWithSpace('undefined'));
+      expect(componentNativeElement.textContent).toBe(
+        wrapWithSpace('undefined')
+      );
       await unpatchedPromise.resolve();
       expect(cdSpy).toBeCalledTimes(1);
       expect(componentNativeElement.textContent).toBe(wrapWithSpace('44'));
@@ -186,7 +203,9 @@ describe('PushPipe used as pipe in the template', () => {
       const value$ = timer(0, asapScheduler).pipe(map(() => 44));
       pushPipeTestComponent.value$ = value$;
       fixturePushPipeTestComponent.detectChanges();
-      expect(componentNativeElement.textContent).toBe(wrapWithSpace('undefined'));
+      expect(componentNativeElement.textContent).toBe(
+        wrapWithSpace('undefined')
+      );
       await Promise.resolve();
       expect(cdSpy).toBeCalledTimes(1);
       expect(componentNativeElement.textContent).toBe(wrapWithSpace('44'));
@@ -196,13 +215,14 @@ describe('PushPipe used as pipe in the template', () => {
       const value$ = timer(0).pipe(map(() => 44));
       pushPipeTestComponent.value$ = value$;
       fixturePushPipeTestComponent.detectChanges();
-      expect(componentNativeElement.textContent).toBe(wrapWithSpace('undefined'));
-      await new Promise(resolve => {
+      expect(componentNativeElement.textContent).toBe(
+        wrapWithSpace('undefined')
+      );
+      await new Promise((resolve) => {
         setTimeout(resolve);
-      })
+      });
       expect(cdSpy).toBeCalledTimes(1);
       expect(componentNativeElement.textContent).toBe(wrapWithSpace('44'));
     });
-
-  })
+  });
 });

--- a/libs/template/unpatch/src/lib/tests/unpatch.directive.spec.ts
+++ b/libs/template/unpatch/src/lib/tests/unpatch.directive.spec.ts
@@ -4,7 +4,6 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { UnpatchDirective } from '../unpatch.directive';
-import { UnpatchModule } from '../unpatch.module';
 
 describe(UnpatchDirective.name, () => {
   enum LogEvent {
@@ -35,7 +34,7 @@ describe(UnpatchDirective.name, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [UnpatchModule],
+      imports: [UnpatchDirective],
       declarations: [TestComponent],
       teardown: { destroyAfterEach: true },
     });

--- a/libs/template/unpatch/src/lib/unpatch.directive.ts
+++ b/libs/template/unpatch/src/lib/unpatch.directive.ts
@@ -117,7 +117,7 @@ export function unpatchEventListener(
  *
  * @publicApi
  */
-@Directive({ selector: '[unpatch]' })
+@Directive({ selector: '[unpatch]', standalone: true })
 /**
  * @todo: add prefix [rxUnpatch]
  */

--- a/libs/template/unpatch/src/lib/unpatch.module.ts
+++ b/libs/template/unpatch/src/lib/unpatch.module.ts
@@ -2,8 +2,9 @@ import { NgModule } from '@angular/core';
 
 import { UnpatchDirective } from './unpatch.directive';
 
+/** @deprecated use the standalone import, will be removed with v16 */
 @NgModule({
-  declarations: [UnpatchDirective],
+  imports: [UnpatchDirective],
   exports: [UnpatchDirective],
 })
 export class UnpatchModule {}


### PR DESCRIPTION
This PR introduces the standalone API for all directives and pipes in the template package. It also deprecates the usage of the existing `NgModule`s and specifies version 16 as the point in time where they get dropped. We can ship a migration script targeted to version 16 when we upgrade