### PR TITLE
feat(isr): add the possibility to create the cache in several variants

### DIFF
--- a/apps/docs/docs/isr/cache-variants.md
+++ b/apps/docs/docs/isr/cache-variants.md
@@ -1,0 +1,115 @@
+---
+sidebar_label: Cache Variants
+sidebar_position: 11
+title: Cache Variants
+---
+
+## Why do we need it?
+
+In some apps, pages are displayed in different variants. This can be the case, for example, if the application has a login. Users who are already logged in may not see a login button or something similar, whereas an authenticated user will.
+
+These scenarios would lead to a content shift after delivery of the cached variant that does not correspond to the user status.
+
+## How to use it?
+
+For these cases the configuration can be extended by any number of render variants by the `variants` property.
+
+```typescript title="server.ts"
+const isr = new ISRHandler({
+  ...
+  // highlight-next-line
+  variants: [] // 👈 register your variants here
+});
+```
+
+The `RenderVariant` interface is defined as follows:
+
+```typescript
+export interface RenderVariant {
+  identifier: string;
+  detectVariant: (req: Request) => boolean;
+  simulateVariant?: (req: Request) => Request;
+}
+```
+
+### identifier
+
+The `identifier` must be unique and is used next to the URL as a key for the cache.
+
+### detectVariant
+
+The `detectVariant` callback detects from the current request whether a defined variant must be delivered. This can happen e.g. on the basis of a cookie or similar. The return value is a boolean which determines whether this request fits the variant or not.
+
+### simulateVariant
+
+If on-demand revalidation is also to be used for the different variants, a way must be provided to modify the request so that it can be recognized again by the `detectVariant` callback.
+
+For example, a placeholder for an authentication cookie can be added so that an authenticated variant of the app is rendered.
+For this we use the `simulateVariant` callback, which is called before rendering to modify the request.
+
+### Example
+
+```typescript title="server.ts"
+const isr = new ISRHandler({
+  ...
+  variants: [
+      {
+          identifier: 'logged-in', // 👈 key to cache the variant
+          detectVariant: (req) => {
+              // 👇 Variant is recognized as soon as the request contains a cookie 'access_token'
+              return req.cookies && req.cookies.access_token;
+          },
+          simulateVariant: (req) => {
+              // 👇 For on-demand revalidation we insert a placeholder 'access_token' cookie
+              req.cookies['access_token'] = 'isr';
+              return req;
+          }
+      },
+  ]
+});
+```
+
+## Gotchas
+
+If more than one variant is registered, the one where the `detectVariant` returns `true` the first time is used.
+
+If a variant is to become a combination of different variants, this state should be registered as an independent variant before the corresponding single variant.
+
+```typescript title="server.ts"
+const isr = new ISRHandler({
+  ...
+  variants: [
+      {
+          identifier: 'A_AND_B',
+          detectVariant: (req) => req.cookies && req.cookies.is_A && req.cookies.is_B,
+          simulateVariant: (req) => {
+              req.cookies['is_A'] = true;
+              req.cookies['is_B'] = true;
+              return req;
+          }
+      },
+      {
+          identifier: 'A',
+          detectVariant: (req) => req.cookies && req.cookies.is_A,
+          simulateVariant: (req) => {
+              req.cookies['is_A'] = true;
+              return req;
+          }
+      },
+      {
+          identifier: 'B',
+          detectVariant: (req) => req.cookies && req.cookies.is_B,
+          simulateVariant: (req) => {
+              req.cookies['is_B'] = true;
+              return req;
+          }
+      },
+  ]
+});
+```
+
+:::caution **Important:**
+For each variant entered here, a corresponding duplicate is cached per page. So be aware that depending on the cache handler this could significantly increase the disk or RAM usage.
+:::
+
+Note that when using placeholder cookies or similar, the application should have appropriate exceptions defined to avoid runtime errors caused by invalid values.

