### PR TITLE
feat(state): provide state config through injection tokens

### DIFF
--- a/apps/docs/docs/state/actions/actions.mdx
+++ b/apps/docs/docs/state/actions/actions.mdx
@@ -38,7 +38,7 @@ Actions are an essential part of any state management system. They represent uni
 system events or device APIs. From a pure technical perspective, actions are the triggers for state changes and side effect executions.
 The `@rx-angular/state/actions` package helps to reduce & streamline your code used to create composable action streams.
 
-It is best suited to be used in combination with [RxState](./setup) and/or [RxEffects](./effects) but can also be
+It is best suited to be used in combination with [RxState](./getting-started) and/or [RxEffects](./effects) but can also be
 used in a standalone way.
 
 :::note
@@ -93,9 +93,7 @@ class LoginComponent {
   actions = rxActions<{ login: { username: string; password: string } }>();
 
   constructor(private service: AuthService) {
-    this.actions.login$
-      .pipe(exhaustMap((credentials) => this.service.login(credentials)))
-      .subscribe();
+    this.actions.login$.pipe(exhaustMap((credentials) => this.service.login(credentials))).subscribe();
   }
 }
 ```
@@ -138,15 +136,12 @@ class LoginComponent {
   actions = rxActions<{ login: { username: string; password: string } }>();
 
   private loginEffect = this.actions.onLogin(
-    (credentials$) =>
-      credentials$.pipe(
-        exhaustMap((credentials) => this.service.login(credentials))
-      ),
-    () => this.doc.defaultView.alert('successfully logged in')
+    (credentials$) => credentials$.pipe(exhaustMap((credentials) => this.service.login(credentials))),
+    () => this.doc.defaultView.alert('successfully logged in'),
   );
   constructor(
     private service: AuthService,
-    @Inject(DOCUMENT) private doc: Document
+    @Inject(DOCUMENT) private doc: Document,
   ) {}
 }
 ```
