### PR TITLE
docs(template):  add setup example with standalone cmp and fix typos

### DIFF
--- a/apps/docs/docs/cdk/render-strategies/strategies/basic-strategies.md
+++ b/apps/docs/docs/cdk/render-strategies/strategies/basic-strategies.md
@@ -158,12 +158,12 @@ class Component {
 ### Template
 
 ```ts
-import { LetModule } from '@rx-angular/template/let';
-import { ForModule } from '@rx-angular/template/for';
-import { PushModule } from '@rx-angular/template/push';
+import { LetDirective } from '@rx-angular/template/let';
+import { PushPipe } from '@rx-angular/template/push';
+import { RxFor } from '@rx-angular/template/for';
 
 @Module({
-  imports: [LetModule, ForModule, PushModule],
+  imports: [LetDirective, PushPipe, RxFor],
 })
 class Module {}
 ```

--- a/apps/docs/docs/template/api/let-directive.md
+++ b/apps/docs/docs/template/api/let-directive.md
@@ -115,28 +115,14 @@ n/a
 
 ## Setup
 
-The `LetModule` can be imported as following:
-
-Module based setup:
+The `LetDirective` can be imported as following:
 
 ```ts
-import { LetModule } from '@rx-angular/template/let';
-
-@NgModule({
-  imports: [LetModule],
-  // ...
-})
-export class AnyModule {}
-```
-
-Standalone component setup:
-
-```ts
-import { LetModule } from '@rx-angular/template/let';
+import { LetDirective } from '@rx-angular/template/let';
 
 @Component({
   standalone: true,
-  imports: [LetModule],
+  imports: [LetDirective],
   template: `...`,
 })
 export class AnyComponent {}
@@ -237,7 +223,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <button (click)="nextTrigger$.next()">show value</button>
     <ng-container
@@ -263,7 +249,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <ng-container *rxLet="num$; let n; error: error; errorTrg: errorTrigger$">
       {{ n }}
@@ -286,7 +272,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <ng-container
       *rxLet="num$; let n; complete: complete; completeTrg: completeTrigger$"
@@ -311,7 +297,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <input (input)="search($event.target.value)" />
     <ng-container
@@ -348,7 +334,7 @@ in a convenient way.
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <input (input)="search($event.target.value)" />
     <ng-container

--- a/apps/docs/docs/template/api/let-directive.md
+++ b/apps/docs/docs/template/api/let-directive.md
@@ -392,7 +392,9 @@ The default value for strategy is [`normal`](../../cdk/render-strategies/strateg
 ```
 
 ```ts
-@Component()
+@Component({
+  /**/
+})
 export class AppComponent {
   strategy = 'low';
   strategy$ = of('immediate');
@@ -447,9 +449,9 @@ The result of the `renderCallback` will contain the currently rendered value of 
  @Component({
    selector: 'app-root',
    template: `
-   <ng-container *rxLet="num$; let n; renderCallback: valueRendered;">
-      {{ n }}
-   </ng-container>
+    <ng-container *rxLet="num$; let n; renderCallback: valueRendered;">
+        {{ n }}
+    </ng-container>
    `
  })
  export class AppComponent {
@@ -477,7 +479,7 @@ For more details read about [NgZone optimizations](../performance-issues/ngzone-
 
 ```ts
 @Component({
-  selector: 'any-component>',
+  selector: 'app-root',
   template: `
     <div
       *rxLet="bgColor$; let bgColor; patchZone: false"

--- a/apps/docs/docs/template/api/rx-for-directive.md
+++ b/apps/docs/docs/template/api/rx-for-directive.md
@@ -107,28 +107,14 @@ The following context variables are available for each template:
 
 ## Setup
 
-The `ForModule` can be imported as following:
-
-Module based setup:
+The `RxFor` can be imported as following:
 
 ```
-import { ForModule } from "@rx-angular/template/for";
-
-@NgModule({
-  imports: [ForModule],
-  // ...
-})
-export class AnyModule {}
-```
-
-Standalone component setup:
-
-```
-import { ForModule } from "@rx-angular/template/for";
+import { RxFor } from "@rx-angular/template/for";
 
 @Component({
     standalone: true,
-    imports: [ForModule],
+    imports: [RxFor],
     template: `...`
 })
 export class AnyComponent {}

--- a/apps/docs/docs/template/api/rx-for-directive.md
+++ b/apps/docs/docs/template/api/rx-for-directive.md
@@ -115,7 +115,7 @@ Module based setup:
 import { ForModule } from "@rx-angular/template/for";
 
 @NgModule({
-  imports: [ ForModule ],
+  imports: [ForModule],
   // ...
 })
 export class AnyModule {}
@@ -126,9 +126,9 @@ Standalone component setup:
 ```
 import { ForModule } from "@rx-angular/template/for";
 
-@NgComponent({
+@Component({
     standalone: true,
-    imports: [ ForModule ],
+    imports: [ForModule],
     template: `...`
 })
 export class AnyComponent {}
@@ -151,11 +151,11 @@ export class AnyComponent {}
 ### Simple example using `*rxFor` with `Observable` values
 
 ```ts
-@NgComponent({
+@Component({
     template: `
-    <ul>
-      <li *rxFor="let item of items$; trackBy: trackItem">{{ item }}</li>
-    </ul>
+      <ul>
+        <li *rxFor="let item of items$; trackBy: trackItem">{{ item }}</li>
+      </ul>
     `
 })
 export class AnyComponent {
@@ -173,11 +173,11 @@ export class AnyComponent {
 > As `rxFor` accepts also static values it can serve as a drop in replacement with an easy find and replace refactoring.
 
 ```typescript
-@NgComponent({
+@Component({
     template: `
-    <ul>
-      <li *rxFor="let item of items; trackBy: trackItem">{{ item }}</li>
-    </ul>
+      <ul>
+        <li *rxFor="let item of items; trackBy: trackItem">{{ item }}</li>
+      </ul>
     `
 })
 export class AnyComponent {
@@ -195,12 +195,12 @@ export class AnyComponent {
 > As `rxFor` accepts also static values it can serve as a drop in replacement with an easy find and replace refacturing.
 
 ```typescript
-@NgComponent({
+@Component({
   template: `
     <ul>
       <li *rxFor="let item of items; trackBy: 'id'">{{ item }}</li>
     </ul>
-    `,
+  `,
 })
 export class AnyComponent {}
 ```
@@ -272,7 +272,9 @@ The default value for strategy is [`normal`](../../cdk/render-strategies/strateg
 ```
 
 ```ts
-@Component()
+@Component({
+  /**/
+})
 export class AppComponent {
   strategy = 'low';
   strategy$ = of('immediate');
@@ -303,7 +305,7 @@ Imagine the following situation:
   template: ` <ng-content select="app-list-item"></ng-content>`,
 })
 export class AppListComponent {
-  @ContentChildren(AppListItemComponent)
+  @ContentChildren(AppListItemComponent);
   appListItems: QueryList<AppListItemComponent>;
 }
 ```
@@ -436,7 +438,7 @@ For more details read about [NgZone optimizations](../performance-issues/ngzone-
 
 ```ts
 @Component({
-  selector: 'any-component>',
+  selector: 'app-root',
   template: `
     <div
       *rxFor="let bgColor; in: bgColor$; patchZone: false"

--- a/apps/docs/docs/template/api/rx-if-directive.md
+++ b/apps/docs/docs/template/api/rx-if-directive.md
@@ -103,28 +103,14 @@ n/a
 
 ## Setup
 
-The `IfModule` can be imported as following:
-
-Module based setup:
+The `RxIf` can be imported as following:
 
 ```ts
-import { IfModule } from '@rx-angular/template/if';
-
-@NgModule({
-  imports: [IfModule],
-  // ...
-})
-export class AnyModule {}
-```
-
-Standalone component setup:
-
-```ts
-import { IfModule } from '@rx-angular/template/if';
+import { RxIf } from '@rx-angular/template/if';
 
 @Component({
   standalone: true,
-  imports: [IfModule],
+  imports: [RxIf],
   template: `...`,
 })
 export class AnyComponent {}

--- a/apps/docs/docs/template/api/rx-if-directive.md
+++ b/apps/docs/docs/template/api/rx-if-directive.md
@@ -287,7 +287,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <button (click)="nextTrigger$.next()">show value</button>
     <ng-container *rxIf="show; complete: complete; nextTrg: nextTrigger$">
@@ -309,7 +309,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <ng-container *rxIf="show$; let n; error: error; errorTrg: errorTrigger$">
       <item></item>
@@ -330,7 +330,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <ng-container
       *rxIf="show$; complete: complete; completeTrg: completeTrigger$"
@@ -353,7 +353,7 @@ e.g. from the complete template back to the value display
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <input (input)="search($event.target.value)" />
     <ng-container
@@ -384,7 +384,7 @@ in a convenient way.
 
 ```typescript
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <input (input)="search($event.target.value)" />
     <ng-container *rxIf="show$; suspense: suspense; contextTrg: contextTrg$">
@@ -504,7 +504,7 @@ For more details read about [NgZone optimizations](../performance-issues/ngzone-
 
 ```ts
 @Component({
-  selector: 'any-component',
+  selector: 'app-root',
   template: `
     <div *rxIf="enabled$; patchZone: false" (drag)="itemDrag($event)"></div>
   `,

--- a/libs/template/README.md
+++ b/libs/template/README.md
@@ -70,34 +70,18 @@ nx migrate @rx-angular/template
 
 ## Basic setup
 
-You can import each feature module individually.
-
-Module based setup:
+You can import each feature individually.
 
 ```typescript
-import { LetModule } from '@rx-angular/template/let';
-import { ForModule } from '@rx-angular/template/for';
-import { PushModule } from '@rx-angular/template/push';
-import { UnpatchModule } from '@rx-angular/template/unpatch';
-
-@NgModule({
-  declarations: [...],
-  imports: [ForModule, LetModule, PushModule, UnpatchModule],
-})
-export class AnyModule {}
-```
-
-Standalone component setup:
-
-```typescript
-import { LetModule } from '@rx-angular/template/let';
-import { ForModule } from '@rx-angular/template/for';
-import { PushModule } from '@rx-angular/template/push';
-import { UnpatchModule } from '@rx-angular/template/unpatch';
+import { LetDirective } from '@rx-angular/template/let';
+import { RxFor } from '@rx-angular/template/for';
+import { RxIf } from '@rx-angular/template/if';
+import { PushPipe } from '@rx-angular/template/push';
+import { UnpatchDirective } from '@rx-angular/template/unpatch';
 
 @Component({
   standalone: true,
-  imports: [ForModule, LetModule, PushModule, UnpatchModule],
+  imports: [LetDirective, RxFor, RxIf, PushPipe, UnpatchDirective],
   template: `...`,
 })
 export class AnyComponent {}

--- a/libs/template/README.md
+++ b/libs/template/README.md
@@ -72,6 +72,8 @@ nx migrate @rx-angular/template
 
 You can import each feature module individually.
 
+Module based setup:
+
 ```typescript
 import { LetModule } from '@rx-angular/template/let';
 import { ForModule } from '@rx-angular/template/for';
@@ -82,7 +84,23 @@ import { UnpatchModule } from '@rx-angular/template/unpatch';
   declarations: [...],
   imports: [ForModule, LetModule, PushModule, UnpatchModule],
 })
-export class MyModule {}
+export class AnyModule {}
+```
+
+Standalone component setup:
+
+```typescript
+import { LetModule } from '@rx-angular/template/let';
+import { ForModule } from '@rx-angular/template/for';
+import { PushModule } from '@rx-angular/template/push';
+import { UnpatchModule } from '@rx-angular/template/unpatch';
+
+@Component({
+  standalone: true,
+  imports: [ForModule, LetModule, PushModule, UnpatchModule],
+  template: `...`,
+})
+export class AnyComponent {}
 ```
 
 ## Version Compatibility


### PR DESCRIPTION
I added an example to the basic setup with standalone components and also fixed several typos or consistency stuff in the `@rx-angular/template` doc.