--- a/libs/isr/models/src/cache-handler.ts
+++ b/libs/isr/models/src/cache-handler.ts
@@ -24,7 +24,7 @@ export interface RenderVariant {
 
 export interface VariantRebuildItem {
   url: string;
-  cachKey: string;
+  cacheKey: string;
   reqSimulator: (req: Request) => Request;
 }
 

--- a/libs/isr/models/src/cache-handler.ts
+++ b/libs/isr/models/src/cache-handler.ts
@@ -1,3 +1,5 @@
+import { Request } from 'express';
+
 /**
  * CacheISRConfig is the configuration object that is used to store the
  * cache data in the cache handler.
@@ -12,6 +14,18 @@ export interface CacheData {
   html: string;
   options: CacheISRConfig;
   createdAt: number;
+}
+
+export interface RenderVariant {
+  identifier: string;
+  detectVariant: (req: Request) => boolean;
+  simulateVariant?: (req: Request) => Request;
+}
+
+export interface VariantRebuildItem {
+  url: string;
+  cachKey: string;
+  reqSimulator: (req: Request) => Request;
 }
 
 export abstract class CacheHandler {

--- a/libs/isr/models/src/index.ts
+++ b/libs/isr/models/src/index.ts
@@ -3,6 +3,8 @@ export {
   CacheISRConfig,
   CacheISRConfig as ISROptions,
   CacheData,
+  RenderVariant,
+  VariantRebuildItem,
 } from './cache-handler';
 
 export {

--- a/libs/isr/models/src/isr-handler-config.ts
+++ b/libs/isr/models/src/isr-handler-config.ts
@@ -46,7 +46,7 @@ export interface ISRHandlerConfig {
   /**
    * An optional way to define multiple variants of a page.
    * This can be useful if the appearance page differs, for example,
-   * based on a cookie and the chaed variant would thus lead to a content shift.
+   * based on a cookie and the cached variant would thus lead to a content shift.
    * Each variant needs an identifier and a callback function
    * to identify the variant. It is also possible to modify the request
    * to recreate the variant in case of on-demand cache invalidation.

--- a/libs/isr/models/src/isr-handler-config.ts
+++ b/libs/isr/models/src/isr-handler-config.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@angular/core';
-import { CacheHandler } from './cache-handler';
+import { CacheHandler, RenderVariant } from './cache-handler';
 import { Request } from 'express';
 
 export interface ISRHandlerConfig {
@@ -42,6 +42,30 @@ export interface ISRHandlerConfig {
    * If not provided, defaults to true.
    */
   skipCachingOnHttpError?: boolean;
+
+  /**
+   * An optional way to define multiple variants of a page.
+   * This can be useful if the appearance page differs, for example,
+   * based on a cookie and the chaed variant would thus lead to a content shift.
+   * Each variant needs an identifier and a callback function
+   * to identify the variant. It is also possible to modify the request
+   * to recreate the variant in case of on-demand cache invalidation.
+   *
+   * @example
+   * variants: [
+   *     {
+   *         identifier: 'logged-in',
+   *         detectVariant: (req) => {
+   *             return req.cookies && req.cookies.access_token;
+   *         },
+   *         simulateVariant: (req) => {
+   *             req.cookies['access_token'] = 'isr';
+   *             return req;
+   *         },
+   *     },
+   * ],
+   */
+  variants?: RenderVariant[];
 }
 
 export interface ServeFromCacheConfig {

--- a/libs/isr/server/src/isr-handler.ts
+++ b/libs/isr/server/src/isr-handler.ts
@@ -80,10 +80,10 @@ export class ISRHandler {
       const { cacheKey, url, reqSimulator } = variantUrl;
 
       // check if the url is in cache
-      const urlExists = await this.cache.has(cachKey);
+      const urlExists = await this.cache.has(cacheKey);
 
       if (!urlExists) {
-        notInCache.push(cachKey);
+        notInCache.push(cacheKey);
         continue;
       }
 
@@ -102,7 +102,7 @@ export class ISRHandler {
 
         // if there are errors when rendering the site we throw an error
         if (errors?.length && this.config.skipCachingOnHttpError) {
-          urlWithErrors[cachKey] = errors;
+          urlWithErrors[cacheKey] = errors;
         }
 
         // add the regenerated page to cache
@@ -110,16 +110,16 @@ export class ISRHandler {
           revalidate,
           buildId: this.config.buildId,
         };
-        await this.cache.add(cachKey, html, cacheConfig);
+        await this.cache.add(cacheKey, html, cacheConfig);
       } catch (err) {
-        urlWithErrors[cachKey] = err;
+        urlWithErrors[cacheKey] = err;
       }
     }
 
     const invalidatedUrls = variantUrlsToInvalidate
-      .map((val) => val.cachKey)
+      .map((val) => val.cacheKey)
       .filter(
-        (cachKey) => !notInCache.includes(cachKey) && !urlWithErrors[cachKey]
+        (cacheKey) => !notInCache.includes(cacheKey) && !urlWithErrors[cacheKey]
       );
 
     if (notInCache.length) {
@@ -156,11 +156,11 @@ export class ISRHandler {
     const defaultVariant = (req: Request) => req;
 
     for (const url of urlsToInvalidate) {
-      result.push({ url, cachKey: url, reqSimulator: defaultVariant });
+      result.push({ url, cacheKey: url, reqSimulator: defaultVariant });
       for (const variant of variants) {
         result.push({
           url,
-          cachKey: getCacheKey(url, variant),
+          cacheKey: getCacheKey(url, variant),
           reqSimulator: variant.simulateVariant
             ? variant.simulateVariant
             : defaultVariant,

--- a/libs/isr/server/src/isr-handler.ts
+++ b/libs/isr/server/src/isr-handler.ts
@@ -77,7 +77,7 @@ export class ISRHandler {
       this.getVariantUrlsToInvalidate(urlsToInvalidate);
 
     for (const variantUrl of variantUrlsToInvalidate) {
-      const { cachKey, url, reqSimulator } = variantUrl;
+      const { cacheKey, url, reqSimulator } = variantUrl;
 
       // check if the url is in cache
       const urlExists = await this.cache.has(cachKey);


### PR DESCRIPTION
Implementation for Issue #1604 

This implementation has no breaking changes. It allows to specify different variants of the cache, e.g. for users who have a cookie to verify their logged in status. If no additional variants are specified, the functionality is unchanged. Also no modification to existing CacheHandler implementations is necessary.

Any number of variants can be specified via the ISRHandler configuration.
Each variant has an identifier and a callback function that recognizes the variant for a given request.

To enable on-demand cache invalidation, a simulateVariant function can also be specified, which can modify the request so that it can be identified for the variant.