@@ -170,10 +165,9 @@ export class MovieService {
 
   private refreshEffect = this.actions.onRefresh(
     // data refresh with applied behaviour
-    (refresh$) =>
-      refresh$.pipe(exhaustMap(() => this.movieResource.getMovies())),
+    (refresh$) => refresh$.pipe(exhaustMap(() => this.movieResource.getMovies())),
     // set the value to the state
-    (movies) => this.movies.set(movies)
+    (movies) => this.movies.set(movies),
   );
 
   refresh() {
@@ -200,10 +194,9 @@ export class MovieService {
   // highlight-start
   private refreshEffect = this.actions.onRefresh(
     // data refresh with applied behaviour
-    (refresh$) =>
-      refresh$.pipe(exhaustMap(() => this.movieResource.getMovies())),
+    (refresh$) => refresh$.pipe(exhaustMap(() => this.movieResource.getMovies())),
     // set the value to the state
-    (movies) => this.movies.set(movies)
+    (movies) => this.movies.set(movies),
   );
   // highlight-end
 
@@ -251,7 +244,7 @@ import { rxActions, eventValue } from '@rx-angular/state/actions';
 class ListComponent {
   actions = rxActions<{ search: string }>(({ transforms }) =>
     // if event is forwarded pluck the value `e?.target?.value` else forward the value as is
-    transforms({ search: eventValue })
+    transforms({ search: eventValue }),
   );
 }
 ```
@@ -274,7 +267,7 @@ export class GreetComponent {
     transforms({
       // highlight-next-line
       greet: (v) => `Hello ${v}`,
-    })
+    }),
   );
 }
 ```
@@ -367,9 +360,7 @@ export class LoginComponent {
   actions = rxActions<{ login: { username: string; password: string } }>();
 
   constructor(private service: AuthService) {
-    this.actions.login$
-      .pipe(exhaustMap((credentials) => this.service.login(credentials)))
-      .subscribe();
+    this.actions.login$.pipe(exhaustMap((credentials) => this.service.login(credentials))).subscribe();
   }
 }
 ```
@@ -405,9 +396,7 @@ describe('LoginComponent', () => {
   it('login on form submit', () => {
     // arrange
     const username = fixture.debugElement.query(By.css('input:first-child'));
-    const password = fixture.debugElement.query(
-      By.css('input[type="password"]')
-    );
+    const password = fixture.debugElement.query(By.css('input[type="password"]'));
     const btn = fixture.debugElement.query(By.css('button'));
     const loginSpy = jest.spyOn(service, 'login');
     username.nativeElement.value = 'user';
@@ -450,10 +439,7 @@ describe('MovieService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        MovieService,
-        { provide: MovieResource, useClass: MovieResourceMock },
-      ],
+      providers: [MovieService, { provide: MovieResource, useClass: MovieResourceMock }],
     }).compileComponents();
     service = TestBed.inject(MovieService);
     resource = TestBed.inject(MovieResource) as any;
@@ -515,9 +501,7 @@ describe('LoginComponent', () => {
   it('should alert success after login', () => {
     // arrange
     const username = fixture.debugElement.query(By.css('input:first-child'));
-    const password = fixture.debugElement.query(
-      By.css('input[type="password"]')
-    );
+    const password = fixture.debugElement.query(By.css('input[type="password"]'));
     const btn = fixture.debugElement.query(By.css('button'));
     const alertSpy = jest.spyOn(documentMock.defaultView, 'alert');
     username.nativeElement.value = 'user';
@@ -558,10 +542,7 @@ describe('MovieService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        MovieService,
-        { provide: MovieResource, useClass: MovieResourceMock },
-      ],
+      providers: [MovieService, { provide: MovieResource, useClass: MovieResourceMock }],
     }).compileComponents();
     service = TestBed.inject(MovieService);
     resource = TestBed.inject(MovieResource);
@@ -601,9 +582,7 @@ describe('GreetComponent', () => {
     const div = fixture.debugElement.query(By.css('div'));
     input.nativeElement.value = 'me';
     // act
-    (input.nativeElement as HTMLInputElement).dispatchEvent(
-      new InputEvent('input')
-    );
+    (input.nativeElement as HTMLInputElement).dispatchEvent(new InputEvent('input'));
     fixture.detectChanges();
     // assert
     expect(div.nativeElement.textContent.trim()).toBe('Hello me');

--- a/apps/docs/docs/state/getting-started.mdx
+++ b/apps/docs/docs/state/getting-started.mdx
@@ -1,14 +1,13 @@
 ---
-sidebar_label: Setup
+sidebar_label: Getting Started
 sidebar_position: 2
-title: Setup
-# Renamed from libs/state/docs/usage.md
+title: Getting Started
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Basic Setup
+## Create a State Instance
 
 The new functional creation API lets you create and configure `RxState` in only one place.
 
@@ -113,8 +112,8 @@ export class MovieListComponent {
         // start with loading true
         startWith({ loading: true }),
         // when request completes, we can set loading to false
-        endWith({ loading: false })
-      )
+        endWith({ loading: false }),
+      ),
     );
   });
 
@@ -301,9 +300,7 @@ export class MovieListComponent {
     // use the oldState and the searchInput to calculate the new state
     //highlight-start
     connect('movies', this.search.valueChanges, (oldState, searchInput) => {
-      return oldState.movies.filter((movie) =>
-        movie.title.includes(searchInput)
-      );
+      return oldState.movies.filter((movie) => movie.title.includes(searchInput));
     });
     //highlight-end
   });
@@ -339,27 +336,22 @@ export class MovieListComponent {
 
   search = new FormControl<string>();
 
-  private state = rxState<{ movies: Movie[]; searchValue: string }>(
-    ({ set, connect }) => {
-      // set initial state
-      set({ movies: [], searchValue: string });
-      // connect global state to your local state
-      connect('movies', this.store.select('movies'));
+  private state = rxState<{ movies: Movie[]; searchValue: string }>(({ set, connect }) => {
+    // set initial state
+    set({ movies: [], searchValue: string });
+    // connect global state to your local state
+    connect('movies', this.store.select('movies'));
 
-      // use the oldState and the searchInput to calculate the new state
-      //highlight-next-line
-      connect('searchValue', this.search.valueChanges);
-    }
-  );
+    // use the oldState and the searchInput to calculate the new state
+    //highlight-next-line
+    connect('searchValue', this.search.valueChanges);
+  });
 
   // derive filteredMovies$ from your stored state as an observable
   //highlight-next-line
-  filteredMovies$ = this.state.select(
-    ['movies', 'searchValue'],
-    (movies, searchValue) => {
-      return movies.filter((movie) => movie.title.includes(searchValue));
-    }
-  ); // Observable<Movie[]>
+  filteredMovies$ = this.state.select(['movies', 'searchValue'], (movies, searchValue) => {
+    return movies.filter((movie) => movie.title.includes(searchValue));
+  }); // Observable<Movie[]>
 
   // derive filteredMovies from your stored state as a signal
   //highlight-next-line
@@ -372,7 +364,7 @@ export class MovieListComponent {
   filteredMovies = this.state.computedFrom(
     select('searchValue'),
     switchMap((searchValue) => this.movieResource.fetchMovies(searchValue)),
-    startWith([] as Movie[]) // needed as the initial value otherwise it will throw an error
+    startWith([] as Movie[]), // needed as the initial value otherwise it will throw an error
   ); // Signal<Movie[]>
 }
 ```
@@ -389,7 +381,7 @@ import { rxState } from '@rx-angular/state';
 export class MovieService {
   private resource = inject(MovieResource);
 
-  private state = rxState<{ movies: Movie[] }>(({ set, connect }) => {
+  readonly state = rxState<{ movies: Movie[] }>(({ set, connect }) => {
     // set initial state
     set({ movies: [] });
     // connect global state to your local state
@@ -401,12 +393,32 @@ export class MovieService {
 
   // select a property for the template to consume as a signal
   movies = this.state.signal('movies'); // Signal<Movie[]>
+}
+```
 
-  // expose the select method
-  select: typeof this.state.select = this.state.select.bind(this.state);
+## expose readOnly rxState from a Service
 
-  // expose the signal method
-  signal: typeof this.state.signal = this.state.signal.bind(this.state);
+If you only want to expose your `RxState` instance as a readonly state, you can use the new `asReadOnly()` function.
+This allows you to only expose APIs that allows consumers to read from your state. Write access remains private to the
+owner of the `RxState` instance.
+
+```typescript
+import { inject, Injectable } from '@angular/core';
+import { rxState } from '@rx-angular/state';
+
+@Injectable({ providedIn: 'root' })
+export class MovieService {
+  private resource = inject(MovieResource);
+
+  private readonly _state = rxState<{ movies: Movie[] }>(({ set, connect }) => {
+    // set initial state
+    set({ movies: [] });
+    // connect global state to your local state
+    connect('movies', this.resource.fetchMovies());
+  });
+
+  // consumers can use `get`, `select`, `signal` and `compute`
+  readonly state = this._state.asReadOnly();
 }
 ```
 
@@ -449,19 +461,116 @@ export class MovieListComponent {
 }
 ```
 
-## Custom state accumulation (mutability)
+## Configuration
+
+There are a couple of settings you can adjust when using `RxState`.
+
+### provideRxStateConfig
+
+Configurations for `RxState` instances are provided in the DI tree by using the `provideRxStateConfig` provider function.
+
+```typescript title="main.ts"
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { provideRxStateConfig } from '@rx-angular/state';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRxStateConfig(),
+    /* define features here */
+  ],
+});
+```
+
+### Scheduler
+
+By default, `RxState` observes changes and computes new states on the [`queueScheduler`](https://rxjs.dev/api/index/const/queueScheduler). You can modify
+this behavior by using the `withScheduler()` or `withSyncScheduler()` configuration features.
+
+The most applicable use case will be to have sync scheduling:
+
+```typescript title="main.ts"
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { provideRxStateConfig, withSyncScheduler } from '@rx-angular/state';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideRxStateConfig(withSyncScheduler())],
+});
+```
+
+It is however also possible to define whatever `SchedulerLike` you want, e.g. make your state asynchronous by using the `asapScheduler`.
+
+```typescript title="main.ts"
+import { bootstrapApplication } from '@angular/platform-browser';
+import { asapScheduler } from 'rxjs';
+import { AppComponent } from './app.component';
+import { provideRxStateConfig, withScheduler } from '@rx-angular/state';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRxStateConfig(
+      /* use the asapScheduler to new states -> makes the state async! */
+      withScheduler(asapScheduler),
+    ),
+  ],
+});
+```
+
+### Accumulator
+
+The accumulator defines how state transitions from change to change and how slices are integrated into the state.
+
+By default, `RxState` operators immutable on the top level of the state. Deeply nested objects are shallow cloned on state changes.
+In order to adjust this behavior or add new functionality, you can define your own `AccumulatorFn`. This enables you to e.g. integrate an `immer` based
+state management.
 
 The `AccumulationFn` is a function that runs on every state change and is responsible for building a new state from a given input.
 By default it merges together the state by spreading it - producing a new object on every change.
 
-```typescript
-const defaultAccumulator: AccumulationFn = <T>(
-  state: T,
-  slice: Partial<T>
-): T => {
+```typescript title="default-accumulator.ts"
+import { AccumulationFn } from '@rx-angular/state/selections';
+
+const defaultAccumulator: AccumulationFn = <T>(state: T, slice: Partial<T>): T => {
   return { ...state, ...slice };
 };
 ```
+
+#### withAccumulator
+
+Use the `withAccumulator` configuration feature to set a custom `AccumulatorFn` via the DI tree.
+
+```typescript title="main.ts"
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { provideRxStateConfig, withAccumulator } from '@rx-angular/state';
+
+import { produce } from 'immer';
+
+const immerAccumulator = (state, slice) =>
+  produce(state, (draft) => {
+    Object.keys(slice).forEach((k) => {
+      draft[k] = slice[k];
+    });
+  });
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRxStateConfig(
+      /* use the asapScheduler to new states -> makes the state async! */
+      withAccumulator(immerAccumulator),
+    ),
+  ],
+});
+```
+
+#### (deprecated) Custom state accumulation (mutability)
+
+:::warning deprecated
+
+The `setAccumulator` API is deprecated in favor of the `withAccumulator` configuration feature
+
+:::
 
 Use `setAccumulator` to change that behavior. This way you could e.g. introduce `immer` as your accumulation to have
 full immutability.
@@ -483,8 +592,7 @@ state = rxState(({ setAccumulator }) => setAccumulator(immerAccumulator));
 Or you can use any other custom deep-copying algorithm or simply go fully mutable.
 
 ```typescript
-const myAccumulator = (state: MyState, slice: Partial<MyState>) =>
-  deepCopy(state, slice);
+const myAccumulator = (state: MyState, slice: Partial<MyState>) => deepCopy(state, slice);
 state.setAccumulator(myAccumulator);
 ```
 
@@ -578,10 +686,7 @@ import { Component } from '@angular/core';
 import { Subject } from 'rxjs';
 
 @Component({
-  template: `<movie
-    (click)="deleteClick$.next(item.id)"
-    *rxFor="let item of items$"
-  />`,
+  template: `<movie (click)="deleteClick$.next(item.id)" *rxFor="let item of items$" />`,
   providers: [RxState],
 })
 export class MovieListComponent {
@@ -591,11 +696,9 @@ export class MovieListComponent {
 
   constructor(
     private state: RxState<{ movies: Movie[] }>,
-    private movieResource: MovieResource
+    private movieResource: MovieResource,
   ) {
-    this.state.hold(
-      this.deleteClick$.pipe(concatMap((id) => this.movieResource.delete(id)))
-    );
+    this.state.hold(this.deleteClick$.pipe(concatMap((id) => this.movieResource.delete(id))));
   }
 }
 ```

--- a/apps/docs/docs/state/getting-started.mdx
+++ b/apps/docs/docs/state/getting-started.mdx
@@ -487,7 +487,42 @@ bootstrapApplication(AppComponent, {
 By default, `RxState` observes changes and computes new states on the [`queueScheduler`](https://rxjs.dev/api/index/const/queueScheduler). You can modify
 this behavior by using the `withScheduler()` or `withSyncScheduler()` configuration features.
 
-The most applicable use case will be to have sync scheduling:
+The `queueScheduler` provides a certain level of integrity, as state mutations that cause other state mutations are executed in the right order.
+
+:::note queueScheduler
+
+When used without delay, it schedules given task synchronously - executes it right when it is scheduled.
+However when called recursively, that is when inside the scheduled task, another task is scheduled with queue scheduler,
+instead of executing immediately as well, that task will be put on a queue and wait for current one to finish.
+
+This means that when you execute task with queue scheduler, you are sure it will end before any other task scheduled with that scheduler will start.
+
+src: (https://rxjs.dev/api/index/const/queueScheduler)
+
+:::
+
+This means, it is possible that u run into the situation where you mutate the state, but isn't synchronous.
+
+See the following very simplified example:
+
+```typescript title="queue-scheduler.example.ts"
+import { rxState } from '@rx-angular/state';
+
+const state = rxState<{ foo: string; bar: string }>();
+
+state.set(() => {
+  // will execute after the { bar: 'bar' } was set
+  state.set('foo', 'foo');
+  console.log(state.get('foo')); // prints undefined
+
+  // will execute first
+  return {
+    bar: 'bar',
+  };
+});
+```
+
+In order to escape this behavior, you can define the scheduling to be fully synchronous:
 
 ```typescript title="main.ts"
 import { bootstrapApplication } from '@angular/platform-browser';

--- a/libs/state/selections/spec/accumulation-observable.spec.ts
+++ b/libs/state/selections/spec/accumulation-observable.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import {
+  ACCUMULATOR_FN_TOKEN,
   createAccumulationObservable,
   select,
 } from '@rx-angular/state/selections';
@@ -40,6 +41,20 @@ describe('createAccumulationObservable', () => {
     testBed.runInInjectionContext(() => {
       const acc = createAccumulationObservable();
       expect(acc).toBeDefined();
+    });
+  });
+
+  it('should use custom accumulator function', () => {
+    const accumulatorSpy = jest.fn((s, sl) => ({ ...s, ...sl }));
+    testBed.overrideProvider(ACCUMULATOR_FN_TOKEN, {
+      useValue: accumulatorSpy,
+    });
+    testBed.runInInjectionContext(() => {
+      const state = createAccumulationObservable<PrimitiveState>();
+      state.subscribe();
+
+      state.nextSlice({ num: 42 });
+      expect(accumulatorSpy).toHaveBeenCalled();
     });
   });
 

--- a/libs/state/selections/spec/accumulation-observable.spec.ts
+++ b/libs/state/selections/spec/accumulation-observable.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import {
-  ACCUMULATOR_FN_TOKEN,
+  RX_ACCUMULATOR_FN,
   createAccumulationObservable,
   select,
 } from '@rx-angular/state/selections';
@@ -46,7 +46,7 @@ describe('createAccumulationObservable', () => {
 
   it('should use custom accumulator function', () => {
     const accumulatorSpy = jest.fn((s, sl) => ({ ...s, ...sl }));
-    testBed.overrideProvider(ACCUMULATOR_FN_TOKEN, {
+    testBed.overrideProvider(RX_ACCUMULATOR_FN, {
       useValue: accumulatorSpy,
     });
     testBed.runInInjectionContext(() => {

--- a/libs/state/selections/spec/accumulation-observable.spec.ts
+++ b/libs/state/selections/spec/accumulation-observable.spec.ts
@@ -1,17 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import {
-  RX_ACCUMULATOR_FN,
-  createAccumulationObservable,
-  select,
-} from '@rx-angular/state/selections';
-import {
-  PrimitiveState,
   initialPrimitiveState,
   jestMatcher,
+  PrimitiveState,
 } from '@test-helpers/rx-angular';
 import { of, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
+import {
+  createAccumulationObservable,
+  RX_ACCUMULATOR_FN,
+} from '../src/lib/accumulation-observable';
+import { select } from '../src/lib/operators';
 
 function setupAccumulationObservable<T extends object>(cfg: {
   initialState?: T;

--- a/libs/state/selections/spec/accumulation-observable.spec.ts
+++ b/libs/state/selections/spec/accumulation-observable.spec.ts
@@ -1,13 +1,16 @@
-import { jestMatcher } from '@test-helpers/rx-angular';
+import { TestBed } from '@angular/core/testing';
 import {
-  initialPrimitiveState,
+  createAccumulationObservable,
+  select,
+} from '@rx-angular/state/selections';
+import {
   PrimitiveState,
+  initialPrimitiveState,
+  jestMatcher,
 } from '@test-helpers/rx-angular';
 import { of, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { select } from '../src';
-import { createAccumulationObservable } from '../src/lib/accumulation-observable';
 
 function setupAccumulationObservable<T extends object>(cfg: {
   initialState?: T;
@@ -24,165 +27,199 @@ function setupAccumulationObservable<T extends object>(cfg: {
   return acc;
 }
 
+let testBed: TestBed;
 let testScheduler: TestScheduler;
 
 beforeEach(() => {
+  testBed = TestBed.configureTestingModule({});
   testScheduler = new TestScheduler(jestMatcher);
 });
 
 describe('createAccumulationObservable', () => {
   it('should return object', () => {
-    const acc = createAccumulationObservable();
-    expect(acc).toBeDefined();
+    testBed.runInInjectionContext(() => {
+      const acc = createAccumulationObservable();
+      expect(acc).toBeDefined();
+    });
   });
 
   describe('signal$', () => {
     it('should return NO empty base-state after init when subscribing late', () => {
       testScheduler.run(({ expectObservable }) => {
-        const state = setupAccumulationObservable({});
-        expectObservable(state.signal$).toBe('');
+        testBed.runInInjectionContext(() => {
+          const state = setupAccumulationObservable({});
+          expectObservable(state.signal$).toBe('');
+        });
       });
     });
 
     it('should return No changes when subscribing late', () => {
       testScheduler.run(({ expectObservable }) => {
-        const state = setupAccumulationObservable<PrimitiveState>({});
-        state.subscribe();
+        testBed.runInInjectionContext(() => {
+          const state = setupAccumulationObservable<PrimitiveState>({});
+          state.subscribe();
 
-        state.nextSlice({ num: 42 });
-        expectObservable(state.signal$.pipe(map((s) => s.num))).toBe('');
+          state.nextSlice({ num: 42 });
+          expectObservable(state.signal$.pipe(map((s) => s.num))).toBe('');
+        });
       });
     });
 
     it('should return changes after subscription', () => {
-      const state = setupAccumulationObservable<PrimitiveState>({});
-      state.subscribe();
-      state.nextSlice({ num: 42 });
-      const slice$ = state.signal$.pipe(select('num'));
+      testBed.runInInjectionContext(() => {
+        const state = setupAccumulationObservable<PrimitiveState>({});
+        state.subscribe();
+        state.nextSlice({ num: 42 });
+        const slice$ = state.signal$.pipe(select('num'));
 
-      let i = -1;
-      const valuesInOrder = ['', { num: 777 }];
-      slice$.subscribe((next) => expect(next).toBe(valuesInOrder[++i]));
-      state.nextSlice({ num: 777 });
+        let i = -1;
+        const valuesInOrder = ['', { num: 777 }];
+        slice$.subscribe((next) => expect(next).toBe(valuesInOrder[++i]));
+        state.nextSlice({ num: 777 });
+      });
     });
 
     it('should log error if getting error', () => {
-      const spy = jest.spyOn(console, 'error').mockImplementation();
-      const state = setupAccumulationObservable<PrimitiveState>({});
-      state.nextSliceObservable(throwError('test') as any);
-      state.subscribe();
+      testBed.runInInjectionContext(() => {
+        const spy = jest.spyOn(console, 'error').mockImplementation();
+        const state = setupAccumulationObservable<PrimitiveState>({});
+        state.nextSliceObservable(throwError('test') as any);
+        state.subscribe();
 
-      expect(spy).toBeCalled();
+        expect(spy).toBeCalled();
+      });
     });
   });
 
   describe('state$', () => {
     it('should return nothing without subscriber', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = setupAccumulationObservable<PrimitiveState>({
-          initialState: initialPrimitiveState,
-          initialize: false,
+        testBed.runInInjectionContext(() => {
+          const acc = setupAccumulationObservable<PrimitiveState>({
+            initialState: initialPrimitiveState,
+            initialize: false,
+          });
+          expectObservable(acc.state$).toBe('');
         });
-        expectObservable(acc.state$).toBe('');
       });
     });
 
     it('should return nothing after init', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = setupAccumulationObservable<PrimitiveState>({
-          initialize: true,
+        testBed.runInInjectionContext(() => {
+          const acc = setupAccumulationObservable<PrimitiveState>({
+            initialize: true,
+          });
+          expectObservable(acc.state$).toBe('');
         });
-        expectObservable(acc.state$).toBe('');
       });
     });
 
     it('should return initial base-state', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = setupAccumulationObservable<PrimitiveState>({
-          initialState: initialPrimitiveState,
+        testBed.runInInjectionContext(() => {
+          const acc = setupAccumulationObservable<PrimitiveState>({
+            initialState: initialPrimitiveState,
+          });
+          expectObservable(acc.state$).toBe('s', { s: initialPrimitiveState });
         });
-        expectObservable(acc.state$).toBe('s', { s: initialPrimitiveState });
       });
     });
   });
 
   describe('state', () => {
     it('should return {} without subscriber', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialize: false,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialize: false,
+        });
+        expect(acc.state).toStrictEqual({});
       });
-      expect(acc.state).toStrictEqual({});
     });
 
     it('should return {} with subscriber', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialize: true,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialize: true,
+        });
+        expect(acc.state).toStrictEqual({});
       });
-      expect(acc.state).toStrictEqual({});
     });
 
     it('should return {} after init', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialize: true,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialize: true,
+        });
+        expect(acc.state).toStrictEqual({});
       });
-      expect(acc.state).toStrictEqual({});
     });
 
     it('should return initial base-state', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialState: initialPrimitiveState,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialState: initialPrimitiveState,
+        });
+        expect(acc.state).toEqual(initialPrimitiveState);
       });
-      expect(acc.state).toEqual(initialPrimitiveState);
     });
   });
 
   describe('nextSlice', () => {
     it('should add new base-state by partial', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = setupAccumulationObservable<PrimitiveState>({});
-        acc.nextSlice({ num: 42 });
-        expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('s', {
-          s: 42,
+        testBed.runInInjectionContext(() => {
+          const acc = setupAccumulationObservable<PrimitiveState>({});
+          acc.nextSlice({ num: 42 });
+          expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('s', {
+            s: 42,
+          });
         });
       });
     });
 
     it('should override previous base-state by partial', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialState: initialPrimitiveState,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialState: initialPrimitiveState,
+        });
+        acc.state$
+          .pipe(map((s) => s.num))
+          .subscribe((res) => expect(res).toBe({ s: 42 }));
+        acc.nextSlice({ num: 43 });
+        acc.state$
+          .pipe(map((s) => s.num))
+          .subscribe((res) => expect(res).toBe({ s: 43 }));
       });
-      acc.state$
-        .pipe(map((s) => s.num))
-        .subscribe((res) => expect(res).toBe({ s: 42 }));
-      acc.nextSlice({ num: 43 });
-      acc.state$
-        .pipe(map((s) => s.num))
-        .subscribe((res) => expect(res).toBe({ s: 43 }));
     });
   });
 
   describe('connectState', () => {
     it('should add new slices', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = setupAccumulationObservable<PrimitiveState>({});
-        acc.nextSliceObservable(of({ num: 42 }));
-        expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('s', {
-          s: 42,
+        testBed.runInInjectionContext(() => {
+          const acc = setupAccumulationObservable<PrimitiveState>({});
+          acc.nextSliceObservable(of({ num: 42 }));
+          expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('s', {
+            s: 42,
+          });
         });
       });
     });
 
     it('should override previous base-state slices', () => {
-      const acc = setupAccumulationObservable<PrimitiveState>({
-        initialState: initialPrimitiveState,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({
+          initialState: initialPrimitiveState,
+        });
+        acc.state$
+          .pipe(map((s) => s.num))
+          .subscribe((res) => expect(res).toBe({ s: 42 }));
+        acc.nextSliceObservable(of({ num: 43 }));
+        acc.state$
+          .pipe(map((s) => s.num))
+          .subscribe((res) => expect(res).toBe({ s: 42 }));
       });
-      acc.state$
-        .pipe(map((s) => s.num))
-        .subscribe((res) => expect(res).toBe({ s: 42 }));
-      acc.nextSliceObservable(of({ num: 43 }));
-      acc.state$
-        .pipe(map((s) => s.num))
-        .subscribe((res) => expect(res).toBe({ s: 42 }));
     });
   });
 
@@ -196,19 +233,21 @@ describe('createAccumulationObservable', () => {
           ...sl,
         };
       };
-      const acc = setupAccumulationObservable<PrimitiveState>({});
-      testScheduler.run(({ expectObservable }) => {
-        acc.nextSlice({ num: 42 });
-        expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('(a)', {
-          a: 44,
+      testBed.runInInjectionContext(() => {
+        const acc = setupAccumulationObservable<PrimitiveState>({});
+        testScheduler.run(({ expectObservable }) => {
+          acc.nextSlice({ num: 42 });
+          expectObservable(acc.state$.pipe(map((s) => s.num))).toBe('(a)', {
+            a: 44,
+          });
+
+          acc.nextAccumulator(customAcc);
+          acc.nextSlice({ num: 43 });
+          acc.nextSlice({ num: 44 });
         });
 
-        acc.nextAccumulator(customAcc);
-        acc.nextSlice({ num: 43 });
-        acc.nextSlice({ num: 44 });
+        expect(numAccCalls).toBe(2);
       });
-
-      expect(numAccCalls).toBe(2);
     });
   });
 
@@ -217,25 +256,29 @@ describe('createAccumulationObservable', () => {
     // the latest value emitted
     xit('should stop on unsubscribe from state', () => {
       testScheduler.run(({ expectObservable }) => {
-        const acc = createAccumulationObservable<PrimitiveState>();
-        const sub = acc.subscribe();
-        acc.nextSlice(initialPrimitiveState);
-        sub.unsubscribe();
-        expectObservable(acc.state$).toBe('');
+        testBed.runInInjectionContext(() => {
+          const acc = createAccumulationObservable<PrimitiveState>();
+          const sub = acc.subscribe();
+          acc.nextSlice(initialPrimitiveState);
+          sub.unsubscribe();
+          expectObservable(acc.state$).toBe('');
+        });
       });
     });
 
     it('should stop from connect observable', () => {
       testScheduler.run(({ expectObservable, hot, expectSubscriptions }) => {
-        const acc = createAccumulationObservable<PrimitiveState>();
-        const sub = acc.subscribe();
-        const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
-        const interval$ = tick$.pipe(map((num) => ({ num })));
-        const subs = '(^!)';
-        acc.nextSliceObservable(interval$);
-        sub.unsubscribe();
-        expectObservable(acc.state$).toBe('');
-        expectSubscriptions(tick$.subscriptions).toBe(subs);
+        testBed.runInInjectionContext(() => {
+          const acc = createAccumulationObservable<PrimitiveState>();
+          const sub = acc.subscribe();
+          const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
+          const interval$ = tick$.pipe(map((num) => ({ num })));
+          const subs = '(^!)';
+          acc.nextSliceObservable(interval$);
+          sub.unsubscribe();
+          expectObservable(acc.state$).toBe('');
+          expectSubscriptions(tick$.subscriptions).toBe(subs);
+        });
       });
     });
   });

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -1,4 +1,7 @@
-export { createAccumulationObservable } from './lib/accumulation-observable';
+export {
+  createAccumulationObservable,
+  ACCUMULATOR_FN_TOKEN,
+} from './lib/accumulation-observable';
 export { CompareFn, KeyCompareMap, PickSlice } from './lib/interfaces/index';
 export { AccumulationFn, Accumulator } from './lib/model';
 export {

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -1,6 +1,6 @@
 export {
   createAccumulationObservable,
-  ACCUMULATOR_FN_TOKEN,
+  RX_ACCUMULATOR_FN,
 } from './lib/accumulation-observable';
 export { CompareFn, KeyCompareMap, PickSlice } from './lib/interfaces/index';
 export { AccumulationFn, Accumulator } from './lib/model';

--- a/libs/state/selections/src/index.ts
+++ b/libs/state/selections/src/index.ts
@@ -1,6 +1,6 @@
 export {
   createAccumulationObservable,
-  RX_ACCUMULATOR_FN,
+  defaultAccumulator,
 } from './lib/accumulation-observable';
 export { CompareFn, KeyCompareMap, PickSlice } from './lib/interfaces/index';
 export { AccumulationFn, Accumulator } from './lib/model';
@@ -9,7 +9,7 @@ export {
   select,
   selectSlice,
   stateful,
-} from './lib/operators/index';
+} from './lib/operators';
 export { createSideEffectObservable } from './lib/side-effect-observable';
 export {
   isDefined,

--- a/libs/state/selections/src/lib/accumulation-observable.ts
+++ b/libs/state/selections/src/lib/accumulation-observable.ts
@@ -32,13 +32,13 @@ const defaultAccumulator: AccumulationFn = <T>(st: T, sl: Partial<T>): T => {
  * @example
  * providers: [
  *  {
- *   provide: ACCUMULATOR_FN_TOKEN,
+ *   provide: RX_ACCUMULATOR_FN,
  *   useValue: (state, slice) => ({ ...state, ...slice })
  *  }
  * ]
  */
-export const ACCUMULATOR_FN_TOKEN = new InjectionToken<AccumulationFn>(
-  'ACCUMULATOR_FN',
+export const RX_ACCUMULATOR_FN = new InjectionToken<AccumulationFn>(
+  'RX_ACCUMULATOR_FN',
   {
     factory: () => defaultAccumulator,
   }
@@ -48,7 +48,7 @@ export function createAccumulationObservable<T extends object>(
   stateObservables = new Subject<Observable<Partial<T>>>(),
   stateSlices = new Subject<Partial<T>>()
 ): Accumulator<T> {
-  const accumulatorFn = inject(ACCUMULATOR_FN_TOKEN);
+  const accumulatorFn = inject(RX_ACCUMULATOR_FN);
   const accumulatorObservable = new BehaviorSubject(accumulatorFn);
   const signal$ = merge(
     stateObservables.pipe(

--- a/libs/state/selections/src/lib/side-effect-observable.ts
+++ b/libs/state/selections/src/lib/side-effect-observable.ts
@@ -1,15 +1,27 @@
-import { merge, Observable, queueScheduler, Subject, Subscribable, Subscription } from 'rxjs';
+import {
+  merge,
+  Observable,
+  queueScheduler,
+  SchedulerLike,
+  Subject,
+  Subscribable,
+  Subscription,
+} from 'rxjs';
 import { mergeAll, observeOn } from 'rxjs/operators';
 
 export function createSideEffectObservable<T>(
-  stateObservables = new Subject<Observable<T>>()
+  stateObservables = new Subject<Observable<T>>(),
+  scheduler: SchedulerLike | null = queueScheduler,
 ): {
   effects$: Observable<T>;
   nextEffectObservable: (effect$: Observable<T>) => void;
   subscribe: () => Subscription;
 } & Subscribable<T> {
   const effects$: Observable<T> = merge(
-    stateObservables.pipe(mergeAll(), observeOn(queueScheduler))
+    stateObservables.pipe(
+      mergeAll(),
+      scheduler ? observeOn(scheduler) : (o$) => o$,
+    ),
   );
 
   function nextEffectObservable(effect$: Observable<T>): void {
@@ -23,6 +35,6 @@ export function createSideEffectObservable<T>(
   return {
     effects$,
     nextEffectObservable,
-    subscribe
+    subscribe,
   };
 }

--- a/libs/state/src/index.ts
+++ b/libs/state/src/index.ts
@@ -1,3 +1,11 @@
+export {
+  provideRxStateConfig,
+  RX_ACCUMULATOR_FN,
+  RX_STATE_SCHEDULER,
+  withAccumulatorFn,
+  withScheduler,
+  withSyncScheduler,
+} from './lib/provide-rx-state-config';
 export { rxState, RxStateSetupFn } from './lib/rx-state';
 export {
   ProjectStateFn,

--- a/libs/state/src/lib/provide-rx-state-config.ts
+++ b/libs/state/src/lib/provide-rx-state-config.ts
@@ -1,5 +1,9 @@
 import { InjectionToken, Provider } from '@angular/core';
-import { AccumulationFn, RX_ACCUMULATOR_FN } from '../../selections/src';
+import {
+  AccumulationFn,
+  defaultAccumulator,
+} from '@rx-angular/state/selections';
+import { queueScheduler, SchedulerLike } from 'rxjs';
 
 export const enum RX_STATE_CONFIGS {
   Scheduler,
@@ -13,6 +17,25 @@ interface RxStateConfigFn {
 
 /**
  * Injection token for the default accumulator function.
+ *
+ * @example
+ * providers: [
+ *  {
+ *   provide: RX_ACCUMULATOR_FN,
+ *   useValue: (state, slice) => ({ ...state, ...slice })
+ *  }
+ * ]
+ */
+export const RX_ACCUMULATOR_FN = new InjectionToken<AccumulationFn>(
+  'RX_ACCUMULATOR_FN',
+  {
+    providedIn: 'root',
+    factory: () => defaultAccumulator,
+  },
+);
+
+/**
+ * Injection token for the default accumulator function.
  * @param fn
  */
 export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
@@ -22,11 +45,11 @@ export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
   };
 }
 
-export const RX_STATE_SCHEDULER = new InjectionToken<any>(
+export const RX_STATE_SCHEDULER = new InjectionToken<SchedulerLike | 'sync'>(
   'RX_STATE_SCHEDULER',
   {
     providedIn: 'root',
-    factory: () => undefined,
+    factory: () => queueScheduler,
   },
 );
 
@@ -35,11 +58,22 @@ export const RX_STATE_SCHEDULER = new InjectionToken<any>(
  * @param fn
  */
 export function withScheduler(
-  scheduler: any /* TODO: add type here*/,
+  scheduler: SchedulerLike | 'sync',
 ): RxStateConfigFn {
   return {
     kind: RX_STATE_CONFIGS.Scheduler,
     providers: [{ provide: RX_STATE_SCHEDULER, useValue: scheduler }],
+  };
+}
+
+/**
+ * Injection token for the default scheduler for rxState.
+ * @param fn
+ */
+export function withSyncScheduler(): RxStateConfigFn {
+  return {
+    kind: RX_STATE_CONFIGS.Scheduler,
+    providers: [{ provide: RX_STATE_SCHEDULER, useValue: 'sync' }],
   };
 }
 

--- a/libs/state/src/lib/provide-rx-state-config.ts
+++ b/libs/state/src/lib/provide-rx-state-config.ts
@@ -32,7 +32,7 @@ export const RX_ACCUMULATOR_FN = new InjectionToken<AccumulationFn>(
 );
 
 /**
- * Injection token for the default accumulator function.
+ * Provider function to specify a custom `AccumulationFn` for `RxState` to use.
  * @param fn
  */
 export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
@@ -42,6 +42,17 @@ export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
   };
 }
 
+/**
+ * Injection token for the default state scheduler
+ *
+ * @example
+ * providers: [
+ *  {
+ *   provide: RX_STATE_SCHEDULER,
+ *   useValue: asapScheduler
+ *  }
+ * ]
+ */
 export const RX_STATE_SCHEDULER = new InjectionToken<SchedulerLike | 'sync'>(
   'RX_STATE_SCHEDULER',
   {
@@ -51,7 +62,7 @@ export const RX_STATE_SCHEDULER = new InjectionToken<SchedulerLike | 'sync'>(
 );
 
 /**
- * Injection token for the default scheduler for rxState.
+ * Provider function to specify a scheduler for `RxState` to perform state updates & emit new values.
  * @param scheduler
  */
 export function withScheduler(
@@ -64,8 +75,8 @@ export function withScheduler(
 }
 
 /**
- * Injection token for the default scheduler for rxState.
- * @param fn
+ * Provider function to specify synchronous (no) scheduling for `RxState`. The state computations
+ * will be fully synchronous instead of using the default `queueScheduler`
  */
 export function withSyncScheduler(): RxStateConfigFn {
   return {

--- a/libs/state/src/lib/provide-rx-state-config.ts
+++ b/libs/state/src/lib/provide-rx-state-config.ts
@@ -5,10 +5,7 @@ import {
 } from '@rx-angular/state/selections';
 import { queueScheduler, SchedulerLike } from 'rxjs';
 
-export const enum RX_STATE_CONFIGS {
-  Scheduler,
-  Accumulator,
-}
+export type RX_STATE_CONFIGS = 'Accumulator' | 'Scheduler';
 
 interface RxStateConfigFn {
   kind: RX_STATE_CONFIGS;
@@ -40,7 +37,7 @@ export const RX_ACCUMULATOR_FN = new InjectionToken<AccumulationFn>(
  */
 export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
   return {
-    kind: RX_STATE_CONFIGS.Accumulator,
+    kind: 'Accumulator',
     providers: [{ provide: RX_ACCUMULATOR_FN, useValue: fn }],
   };
 }
@@ -61,7 +58,7 @@ export function withScheduler(
   scheduler: SchedulerLike | 'sync',
 ): RxStateConfigFn {
   return {
-    kind: RX_STATE_CONFIGS.Scheduler,
+    kind: 'Scheduler',
     providers: [{ provide: RX_STATE_SCHEDULER, useValue: scheduler }],
   };
 }
@@ -72,7 +69,7 @@ export function withScheduler(
  */
 export function withSyncScheduler(): RxStateConfigFn {
   return {
-    kind: RX_STATE_CONFIGS.Scheduler,
+    kind: 'Scheduler',
     providers: [{ provide: RX_STATE_SCHEDULER, useValue: 'sync' }],
   };
 }

--- a/libs/state/src/lib/provide-rx-state-config.ts
+++ b/libs/state/src/lib/provide-rx-state-config.ts
@@ -1,0 +1,64 @@
+import { InjectionToken, Provider } from '@angular/core';
+import { AccumulationFn, RX_ACCUMULATOR_FN } from '../../selections/src';
+
+export const enum RX_STATE_CONFIGS {
+  Scheduler,
+  Accumulator,
+}
+
+interface RxStateConfigFn {
+  kind: RX_STATE_CONFIGS;
+  providers: Provider[];
+}
+
+/**
+ * Injection token for the default accumulator function.
+ * @param fn
+ */
+export function withAccumulatorFn(fn: AccumulationFn): RxStateConfigFn {
+  return {
+    kind: RX_STATE_CONFIGS.Accumulator,
+    providers: [{ provide: RX_ACCUMULATOR_FN, useValue: fn }],
+  };
+}
+
+export const RX_STATE_SCHEDULER = new InjectionToken<any>(
+  'RX_STATE_SCHEDULER',
+  {
+    providedIn: 'root',
+    factory: () => undefined,
+  },
+);
+
+/**
+ * Injection token for the default scheduler for rxState.
+ * @param fn
+ */
+export function withScheduler(
+  scheduler: any /* TODO: add type here*/,
+): RxStateConfigFn {
+  return {
+    kind: RX_STATE_CONFIGS.Scheduler,
+    providers: [{ provide: RX_STATE_SCHEDULER, useValue: scheduler }],
+  };
+}
+
+/**
+ * This function is used to provide the configuration for the rxState function.
+ *
+ * You can provide multiple configurations at once.
+ *
+ * You can use these functions to provide the configuration:
+ * - withAccumulatorFn - to provide a custom accumulator function
+ * - withScheduler - to provide a custom scheduler
+ *
+ */
+export function provideRxStateConfig(
+  ...configs: RxStateConfigFn[]
+): Provider[] {
+  return flatten(configs.map((c) => c.providers));
+}
+
+function flatten<T>(arr: T[][]): T[] {
+  return arr.reduce((acc, val) => acc.concat(val), []);
+}

--- a/libs/state/src/lib/provide-rx-state-config.ts
+++ b/libs/state/src/lib/provide-rx-state-config.ts
@@ -55,7 +55,7 @@ export const RX_STATE_SCHEDULER = new InjectionToken<SchedulerLike | 'sync'>(
 
 /**
  * Injection token for the default scheduler for rxState.
- * @param fn
+ * @param scheduler
  */
 export function withScheduler(
   scheduler: SchedulerLike | 'sync',

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -88,7 +88,7 @@ export class RxState<State extends object>
     this.scheduler === 'sync' ? null : this.scheduler,
   );
   private effectObservable = createSideEffectObservable(
-    new Subject<Observable<State>>(),
+    new Subject<Observable<unknown>>(),
     this.scheduler === 'sync' ? null : this.scheduler,
   );
 

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -157,6 +157,10 @@ export class RxState<State extends object>
    *
    * @param {AccumulationFn} accumulatorFn
    * @return void
+   *
+   * @deprecated
+   * Use `provideRxStateConfig` and provide the accumulator with the `withAccumulator` provider function.
+   * Will be removed in future versions.
    */
   setAccumulator(accumulatorFn: AccumulationFn): void {
     this.accumulator.nextAccumulator(accumulatorFn);


### PR DESCRIPTION
Add provider functions to configure state through injection tokens:

- `provideRxStateConfig`
  - `withAccumulator`
  - `withSyncScheduler`
  - `withScheduler`
  
 Usage example:

```ts
bootstrapApplication(AppComponent, {
  providers: [
    provideRxStateConfig(
      withAccumulator(myCustomAccumulator),
      withSyncScheduler(),
    ),
  ],
});
```
  
It also exposes underlying injection tokens: 
 
 - `RX_ACCUMULATOR_FN`
 - `RX_STATE_SCHEDULER`
 
And finally, deprecate `RxState.setAccumulator` function.

closes #1621