### PR TITLE
fix(template): fix memory leaks & runtime errors caused by virtual scroll

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -135,6 +135,10 @@ export class DynamicSizeVirtualScrollStrategy<
     this._contentSize$.next(size);
   }
 
+  private get contentSize(): number {
+    return this._contentSize;
+  }
+
   /** @internal */
   private readonly _renderedRange$ = new ReplaySubject<ListRange>(1);
   /** @internal */

--- a/libs/template/experimental/virtual-scrolling/src/lib/util.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/util.ts
@@ -22,17 +22,19 @@ export function unpatchedMicroTask(): Observable<void> {
   return from(Promise.resolve()) as Observable<void>;
 }
 
-export function unpatchedScroll(el: any): Observable<void> {
+export function unpatchedScroll(el: EventTarget): Observable<void> {
   return new Observable<void>((observer) => {
     const listener = () => observer.next();
     getZoneUnPatchedApi(el, 'addEventListener').call(el, 'scroll', listener, {
       passive: true,
     });
     return () => {
-      getZoneUnPatchedApi(
-        this.elementRef.nativeElement,
-        'removeEventListener'
-      ).call(el, 'scroll', listener, { passive: true });
+      getZoneUnPatchedApi(el, 'removeEventListener').call(
+        el,
+        'scroll',
+        listener,
+        { passive: true }
+      );
     };
   });
 }


### PR DESCRIPTION
# Description

Just noticed a really bad bug slipped into the virtual scroll package. On destruction the virtual scroll strategies raise an error as there is a bug in the unsubscription logic of the scroll listener. This will also lead to memory leaks as the scroll listener is never detached.

![image](https://github.com/rx-angular/rx-angular/assets/4904455/ce1d8c66-cb1c-4418-bb59-13ad148e4f2f)
