### PR TITLE
refactor(state): ensure strong typing for sideEffectFn in ActionEffects

### DIFF
--- a/libs/state/actions/src/lib/types.ts
+++ b/libs/state/actions/src/lib/types.ts
@@ -49,9 +49,9 @@ export type ActionObservables<T extends Actions> = {
 };
 
 export type ActionEffects<T extends Actions, O = T> = {
-  [K in ExtractString<T> as `on${Capitalize<K>}`]: (
-    fn: OperatorFunction<T[K], T[K] | any>,
-    sideEffectFn?: (value: T[K] | any) => void
+  [K in ExtractString<T> as `on${Capitalize<string & K>}`]: <R>(
+    fn: OperatorFunction<T[K], R>,
+    sideEffectFn?: (value: R) => void
   ) => () => void;
 };
 


### PR DESCRIPTION
I'm not sure if this is wanted, however I kept having to type my side effects from the operator. Modified the type locally from NPM package and it solved my issue.  So I thought I'll see if this works for you and not just a local patch file

- Replace 'any' with inferred type from OperatorFunction's return type
- Enhance type safety and consistency across ActionEffects utility