### PR TITLE
fix(state): handle error emission in `connect` using `ErrorHandler`

### DIFF
--- a/libs/state/selections/src/lib/accumulation-observable.ts
+++ b/libs/state/selections/src/lib/accumulation-observable.ts
@@ -25,11 +25,12 @@ const defaultAccumulator: AccumulationFn = <T>(st: T, sl: Partial<T>): T => {
   return { ...st, ...sl };
 };
 
-export function createAccumulationObservable<T extends object>(
+export function createAccumulationObservable<T extends object>({
   stateObservables = new Subject<Observable<Partial<T>>>(),
   stateSlices = new Subject<Partial<T>>(),
-  accumulatorObservable = new BehaviorSubject(defaultAccumulator)
-): Accumulator<T> {
+  accumulatorObservable = new BehaviorSubject(defaultAccumulator),
+  handleError = (e: any) => console.error(e),
+} = {}): Accumulator<T> {
   const signal$ = merge(
     stateObservables.pipe(
       distinctUntilChanged(),
@@ -45,7 +46,7 @@ export function createAccumulationObservable<T extends object>(
     ),
     tap(
       (newState) => (compositionObservable.state = newState),
-      (error) => console.error(error)
+      (error) => handleError(error)
     ),
     // @Notice We catch the error here as it get lost in between `publish` and `publishReplay`. We return empty to
     catchError((e) => EMPTY),

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { ErrorHandler, inject, Injectable, OnDestroy } from '@angular/core';
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import {
   AccumulationFn,
@@ -53,8 +53,10 @@ export type ProjectValueReducer<T, K extends keyof T, V> = (
 @Injectable()
 export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
   private subscription = new Subscription();
-
-  private accumulator = createAccumulationObservable<T>();
+  private handleError = inject(ErrorHandler).handleError;
+  private accumulator = createAccumulationObservable<T>({
+    handleError: this.handleError,
+  });
   private effectObservable = createSideEffectObservable();
 
   /**


### PR DESCRIPTION
It's potentially a breaking change as with these changes instantiating RxState outside of Angular context will raise the following error: 

```
NG0203: inject() must be called from an injection context such as a constructor, a factory function, a field initializer, or a function used with `EnvironmentInjector#runInContext`. Find more at https://angular.io/errors/NG0203
```

Fixes #1536