### PR TITLE
refactor(state): simplify connect implementation

### DIFF
--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -434,7 +434,7 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
       const slice$ = keyOrInputOrSlice$.pipe(
         map((v) => projectionStateFn(this.accumulator.state, v as V))
       );
-      this.accumulator.nextSliceObservable(slice$);
+      this.accumulator.nextSliceObservable(slice$ as Observable<V>);
       return;
     }
 
@@ -448,7 +448,7 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
       const slice$ = toObservable(keyOrInputOrSlice$, {
         injector: this.injector,
       }).pipe(map((v) => projectionStateFn(this.accumulator.state, v as V)));
-      this.accumulator.nextSliceObservable(slice$);
+      this.accumulator.nextSliceObservable(slice$ as Observable<V>);
       return;
     }
 

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -414,12 +414,14 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
       !projectValueFn
     ) {
       this.accumulator.nextSliceObservable(keyOrInputOrSlice$);
+      return;
     }
 
     if (isSignal(keyOrInputOrSlice$) && !projectOrSlices$ && !projectValueFn) {
       this.accumulator.nextSliceObservable(
         toObservable(keyOrInputOrSlice$, { injector: this.injector })
       );
+      return;
     }
 
     if (


### PR DESCRIPTION
Simplification and elimination of handling the `connect`-overloads.

for reference: https://github.com/rx-angular/rx-angular/pull/1644#discussion_r1408870876 