### PR TITLE
fix(template): virtual-scroll scrollStrategy dependency error in es2022

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -6,9 +6,9 @@ import {
   ContentChild,
   ElementRef,
   OnDestroy,
-  Optional,
   Output,
   ViewChild,
+  inject,
 } from '@angular/core';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
@@ -108,6 +108,11 @@ export class RxVirtualScrollViewportComponent
     AfterContentInit,
     OnDestroy
 {
+  private elementRef = inject(ElementRef<HTMLElement>);
+  private scrollStrategy = inject(RxVirtualScrollStrategy<unknown>, {
+    optional: true,
+  });
+
   /** @internal */
   @ViewChild('runway', { static: true })
   private runway!: ElementRef<HTMLElement>;
@@ -142,7 +147,7 @@ export class RxVirtualScrollViewportComponent
    * in sync with the DOM when the next `renderCallback` emitted an event.
    */
   @Output()
-  readonly viewRange = this.scrollStrategy.renderedRange$;
+  readonly viewRange = this.scrollStrategy?.renderedRange$;
 
   /**
    * @description
@@ -151,17 +156,14 @@ export class RxVirtualScrollViewportComponent
    * item actually being visible to the user.
    */
   @Output()
-  readonly scrolledIndexChange = this.scrollStrategy.scrolledIndex$;
+  readonly scrolledIndexChange = this.scrollStrategy?.scrolledIndex$;
 
   /** @internal */
   private readonly destroy$ = new Subject<void>();
 
   /** @internal */
-  constructor(
-    private elementRef: ElementRef<HTMLElement>,
-    @Optional() private scrollStrategy: RxVirtualScrollStrategy<unknown>
-  ) {
-    if (NG_DEV_MODE && !scrollStrategy) {
+  constructor() {
+    if (NG_DEV_MODE && !this.scrollStrategy) {
       throw Error(
         'Error: rx-virtual-scroll-viewport requires an `RxVirtualScrollStrategy` to be set.'
       );

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -147,7 +147,7 @@ export class RxVirtualScrollViewportComponent
    * in sync with the DOM when the next `renderCallback` emitted an event.
    */
   @Output()
-  readonly viewRange = this.scrollStrategy?.renderedRange$;
+  readonly viewRange = this.scrollStrategy.renderedRange$;
 
   /**
    * @description
@@ -156,7 +156,7 @@ export class RxVirtualScrollViewportComponent
    * item actually being visible to the user.
    */
   @Output()
-  readonly scrolledIndexChange = this.scrollStrategy?.scrolledIndex$;
+  readonly scrolledIndexChange = this.scrollStrategy.scrolledIndex$;
 
   /** @internal */
   private readonly destroy$ = new Subject<void>();


### PR DESCRIPTION
use inject for dependency injection to prevent class instance members undefined errors

When virtual scroll feature used in a project with "target": "es2022" it's broken because class filed uses dependency injection field before initialization
`readonly viewRange = this.scrollStrategy.renderedRange$;`
throws an error and nothing is rendered.

Using inject instead of constructor injection fixes the issue
