### PR TITLE
fix(template): fix properties not initialized

### DIFF
--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -2,9 +2,9 @@ import {
   ChangeDetectorRef,
   Directive,
   DoCheck,
-  ElementRef,
   EmbeddedViewRef,
   ErrorHandler,
+  inject,
   Input,
   IterableDiffers,
   NgIterable,
@@ -82,6 +82,22 @@ declare const ngDevMode: boolean;
 export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   implements OnInit, DoCheck, OnDestroy
 {
+  /** @internal */
+  private iterableDiffers = inject(IterableDiffers);
+  /** @internal */
+  private cdRef = inject(ChangeDetectorRef);
+  /** @internal */
+  private ngZone = inject(NgZone);
+  /** @internal */
+  private templateRef =
+    inject<TemplateRef<RxForViewContext<T, U>>>(TemplateRef);
+  /** @internal */
+  private viewContainerRef = inject(ViewContainerRef);
+  /** @internal */
+  private strategyProvider = inject(RxStrategyProvider);
+  /** @internal */
+  private errorHandler = inject(ErrorHandler);
+
   /** @internal */
   private staticValue?: U;
   /** @internal */
@@ -382,18 +398,6 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
   private get template(): TemplateRef<RxForViewContext<T, U>> {
     return this._template || this.templateRef;
   }
-
-  /** @internal */
-  constructor(
-    private iterableDiffers: IterableDiffers,
-    private cdRef: ChangeDetectorRef,
-    private ngZone: NgZone,
-    private eRef: ElementRef,
-    private templateRef: TemplateRef<RxForViewContext<T, U>>,
-    private readonly viewContainerRef: ViewContainerRef,
-    private strategyProvider: RxStrategyProvider,
-    private errorHandler: ErrorHandler
-  ) {}
 
   /** @internal */
   private strategyInput$ = new ReplaySubject<

--- a/libs/template/if/src/lib/if.directive.ts
+++ b/libs/template/if/src/lib/if.directive.ts
@@ -9,22 +9,22 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
+  inject,
 } from '@angular/core';
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
 import {
-  createTemplateNotifier,
   RxNotificationKind,
+  createTemplateNotifier,
 } from '@rx-angular/cdk/notifications';
 import {
   RxStrategyNames,
   RxStrategyProvider,
 } from '@rx-angular/cdk/render-strategies';
 import {
-  createTemplateManager,
   RxTemplateManager,
+  createTemplateManager,
 } from '@rx-angular/cdk/template';
 import {
-  merge,
   NEVER,
   NextObserver,
   Observable,
@@ -32,12 +32,13 @@ import {
   ReplaySubject,
   Subject,
   Subscription,
+  merge,
 } from 'rxjs';
-import { mergeAll, filter, map } from 'rxjs/operators';
+import { filter, map, mergeAll } from 'rxjs/operators';
 import {
   RxIfTemplateNames,
-  rxIfTemplateNames,
   RxIfViewContext,
+  rxIfTemplateNames,
 } from './model/index';
 
 /**
@@ -69,6 +70,17 @@ import {
 export class RxIf<T = unknown>
   implements OnInit, OnChanges, OnDestroy, OnChanges
 {
+  /** @internal */
+  private strategyProvider = inject(RxStrategyProvider);
+  /** @internal */
+  private cdRef = inject(ChangeDetectorRef);
+  /** @internal */
+  private ngZone = inject(NgZone);
+  /** @internal */
+  private templateRef = inject<TemplateRef<RxIfViewContext<T>>>(TemplateRef);
+  /** @internal */
+  private viewContainerRef = inject(ViewContainerRef);
+
   /** @internal */
   private subscription = new Subscription();
   /** @internal */
@@ -476,14 +488,6 @@ export class RxIf<T = unknown>
   private get thenTemplate(): TemplateRef<RxIfViewContext<T>> {
     return this.then ? this.then : this.templateRef;
   }
-
-  constructor(
-    private strategyProvider: RxStrategyProvider,
-    private cdRef: ChangeDetectorRef,
-    private ngZone: NgZone,
-    private readonly templateRef: TemplateRef<RxIfViewContext<T>>,
-    private readonly viewContainerRef: ViewContainerRef
-  ) {}
 
   /** @internal */
   ngOnInit() {

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Directive,
   ErrorHandler,
+  inject,
   Input,
   NgZone,
   OnChanges,
@@ -40,7 +41,7 @@ import {
   Subject,
   Subscription,
 } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 /** @internal */
 type RxLetTemplateNames = 'nextTpl' | RxBaseTemplateNames;
@@ -95,6 +96,20 @@ export interface RxLetViewContext<T> extends RxViewContext<T> {
 @Directive({ selector: '[rxLet]', standalone: true })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class RxLet<U> implements OnInit, OnDestroy, OnChanges {
+  /** @internal */
+  private strategyProvider = inject(RxStrategyProvider);
+  /** @internal */
+  private cdRef = inject(ChangeDetectorRef);
+  /** @internal */
+  private ngZone = inject(NgZone);
+  /** @internal */
+  private nextTemplateRef =
+    inject<TemplateRef<RxLetViewContext<U>>>(TemplateRef);
+  /** @internal */
+  private viewContainerRef = inject(ViewContainerRef);
+  /** @internal */
+  private errorHandler = inject(ErrorHandler);
+
   static ngTemplateGuard_rxLet: 'binding';
 
   /**
@@ -468,15 +483,6 @@ export class RxLet<U> implements OnInit, OnDestroy, OnChanges {
    * }
    */
   @Input('rxLetPatchZone') patchZone = this.strategyProvider.config.patchZone;
-
-  constructor(
-    private strategyProvider: RxStrategyProvider,
-    public cdRef: ChangeDetectorRef,
-    private ngZone: NgZone,
-    private readonly nextTemplateRef: TemplateRef<RxLetViewContext<U>>,
-    private readonly viewContainerRef: ViewContainerRef,
-    private errorHandler: ErrorHandler
-  ) {}
 
   /** @internal */
   private observablesHandler = createTemplateNotifier<U>();

--- a/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
@@ -5,9 +5,9 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
-import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
-import { asapScheduler, delay, Observable, ReplaySubject, Subject } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import { Observable, ReplaySubject, Subject, asapScheduler, delay } from 'rxjs';
 import { RxLet } from '../let.directive';
 
 @Component({
@@ -104,7 +104,7 @@ describe('LetDirective parent notification', () => {
 
       it('should update parent', (done) => {
         fixture.detectChanges();
-        const cdRef = componentInstance.letChildren.first.cdRef;
+        const cdRef = (componentInstance.letChildren.first as any).cdRef;
         cdRef.detectChanges = jest.fn();
         const behavior = strategyProvider.strategies[strategy].behavior;
         componentInstance.rendered$
@@ -122,8 +122,8 @@ describe('LetDirective parent notification', () => {
 
       it('should scope parent notifications', (done) => {
         fixture.detectChanges();
-        const cdRef = componentInstance.letChildren.first.cdRef;
-        const cdRef2 = componentInstance.letChildren.last.cdRef;
+        const cdRef = (componentInstance.letChildren.first as any).cdRef;
+        const cdRef2 = (componentInstance.letChildren.last as any).cdRef;
         expect(cdRef2).toEqual(cdRef);
         cdRef.detectChanges = jest.fn();
         const behavior = strategyProvider.strategies[strategy].behavior;
@@ -167,7 +167,7 @@ describe('LetDirective parent notification', () => {
 
       it('should not update parent', (done) => {
         fixture.detectChanges();
-        const cdRef = componentInstance.letChildren.first.cdRef;
+        const cdRef = (componentInstance.letChildren.first as any).cdRef;
         cdRef.detectChanges = jest.fn();
         const behavior = strategyProvider.strategies[strategy].behavior;
         componentInstance.rendered$

--- a/libs/template/push/src/lib/push.pipe.ts
+++ b/libs/template/push/src/lib/push.pipe.ts
@@ -4,18 +4,19 @@ import {
   OnDestroy,
   Pipe,
   PipeTransform,
+  inject,
   untracked,
 } from '@angular/core';
+import {
+  RxNotification,
+  RxNotificationKind,
+  createTemplateNotifier,
+} from '@rx-angular/cdk/notifications';
 import {
   RxStrategyNames,
   RxStrategyProvider,
   strategyHandling,
 } from '@rx-angular/cdk/render-strategies';
-import {
-  createTemplateNotifier,
-  RxNotification,
-  RxNotificationKind,
-} from '@rx-angular/cdk/notifications';
 import {
   MonoTypeOperatorFunction,
   NextObserver,
@@ -26,9 +27,9 @@ import {
   Unsubscribable,
 } from 'rxjs';
 import {
+  filter,
   shareReplay,
   skip,
-  filter,
   switchMap,
   tap,
   withLatestFrom,
@@ -87,6 +88,12 @@ import {
  */
 @Pipe({ name: 'push', pure: false, standalone: true })
 export class RxPush implements PipeTransform, OnDestroy {
+  /** @internal */
+  private strategyProvider = inject(RxStrategyProvider);
+  /** @internal */
+  private cdRef = inject(ChangeDetectorRef);
+  /** @internal */
+  private ngZone = inject(NgZone);
   /**
    * @internal
    * This is typed as `any` because the type cannot be inferred
@@ -111,12 +118,6 @@ export class RxPush implements PipeTransform, OnDestroy {
   private patchZone: false | NgZone;
   /** @internal */
   private _renderCallback: NextObserver<any>;
-
-  constructor(
-    private strategyProvider: RxStrategyProvider,
-    private cdRef: ChangeDetectorRef,
-    private ngZone: NgZone
-  ) {}
 
   transform<U>(
     potentialObservable: null,


### PR DESCRIPTION
Resolves "@rx-angular/template": "^16.0.0" ->  Cannot read properties of undefined (reading 'config'). Fixes #1580.