### PR TITLE
chore: enable and fix consistent-type-imports rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,9 +47,15 @@
         "plugin:@typescript-eslint/recommended"
       ],
       "parserOptions": {
-        "project": "./tsconfig.*?.json"
+        "project": "tsconfig.base.json"
       },
       "rules": {
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          {
+            "fixStyle": "inline-type-imports"
+          }
+        ],
         "@typescript-eslint/ban-ts-comment": "warn",
         "@typescript-eslint/no-inferrable-types": "warn",
         "@typescript-eslint/ban-types": "warn",

--- a/apps/ssr/src/app/app.component.ts
+++ b/apps/ssr/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { isPlatformServer } from '@angular/common';
-import { Component, Inject, NgZone, OnInit, PLATFORM_ID } from '@angular/core';
+import type { OnInit } from '@angular/core';
+import { Component, Inject, NgZone, PLATFORM_ID } from '@angular/core';
 import { rxState } from '@rx-angular/state';
 import { RxFor } from '@rx-angular/template/for';
 import { RxLet } from '@rx-angular/template/let';

--- a/apps/ssr/src/app/app.config.server.ts
+++ b/apps/ssr/src/app/app.config.server.ts
@@ -1,4 +1,5 @@
-import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import type { ApplicationConfig } from '@angular/core';
+import { mergeApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
 import { appConfig } from './app.config';
 

--- a/apps/ssr/src/app/app.config.ts
+++ b/apps/ssr/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig } from '@angular/core';
+import type { ApplicationConfig } from '@angular/core';
 
 import { provideClientHydration } from '@angular/platform-browser';
 

--- a/libs/cdk/coalescing/src/lib/coalesceWith.ts
+++ b/libs/cdk/coalescing/src/lib/coalesceWith.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   MonoTypeOperatorFunction,
-  Observable,
   Observer,
   Subscriber,
-  Subscription,
   Unsubscribable,
 } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { coalescingManager } from './coalescingManager';
 
 /**

--- a/libs/cdk/coercing/spec/coerce-all-factory.spec.ts
+++ b/libs/cdk/coercing/spec/coerce-all-factory.spec.ts
@@ -1,9 +1,9 @@
+import type { Observable } from 'rxjs';
 import {
   BehaviorSubject,
   concatAll,
   exhaustAll,
   mergeAll,
-  Observable,
   of,
   ReplaySubject,
   Subject,

--- a/libs/cdk/coercing/spec/coerceDistinctObservableWith.spec.ts
+++ b/libs/cdk/coercing/spec/coerceDistinctObservableWith.spec.ts
@@ -1,11 +1,5 @@
-import {
-  concatAll,
-  exhaustAll,
-  mergeAll,
-  Observable,
-  Subject,
-  take,
-} from 'rxjs';
+import type { Observable } from 'rxjs';
+import { concatAll, exhaustAll, mergeAll, Subject, take } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { jestMatcher } from '@test-helpers/rx-angular';

--- a/libs/cdk/coercing/src/lib/coerce-all-factory.ts
+++ b/libs/cdk/coercing/src/lib/coerce-all-factory.ts
@@ -1,4 +1,5 @@
-import { Observable, OperatorFunction, Subject } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
+import { Subject } from 'rxjs';
 import { switchAll } from 'rxjs/operators';
 import { coerceDistinctWith } from './coerceDistinctObservableWith';
 

--- a/libs/cdk/coercing/src/lib/coerceDistinctObservable.ts
+++ b/libs/cdk/coercing/src/lib/coerceDistinctObservable.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
 import { distinctUntilChanged, switchAll } from 'rxjs/operators';
 import { coerceObservable } from './coerceObservable';
 

--- a/libs/cdk/coercing/src/lib/coerceDistinctObservableWith.ts
+++ b/libs/cdk/coercing/src/lib/coerceDistinctObservableWith.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
 import { distinctUntilChanged, switchAll } from 'rxjs/operators';
 import { coerceObservableWith } from './coerceObservableWith';
 

--- a/libs/cdk/coercing/src/lib/coerceObservable.ts
+++ b/libs/cdk/coercing/src/lib/coerceObservable.ts
@@ -1,4 +1,5 @@
-import { isObservable, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { isObservable, of } from 'rxjs';
 
 /**
  * This Observable factory creates an Observable out of a static value or an Observable.

--- a/libs/cdk/coercing/src/lib/coerceObservableWith.ts
+++ b/libs/cdk/coercing/src/lib/coerceObservableWith.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { coerceObservable } from './coerceObservable';
 

--- a/libs/cdk/internals/core/src/lib/accumulateObservables.spec.ts
+++ b/libs/cdk/internals/core/src/lib/accumulateObservables.spec.ts
@@ -1,7 +1,8 @@
 import { TestScheduler } from 'rxjs/testing';
 import { jestMatcher } from '@test-helpers/rx-angular';
 import { coalesceWith } from '@rx-angular/cdk/coalescing';
-import { from, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
 import { accumulateObservables } from './accumulateObservables';
 
 let testScheduler: TestScheduler;

--- a/libs/cdk/internals/core/src/lib/accumulateObservables.ts
+++ b/libs/cdk/internals/core/src/lib/accumulateObservables.ts
@@ -1,7 +1,8 @@
 import { coalesceWith } from '@rx-angular/cdk/coalescing';
-import { combineLatest, from, Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { combineLatest, from } from 'rxjs';
 import { distinctUntilChanged, filter, map, shareReplay } from 'rxjs/operators';
-import {
+import type {
   ArrayReducerFn,
   ExtractObservableValue,
   NotEmpty,
@@ -94,6 +95,6 @@ export function accumulateObservables<T extends ObservableMap & NotEmpty<T>>(
       values.reduce(getEntriesToObjectReducerFn(keys), {} as any)
     ),
     // by using shareReplay we share the last composition work done to create the accumulated object
-    shareReplay({refCount: true, bufferSize: 1})
+    shareReplay({ refCount: true, bufferSize: 1 })
   );
 }

--- a/libs/cdk/internals/core/src/lib/model.ts
+++ b/libs/cdk/internals/core/src/lib/model.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
 /**
  * Type to specify an object of observables

--- a/libs/cdk/internals/core/src/lib/timeout.ts
+++ b/libs/cdk/internals/core/src/lib/timeout.ts
@@ -1,4 +1,5 @@
-import { Observable, Subscriber } from 'rxjs';
+import type { Subscriber } from 'rxjs';
+import { Observable } from 'rxjs';
 import { mapTo, concatMap } from 'rxjs/operators';
 import { getZoneUnPatchedApi } from './get-zone-unpatched-api';
 
@@ -7,11 +8,12 @@ import { getZoneUnPatchedApi } from './get-zone-unpatched-api';
  * The timeout it unpatched to not avoid zone pollution
  * @param setTimeoutFn
  */
-function timeout(
-  delay: number = 0
-) {
+function timeout(delay = 0) {
   return new Observable<number>((subscriber: Subscriber<number>) => {
-    const asyncID = getZoneUnPatchedApi('setTimeout')(() => subscriber.next(0), delay);
+    const asyncID = getZoneUnPatchedApi('setTimeout')(
+      () => subscriber.next(0),
+      delay
+    );
     return () => {
       getZoneUnPatchedApi('clearTimeout')(asyncID);
     };
@@ -22,7 +24,6 @@ function timeout(
  *
  */
 export function timeoutSwitchMapWith<T>() {
-  return (o$: Observable<T>) => o$.pipe(
-    concatMap((v) => timeout().pipe(mapTo(v)))
-  )
+  return (o$: Observable<T>) =>
+    o$.pipe(concatMap((v) => timeout().pipe(mapTo(v))));
 }

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
 // https://github.com/facebook/react/blob/master/packages/scheduler/src/__tests__/SchedulerDOM-test.js
 import { ɵglobal } from '@angular/core';
 

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.ts
@@ -2,13 +2,8 @@
 
 import { ɵglobal } from '@angular/core';
 import { enableIsInputPending } from './schedulerFeatureFlags';
-import {
-  peek,
-  pop,
-  push,
-  ReactSchedulerTask,
-  SchedulerTaskZone,
-} from './schedulerMinHeap';
+import type { ReactSchedulerTask, SchedulerTaskZone } from './schedulerMinHeap';
+import { peek, pop, push } from './schedulerMinHeap';
 
 import { PriorityLevel } from './schedulerPriorities';
 

--- a/libs/cdk/internals/scheduler/src/lib/schedulerMinHeap.ts
+++ b/libs/cdk/internals/scheduler/src/lib/schedulerMinHeap.ts
@@ -1,5 +1,5 @@
 import { NgZone } from '@angular/core';
-import { PriorityLevel } from './schedulerPriorities';
+import type { PriorityLevel } from './schedulerPriorities';
 
 type Heap = Array<ReactSchedulerTask>;
 

--- a/libs/cdk/notifications/src/lib/create-template-notifier.spec.ts
+++ b/libs/cdk/notifications/src/lib/create-template-notifier.spec.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject, NEVER, of, throwError } from 'rxjs';
 import { createTemplateNotifier } from './create-template-notifier';
-import { RxNotification, RxNotificationKind } from './model';
+import type { RxNotification } from './model';
+import { RxNotificationKind } from './model';
 
 describe(createTemplateNotifier.name, () => {
   it('should not emit anything when input is NEVER', () => {

--- a/libs/cdk/notifications/src/lib/create-template-notifier.ts
+++ b/libs/cdk/notifications/src/lib/create-template-notifier.ts
@@ -1,11 +1,5 @@
-import {
-  from,
-  isObservable,
-  NEVER,
-  Observable,
-  ObservableInput,
-  ReplaySubject,
-} from 'rxjs';
+import type { ObservableInput } from 'rxjs';
+import { from, isObservable, NEVER, Observable, ReplaySubject } from 'rxjs';
 import {
   distinctUntilChanged,
   map,
@@ -15,7 +9,8 @@ import {
 } from 'rxjs/operators';
 
 import { rxMaterialize } from './rx-materialize';
-import { RxNotification, RxNotificationKind } from './model';
+import type { RxNotification } from './model';
+import { RxNotificationKind } from './model';
 import { toRxSuspenseNotification } from './notification-transforms';
 
 /**

--- a/libs/cdk/notifications/src/lib/notification-transforms.ts
+++ b/libs/cdk/notifications/src/lib/notification-transforms.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   RxSuspenseNotification,
-  RxNotificationKind,
   RxErrorNotification,
   RxCompleteNotification,
 } from './model';
+import { RxNotificationKind } from './model';
 
 export function toRxErrorNotification<T>(
   error?: any,

--- a/libs/cdk/notifications/src/lib/rx-materialize.ts
+++ b/libs/cdk/notifications/src/lib/rx-materialize.ts
@@ -1,7 +1,8 @@
-import { OperatorFunction, Notification } from 'rxjs';
+import type { OperatorFunction, Notification } from 'rxjs';
 import { map, materialize, tap } from 'rxjs/operators';
 
-import { RxNotification, RxNotificationKind } from './model';
+import type { RxNotification } from './model';
+import { RxNotificationKind } from './model';
 
 export function rxMaterialize<T>(): OperatorFunction<T, RxNotification<T>> {
   return (o$) =>

--- a/libs/cdk/notifications/src/lib/template-trigger-handling.ts
+++ b/libs/cdk/notifications/src/lib/template-trigger-handling.ts
@@ -1,9 +1,10 @@
-import { Observable, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { mergeAll, share } from 'rxjs/operators';
 
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
 
-import { RxNotification } from './model';
+import type { RxNotification } from './model';
 
 /**
  * @internal

--- a/libs/cdk/render-strategies/spec/onStrategy.spec.ts
+++ b/libs/cdk/render-strategies/spec/onStrategy.spec.ts
@@ -1,9 +1,9 @@
 import { TestScheduler } from 'rxjs/testing';
 import { jestMatcher } from '@test-helpers/rx-angular';
+import type { RxStrategyCredentials } from '@rx-angular/cdk/render-strategies';
 import {
   onStrategy,
   RX_NATIVE_STRATEGIES,
-  RxStrategyCredentials,
 } from '@rx-angular/cdk/render-strategies';
 import { animationFrameScheduler, observeOn, tap } from 'rxjs';
 

--- a/libs/cdk/render-strategies/src/lib/concurrent-strategies.ts
+++ b/libs/cdk/render-strategies/src/lib/concurrent-strategies.ts
@@ -1,5 +1,6 @@
-import { NgZone } from '@angular/core';
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import type { NgZone } from '@angular/core';
+import type { MonoTypeOperatorFunction } from 'rxjs';
+import { Observable } from 'rxjs';
 import { filter, mapTo, switchMap } from 'rxjs/operators';
 import {
   cancelCallback,
@@ -8,12 +9,13 @@ import {
   PriorityLevel,
 } from '@rx-angular/cdk/internals/scheduler';
 
-import {
+import type {
   RxCustomStrategyCredentials,
   RxConcurrentStrategyNames,
   RxStrategyCredentials,
 } from './model';
-import { coalescingManager, coalescingObj } from '@rx-angular/cdk/coalescing';
+import type { coalescingObj } from '@rx-angular/cdk/coalescing';
+import { coalescingManager } from '@rx-angular/cdk/coalescing';
 
 // set default to 60fps
 forceFrameRate(60);

--- a/libs/cdk/render-strategies/src/lib/config.ts
+++ b/libs/cdk/render-strategies/src/lib/config.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { RX_CONCURRENT_STRATEGIES } from './concurrent-strategies';
-import {
+import type {
   RxCustomStrategyCredentials,
   RxDefaultStrategyNames,
   RxStrategyNames,

--- a/libs/cdk/render-strategies/src/lib/model.ts
+++ b/libs/cdk/render-strategies/src/lib/model.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectorRef, NgZone } from '@angular/core';
-import { coalescingObj } from '@rx-angular/cdk/coalescing';
-import { RxNotification } from '@rx-angular/cdk/notifications';
-import { Observable } from 'rxjs';
+import type { ChangeDetectorRef, NgZone } from '@angular/core';
+import type { coalescingObj } from '@rx-angular/cdk/coalescing';
+import type { RxNotification } from '@rx-angular/cdk/notifications';
+import type { Observable } from 'rxjs';
 
 export interface ScheduleOnStrategyOptions {
   scope?: {};

--- a/libs/cdk/render-strategies/src/lib/native-strategies.ts
+++ b/libs/cdk/render-strategies/src/lib/native-strategies.ts
@@ -3,7 +3,7 @@ import { coalesceWith } from '@rx-angular/cdk/coalescing';
 import { getZoneUnPatchedApi } from '@rx-angular/cdk/internals/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import {
+import type {
   RxCustomStrategyCredentials,
   RxNativeStrategyNames,
   RxStrategyCredentials,

--- a/libs/cdk/render-strategies/src/lib/onStrategy.ts
+++ b/libs/cdk/render-strategies/src/lib/onStrategy.ts
@@ -1,8 +1,8 @@
-import { NgZone } from '@angular/core';
-import { RxCoalescingOptions } from '@rx-angular/cdk/coalescing';
+import type { NgZone } from '@angular/core';
+import type { RxCoalescingOptions } from '@rx-angular/cdk/coalescing';
 import { Observable, throwError } from 'rxjs';
 import { catchError, map, take } from 'rxjs/operators';
-import { RxRenderWork, RxStrategyCredentials } from './model';
+import type { RxRenderWork, RxStrategyCredentials } from './model';
 
 /**
  * @internal

--- a/libs/cdk/render-strategies/src/lib/strategy-handling.ts
+++ b/libs/cdk/render-strategies/src/lib/strategy-handling.ts
@@ -1,13 +1,14 @@
-import { Observable, ReplaySubject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import { map, share, startWith, switchAll } from 'rxjs/operators';
 
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
-import {
+import type {
   RxCustomStrategyCredentials,
-  RxStrategies,
   RxStrategyCredentials,
   RxStrategyNames,
 } from './model';
+import { RxStrategies } from './model';
 
 export interface RxStrategyHandler {
   strategy$: Observable<RxStrategyCredentials>;

--- a/libs/cdk/render-strategies/src/lib/strategy-provider.service.ts
+++ b/libs/cdk/render-strategies/src/lib/strategy-provider.service.ts
@@ -1,25 +1,15 @@
-import {
-  ChangeDetectorRef,
-  Inject,
-  Injectable,
-  NgZone,
-  Optional
-} from '@angular/core';
-import {
-  BehaviorSubject,
-  fromEvent,
-  MonoTypeOperatorFunction,
-  Observable
-} from 'rxjs';
+import type { ChangeDetectorRef, NgZone } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
+import type { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { BehaviorSubject, fromEvent } from 'rxjs';
 import { map, shareReplay, switchMap, takeUntil } from 'rxjs/operators';
-import {
-  mergeDefaultConfig, RxRenderStrategiesConfig, RX_RENDER_STRATEGIES_CONFIG
-} from './config';
-import {
+import type { RxRenderStrategiesConfig } from './config';
+import { mergeDefaultConfig, RX_RENDER_STRATEGIES_CONFIG } from './config';
+import type {
   RxStrategies,
   RxStrategyCredentials,
   RxStrategyNames,
-  ScheduleOnStrategyOptions
+  ScheduleOnStrategyOptions,
 } from './model';
 import { onStrategy } from './onStrategy';
 

--- a/libs/cdk/schematics/src/utils/dependency.ts
+++ b/libs/cdk/schematics/src/utils/dependency.ts
@@ -1,4 +1,2 @@
-import {
-  NodeDependency,
-} from '@schematics/angular/utility/dependencies';
+import type { NodeDependency } from '@schematics/angular/utility/dependencies';
 export type Dependency = Omit<NodeDependency, 'version'>;

--- a/libs/cdk/schematics/src/utils/format-files.ts
+++ b/libs/cdk/schematics/src/utils/format-files.ts
@@ -1,4 +1,11 @@
-import { CreateFileAction, noop, OverwriteFileAction, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type {
+  CreateFileAction,
+  OverwriteFileAction,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import { noop } from '@angular-devkit/schematics';
 import * as path from 'path';
 import { from } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';

--- a/libs/cdk/schematics/src/utils/read-json-in-tree.ts
+++ b/libs/cdk/schematics/src/utils/read-json-in-tree.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@angular-devkit/schematics';
+import type { Tree } from '@angular-devkit/schematics';
 
 export function readJsonInTree<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {

--- a/libs/cdk/schematics/src/utils/renaming-rule.ts
+++ b/libs/cdk/schematics/src/utils/renaming-rule.ts
@@ -1,11 +1,14 @@
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import type { Rule, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
+import type {
+  ImportSpecifier,
+  ImportSpecifierStructure,
+  Pattern,
+} from 'ng-morph';
 import {
   addImports,
   createProject,
   getImports,
-  ImportSpecifier,
-  ImportSpecifierStructure,
-  Pattern,
   saveActiveProject,
   setActiveProject,
 } from 'ng-morph';
@@ -43,7 +46,7 @@ export function renamingRule(packageName: Pattern, renames: RenameConfig) {
               .getSourceFile()
               .getFilePath()
               .toString();
-              const key = `${filePath}__${rename.moduleSpecifier}`;
+            const key = `${filePath}__${rename.moduleSpecifier}`;
             const namedImportConfig: ImportConfig = {
               name: rename.namedImport,
             };

--- a/libs/cdk/template/spec/fixtures.ts
+++ b/libs/cdk/template/spec/fixtures.ts
@@ -1,28 +1,27 @@
-import {
+import type {
   AfterViewInit,
   ChangeDetectorRef,
+  ErrorHandler,
+  OnDestroy,
+} from '@angular/core';
+import {
   Component,
   EmbeddedViewRef,
-  ErrorHandler,
   Input,
-  OnDestroy,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { ReplaySubject, Subscription } from 'rxjs';
 import {
   createTemplateNotifier,
   RxNotificationKind,
 } from '../../notifications/src/index';
-import { RxStrategyProvider } from '../../render-strategies/src/index';
-import {
-  createTemplateManager,
-  RxBaseTemplateNames,
-  RxTemplateManager,
-  RxViewContext,
-} from '../src/index';
+import type { RxStrategyProvider } from '../../render-strategies/src/index';
+import type { RxTemplateManager, RxViewContext } from '../src/index';
+import { createTemplateManager, RxBaseTemplateNames } from '../src/index';
 
 @Component({
   selector: 'rx-angular-error-test',

--- a/libs/cdk/template/spec/list-manager.spec.ts
+++ b/libs/cdk/template/spec/list-manager.spec.ts
@@ -1,27 +1,31 @@
 import 'jest-preset-angular/setup-jest'; // TODO: move this into test-setup when zone-config.spec is in its own lib
-import {
+import type {
   AfterViewInit,
   ChangeDetectorRef,
-  Component,
   ElementRef,
   EmbeddedViewRef,
+  IterableDiffers,
+} from '@angular/core';
+import {
+  Component,
   ErrorHandler,
   Input,
-  IterableDiffers,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
-import {
-  createListTemplateManager,
-  RxDefaultListViewContext,
+import type {
   RxListManager,
   RxListViewComputedContext,
   RxListViewContext,
 } from '@rx-angular/cdk/template';
-import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import {
+  createListTemplateManager,
+  RxDefaultListViewContext,
+} from '@rx-angular/cdk/template';
+import type { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
 import { ReplaySubject } from 'rxjs';
 

--- a/libs/cdk/template/spec/template-manager.spec.ts
+++ b/libs/cdk/template/spec/template-manager.spec.ts
@@ -1,10 +1,13 @@
-import { ErrorHandler, TemplateRef, ViewContainerRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { TemplateRef } from '@angular/core';
+import { ErrorHandler, ViewContainerRef } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RxNotificationKind } from '@rx-angular/cdk/notifications';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
-import { RxTemplateManager } from '@rx-angular/cdk/template';
+import type { RxTemplateManager } from '@rx-angular/cdk/template';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { of, ReplaySubject, throwError } from 'rxjs';
+import type { ReplaySubject } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import {
   createTestComponent,

--- a/libs/cdk/template/src/lib/list-template-manager.ts
+++ b/libs/cdk/template/src/lib/list-template-manager.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   EmbeddedViewRef,
   IterableChanges,
   IterableDiffer,
@@ -7,7 +7,8 @@ import {
   TemplateRef,
   TrackByFunction,
 } from '@angular/core';
-import { combineLatest, MonoTypeOperatorFunction, Observable, of } from 'rxjs';
+import type { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { combineLatest, of } from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -15,23 +16,25 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
-import {
+import type {
   RxStrategyCredentials,
-  onStrategy,
-  strategyHandling,
   RxStrategyNames,
 } from '@rx-angular/cdk/render-strategies';
 import {
+  onStrategy,
+  strategyHandling,
+} from '@rx-angular/cdk/render-strategies';
+import type {
   RxListViewComputedContext,
   RxListViewContext,
 } from './list-view-context';
 import { getTemplateHandler } from './list-view-handler';
-import {
+import type {
   RxListTemplateChange,
-  RxListTemplateChangeType,
   RxListTemplateSettings,
   RxRenderSettings,
 } from './model';
+import { RxListTemplateChangeType } from './model';
 import { createErrorHandler } from './render-error';
 import { notifyAllParentsIfNeeded } from './utils';
 

--- a/libs/cdk/template/src/lib/list-view-context.ts
+++ b/libs/cdk/template/src/lib/list-view-context.ts
@@ -1,5 +1,6 @@
-import { NgIterable } from '@angular/core';
-import { BehaviorSubject, Observable, ReplaySubject } from 'rxjs';
+import type { NgIterable } from '@angular/core';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, ReplaySubject } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 
 export interface RxListViewComputedContext {

--- a/libs/cdk/template/src/lib/list-view-handler.ts
+++ b/libs/cdk/template/src/lib/list-view-handler.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   RxListTemplateChange,
   RxListTemplateChanges,
-  RxListTemplateChangeType,
   RxListTemplateSettings,
 } from './model';
-import { EmbeddedViewRef, IterableChanges } from '@angular/core';
-import { RxListViewContext } from './list-view-context';
+import { RxListTemplateChangeType } from './model';
+import type { EmbeddedViewRef, IterableChanges } from '@angular/core';
+import type { RxListViewContext } from './list-view-context';
 import { createEmbeddedView } from './utils';
 
 /**

--- a/libs/cdk/template/src/lib/model.ts
+++ b/libs/cdk/template/src/lib/model.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ChangeDetectorRef,
   EmbeddedViewRef,
   ErrorHandler,
@@ -6,10 +6,10 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
-import { RxNotification } from '@rx-angular/cdk/notifications';
-import { RxStrategies } from '@rx-angular/cdk/render-strategies';
+import type { RxNotification } from '@rx-angular/cdk/notifications';
+import type { RxStrategies } from '@rx-angular/cdk/render-strategies';
 
 export type rxBaseTemplateNames = 'errorTpl' | 'completeTpl' | 'suspenseTpl';
 

--- a/libs/cdk/template/src/lib/render-error.ts
+++ b/libs/cdk/template/src/lib/render-error.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler } from '@angular/core';
+import type { ErrorHandler } from '@angular/core';
 
 /** @internal **/
 export type RxRenderError<T> = [Error, T];
@@ -17,9 +17,7 @@ export function isRxRenderError<T>(e: any): e is RxRenderError<T> {
 }
 
 /** @internal **/
-export function createErrorHandler(
-  _handler?: ErrorHandler
-): ErrorHandler {
+export function createErrorHandler(_handler?: ErrorHandler): ErrorHandler {
   const _handleError = _handler
     ? (e) => _handler.handleError(e)
     : console.error;

--- a/libs/cdk/template/src/lib/template-manager.ts
+++ b/libs/cdk/template/src/lib/template-manager.ts
@@ -1,19 +1,20 @@
-import { EmbeddedViewRef, TemplateRef } from '@angular/core';
-import { RxCoalescingOptions } from '@rx-angular/cdk/coalescing';
-import {
+import type { EmbeddedViewRef, TemplateRef } from '@angular/core';
+import type { RxCoalescingOptions } from '@rx-angular/cdk/coalescing';
+import type {
   RxCompleteNotification,
   RxErrorNotification,
   RxNextNotification,
   RxNotification,
-  RxNotificationKind,
   RxSuspenseNotification,
 } from '@rx-angular/cdk/notifications';
+import { RxNotificationKind } from '@rx-angular/cdk/notifications';
+import type { RxRenderWork } from '@rx-angular/cdk/render-strategies';
 import {
   onStrategy,
-  RxRenderWork,
   strategyHandling,
 } from '@rx-angular/cdk/render-strategies';
-import { EMPTY, merge, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { EMPTY, merge, of } from 'rxjs';
 import {
   catchError,
   map,
@@ -21,7 +22,7 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
-import {
+import type {
   rxBaseTemplateNames,
   RxRenderAware,
   RxRenderSettings,

--- a/libs/cdk/template/src/lib/utils.ts
+++ b/libs/cdk/template/src/lib/utils.ts
@@ -1,22 +1,14 @@
-import {
+import type {
   ChangeDetectorRef,
   EmbeddedViewRef,
   NgZone,
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import {
-  onStrategy,
-  RxStrategyCredentials,
-} from '@rx-angular/cdk/render-strategies';
-import {
-  BehaviorSubject,
-  concat,
-  MonoTypeOperatorFunction,
-  Observable,
-  of,
-  Subject,
-} from 'rxjs';
+import type { RxStrategyCredentials } from '@rx-angular/cdk/render-strategies';
+import { onStrategy } from '@rx-angular/cdk/render-strategies';
+import type { MonoTypeOperatorFunction, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, concat, of } from 'rxjs';
 import { ignoreElements, switchMap } from 'rxjs/operators';
 
 /**

--- a/libs/cdk/transformations/spec/object/deleteProp.spec.ts
+++ b/libs/cdk/transformations/spec/object/deleteProp.spec.ts
@@ -1,8 +1,6 @@
 import { deleteProp } from '@rx-angular/cdk/transformations';
-import {
-  initialPrimitiveState,
-  PrimitiveState,
-} from '@test-helpers/rx-angular';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
+import { initialPrimitiveState } from '@test-helpers/rx-angular';
 
 let primitiveState: PrimitiveState;
 

--- a/libs/cdk/transformations/spec/object/patch.spec.ts
+++ b/libs/cdk/transformations/spec/object/patch.spec.ts
@@ -1,8 +1,7 @@
+import type { NestedState, PrimitiveState } from '@test-helpers/rx-angular';
 import {
   initialNestedState,
   initialPrimitiveState,
-  NestedState,
-  PrimitiveState,
 } from '@test-helpers/rx-angular';
 import { patch } from '@rx-angular/cdk/transformations';
 

--- a/libs/cdk/transformations/spec/object/setProp.spec.ts
+++ b/libs/cdk/transformations/spec/object/setProp.spec.ts
@@ -1,9 +1,8 @@
 import { setProp } from '@rx-angular/cdk/transformations';
+import type { NestedState, PrimitiveState } from '@test-helpers/rx-angular';
 import {
   initialNestedState,
   initialPrimitiveState,
-  NestedState,
-  PrimitiveState,
 } from '@test-helpers/rx-angular';
 
 let primitiveState: PrimitiveState;

--- a/libs/cdk/transformations/spec/object/slice.spec.ts
+++ b/libs/cdk/transformations/spec/object/slice.spec.ts
@@ -1,7 +1,5 @@
-import {
-  initialPrimitiveState,
-  PrimitiveState,
-} from '@test-helpers/rx-angular';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
+import { initialPrimitiveState } from '@test-helpers/rx-angular';
 import { slice } from '@rx-angular/cdk/transformations';
 
 let primitiveState: PrimitiveState;

--- a/libs/cdk/transformations/spec/object/toggle.spec.ts
+++ b/libs/cdk/transformations/spec/object/toggle.spec.ts
@@ -1,8 +1,6 @@
 import { toggle } from '@rx-angular/cdk/transformations';
-import {
-  initialPrimitiveState,
-  PrimitiveState,
-} from '@test-helpers/rx-angular';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
+import { initialPrimitiveState } from '@test-helpers/rx-angular';
 
 let primitiveState: PrimitiveState;
 

--- a/libs/cdk/transformations/src/lib/_internals/valuesComparer.util.ts
+++ b/libs/cdk/transformations/src/lib/_internals/valuesComparer.util.ts
@@ -1,5 +1,5 @@
-import { CompareFn } from '../interfaces/comparable-data-type';
-import { ComparableData } from '../interfaces/comparable-data-type';
+import type { CompareFn } from '../interfaces/comparable-data-type';
+import type { ComparableData } from '../interfaces/comparable-data-type';
 import { isKeyOf } from '../_internals/guards';
 
 const defaultCompareFn = <T>(a: T, b: T) => a === b;
@@ -9,7 +9,6 @@ export function valuesComparer<T>(
   incoming: T,
   compare?: ComparableData<T>
 ): boolean {
-
   if (isKeyOf<T>(compare)) {
     return original[compare] === incoming[compare];
   }

--- a/libs/cdk/transformations/src/lib/array/remove.ts
+++ b/libs/cdk/transformations/src/lib/array/remove.ts
@@ -1,4 +1,4 @@
-import { ComparableData } from '../interfaces/comparable-data-type';
+import type { ComparableData } from '../interfaces/comparable-data-type';
 import { isDefined } from '../_internals/guards';
 import { valuesComparer } from '../_internals/valuesComparer.util';
 

--- a/libs/cdk/transformations/src/lib/array/toDictionary.ts
+++ b/libs/cdk/transformations/src/lib/array/toDictionary.ts
@@ -1,4 +1,5 @@
-import { isDefined, isKeyOf, OnlyKeysOfSpecificType } from '../_internals/guards';
+import type { OnlyKeysOfSpecificType } from '../_internals/guards';
+import { isDefined, isKeyOf } from '../_internals/guards';
 
 /**
  * @description

--- a/libs/cdk/transformations/src/lib/array/update.ts
+++ b/libs/cdk/transformations/src/lib/array/update.ts
@@ -1,4 +1,4 @@
-import { ComparableData } from '../interfaces/comparable-data-type';
+import type { ComparableData } from '../interfaces/comparable-data-type';
 import { valuesComparer } from '../_internals/valuesComparer.util';
 
 /**

--- a/libs/cdk/transformations/src/lib/array/upsert.ts
+++ b/libs/cdk/transformations/src/lib/array/upsert.ts
@@ -1,6 +1,6 @@
 import { isObjectGuard } from '../_internals/guards';
 import { valuesComparer } from '../_internals/valuesComparer.util';
-import { ComparableData } from '../interfaces/comparable-data-type';
+import type { ComparableData } from '../interfaces/comparable-data-type';
 
 /**
  * @description

--- a/libs/cdk/transformations/src/lib/object/toggle.ts
+++ b/libs/cdk/transformations/src/lib/object/toggle.ts
@@ -1,9 +1,5 @@
-import {
-  isDefined,
-  isKeyOf,
-  isObjectGuard,
-  OnlyKeysOfSpecificType,
-} from '../_internals/guards';
+import type { OnlyKeysOfSpecificType } from '../_internals/guards';
+import { isDefined, isKeyOf, isObjectGuard } from '../_internals/guards';
 
 /**
  * @description

--- a/libs/cdk/zone-configurations/src/lib/convenience-methods.ts
+++ b/libs/cdk/zone-configurations/src/lib/convenience-methods.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RxZoneConfigConfiguration,
   RxZoneConfigConvenienceMethods,
 } from './model/zone-config.types';

--- a/libs/cdk/zone-configurations/src/lib/model/zone-config.types.ts
+++ b/libs/cdk/zone-configurations/src/lib/model/zone-config.types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RxZoneGlobalDisableConfigurationsKey,
   RxZoneGlobalSettingsConfigurationsKey,
   RxZoneTestDisableConfigurationsKey,
@@ -9,17 +9,15 @@ import {
 
 export type RxGlobalDisableConfigurationMethods = {
   [disabledFlag in RxZoneGlobalDisableConfigurationsKey]: () => void;
-} &
-  {
-    [symbolFlag in RxZoneGlobalSettingsConfigurationsKey]: () => void;
-  };
+} & {
+  [symbolFlag in RxZoneGlobalSettingsConfigurationsKey]: () => void;
+};
 
 export type RxTestDisableConfigurationMethods = {
   [disabledFlag in RxZoneTestDisableConfigurationsKey]: () => void;
-} &
-  {
-    [symbolFlag in RxZoneTestSettingsConfigurationsKey]: () => void;
-  };
+} & {
+  [symbolFlag in RxZoneTestSettingsConfigurationsKey]: () => void;
+};
 
 export type RxZoneGlobalEventsConfigurationsMethods = {
   [disabledFlag in RxZoneGlobalEventsConfigurationsKey]: (

--- a/libs/cdk/zone-configurations/src/lib/zone-config.spec.ts
+++ b/libs/cdk/zone-configurations/src/lib/zone-config.spec.ts
@@ -1,6 +1,6 @@
 import { zoneConfig } from './zone-config';
-import { RxZoneFlagsHelperFunctions } from './model/configurations.types';
-import {
+import type { RxZoneFlagsHelperFunctions } from './model/configurations.types';
+import type {
   RxZoneGlobalConfigurations,
   RxZoneTestConfigurations,
   RxZoneRuntimeConfigurations,

--- a/libs/cdk/zone-configurations/src/lib/zone-config.ts
+++ b/libs/cdk/zone-configurations/src/lib/zone-config.ts
@@ -1,6 +1,6 @@
 import { ɵglobal } from '@angular/core';
+import type { RxZoneFlagsHelperFunctions } from './model/configurations.types';
 import {
-  RxZoneFlagsHelperFunctions,
   zoneGlobalDisableConfigurationsKeys,
   zoneGlobalEventsConfigurationsKeys,
   zoneGlobalSettingsConfigurationsKeys,
@@ -8,8 +8,8 @@ import {
   zoneTestDisableConfigurationsKeys,
   zoneTestSettingsConfigurationsKeys,
 } from './model/configurations.types';
-import { RxZoneGlobalConfigurations } from './model/zone.configurations.api';
-import {
+import type { RxZoneGlobalConfigurations } from './model/zone.configurations.api';
+import type {
   RxZoneConfigConfiguration,
   RxZoneConfig,
   RxGlobalDisableConfigurationMethods,

--- a/libs/cdk/zone-less/browser/src/browser.ts
+++ b/libs/cdk/zone-less/browser/src/browser.ts
@@ -79,7 +79,7 @@ export function cancelAnimationFrame(id: number): void {
  * @param ms - Required. The intervals (in milliseconds) on how often to execute the code. If the value is less than 10, the value 10 is used
  *
  */
-export function setInterval(cb: TimerHandler, ms: number = 0): number {
+export function setInterval(cb: TimerHandler, ms = 0): number {
   return getZoneUnPatchedApi('setInterval')(cb, ms);
 }
 
@@ -124,7 +124,7 @@ export function clearInterval(id: number): void {
  * @param ms - Optional. The number of milliseconds to wait before executing the code. If omitted, the value 0 is used
  *
  */
-export function setTimeout(cb: TimerHandler, ms: number = 0): number {
+export function setTimeout(cb: TimerHandler, ms = 0): number {
   return getZoneUnPatchedApi('setTimeout')(cb, ms);
 }
 

--- a/libs/eslint-plugin/src/lib/configs/index.ts
+++ b/libs/eslint-plugin/src/lib/configs/index.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import recommended from './recommended';
 import zoneless from './zoneless';
 

--- a/libs/eslint-plugin/src/lib/configs/recommended.ts
+++ b/libs/eslint-plugin/src/lib/configs/recommended.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 export default {
   parser: '@typescript-eslint/parser',

--- a/libs/eslint-plugin/src/lib/configs/zoneless.ts
+++ b/libs/eslint-plugin/src/lib/configs/zoneless.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 export default {
   parser: '@typescript-eslint/parser',

--- a/libs/eslint-plugin/src/lib/rules/index.ts
+++ b/libs/eslint-plugin/src/lib/rules/index.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import noExplicitChangeDetectionApis from './no-explicit-change-detection-apis';
 import noRxstateImperativeInReactive from './no-rxstate-imperative-in-reactive';
 import noRxstateSubscriptionsOutsideConstructor from './no-rxstate-subscriptions-outside-constructor';

--- a/libs/eslint-plugin/src/lib/rules/no-explicit-change-detection-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-explicit-change-detection-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import { docsUrl } from '../utils/docs';
 import { isKeyof } from '../utils/guards';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-rxstate-imperative-in-reactive.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-rxstate-imperative-in-reactive.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-rxstate-imperative-in-reactive';
+import type { MessageIds } from './no-rxstate-imperative-in-reactive';
+import rule from './no-rxstate-imperative-in-reactive';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-rxstate-imperative-in-reactive.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-rxstate-imperative-in-reactive.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { rxstateMethodCallExpression } from '../utils/selectors';

--- a/libs/eslint-plugin/src/lib/rules/no-rxstate-subscriptions-outside-constructor.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-rxstate-subscriptions-outside-constructor.spec.ts
@@ -1,9 +1,10 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, {
+import type {
   MessageIds,
   Options,
 } from './no-rxstate-subscriptions-outside-constructor';
+import rule from './no-rxstate-subscriptions-outside-constructor';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-rxstate-subscriptions-outside-constructor.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-rxstate-subscriptions-outside-constructor.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-browser-apis.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-browser-apis.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-zone-critical-browser-apis';
+import type { MessageIds } from './no-zone-critical-browser-apis';
+import rule from './no-zone-critical-browser-apis';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-browser-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-browser-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-lodash-apis.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-lodash-apis.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-zone-critical-lodash-apis';
+import type { MessageIds } from './no-zone-critical-lodash-apis';
+import rule from './no-zone-critical-lodash-apis';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-lodash-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-lodash-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-creation-apis.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-creation-apis.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-zone-critical-rxjs-creation-apis';
+import type { MessageIds } from './no-zone-critical-rxjs-creation-apis';
+import rule from './no-zone-critical-rxjs-creation-apis';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-creation-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-creation-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-operators.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-operators.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-zone-critical-rxjs-operators';
+import type { MessageIds } from './no-zone-critical-rxjs-operators';
+import rule from './no-zone-critical-rxjs-operators';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-operators.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-operators.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-schedulers.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-schedulers.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './no-zone-critical-rxjs-schedulers';
+import type { MessageIds } from './no-zone-critical-rxjs-schedulers';
+import rule from './no-zone-critical-rxjs-schedulers';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-schedulers.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-critical-rxjs-schedulers.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/no-zone-run-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/no-zone-run-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { isKeyof } from '../utils/guards';

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-layout-sensitive-apis.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-layout-sensitive-apis.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './prefer-no-layout-sensitive-apis';
+import type { MessageIds } from './prefer-no-layout-sensitive-apis';
+import rule from './prefer-no-layout-sensitive-apis';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-layout-sensitive-apis.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-layout-sensitive-apis.ts
@@ -1,8 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 import { namesToRegex } from '../utils/regex';

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-clone-deep.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-clone-deep.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './prefer-no-lodash-clone-deep';
+import type { MessageIds } from './prefer-no-lodash-clone-deep';
+import rule from './prefer-no-lodash-clone-deep';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-clone-deep.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-clone-deep.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-is-equal.spec.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-is-equal.spec.ts
@@ -1,6 +1,7 @@
 import { TSESLint } from '@typescript-eslint/utils';
 import * as path from 'path';
-import rule, { MessageIds } from './prefer-no-lodash-is-equal';
+import type { MessageIds } from './prefer-no-lodash-is-equal';
+import rule from './prefer-no-lodash-is-equal';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-is-equal.ts
+++ b/libs/eslint-plugin/src/lib/rules/prefer-no-lodash-is-equal.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 import * as path from 'path';
 import { docsUrl } from '../utils/docs';
 

--- a/libs/isr/browser/src/isr.service.ts
+++ b/libs/isr/browser/src/isr.service.ts
@@ -1,6 +1,6 @@
 import { isPlatformServer } from '@angular/common';
 import { Injectable, PLATFORM_ID, inject } from '@angular/core';
-import { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
+import type { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
 
 @Injectable({ providedIn: 'root' })
 export class IsrService implements IsrServiceInterface {

--- a/libs/isr/models/src/cache-handler.ts
+++ b/libs/isr/models/src/cache-handler.ts
@@ -1,4 +1,4 @@
-import { Request } from 'express';
+import type { Request } from 'express';
 
 /**
  * CacheISRConfig is the configuration object that is used to store the

--- a/libs/isr/models/src/isr-handler-config.ts
+++ b/libs/isr/models/src/isr-handler-config.ts
@@ -1,6 +1,6 @@
-import { Provider } from '@angular/core';
-import { CacheHandler, RenderVariant } from './cache-handler';
-import { Request } from 'express';
+import type { Provider } from '@angular/core';
+import type { CacheHandler, RenderVariant } from './cache-handler';
+import type { Request } from 'express';
 
 export interface ISRHandlerConfig {
   /**

--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -1,11 +1,8 @@
 import * as fs from 'fs';
 import { join } from 'path';
 
-import {
-  CacheData,
-  CacheHandler,
-  CacheISRConfig,
-} from '@rx-angular/isr/models';
+import type { CacheData, CacheISRConfig } from '@rx-angular/isr/models';
+import { CacheHandler } from '@rx-angular/isr/models';
 import { getRouteISRDataFromHTML } from '../utils/get-isr-options';
 
 export interface FileSystemCacheOptions {

--- a/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CacheData,
   CacheHandler,
   CacheISRConfig,

--- a/libs/isr/server/src/cache-regeneration.ts
+++ b/libs/isr/server/src/cache-regeneration.ts
@@ -1,13 +1,13 @@
-import { Provider } from '@angular/core';
-import {
+import type { Provider } from '@angular/core';
+import type {
   CacheData,
   CacheHandler,
   ISRHandlerConfig,
 } from '@rx-angular/isr/models';
 import { renderUrl } from './utils/render-url';
 import { getRouteISRDataFromHTML } from './utils/get-isr-options';
-import { Request, Response } from 'express';
-import { ISRLogger } from './isr-logger';
+import type { Request, Response } from 'express';
+import type { ISRLogger } from './isr-logger';
 
 export class CacheRegeneration {
   // TODO: make this pluggable because on serverless environments we can't share memory between functions

--- a/libs/isr/server/src/http-errors.interceptor.ts
+++ b/libs/isr/server/src/http-errors.interceptor.ts
@@ -1,13 +1,15 @@
-import { Injectable, Provider } from '@angular/core';
-import {
-  HTTP_INTERCEPTORS,
+import type { Provider } from '@angular/core';
+import { Injectable } from '@angular/core';
+import type {
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
   HttpRequest,
 } from '@angular/common/http';
-import { catchError, Observable, throwError } from 'rxjs';
-import { IsrService } from '@rx-angular/isr/browser';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import type { Observable } from 'rxjs';
+import { catchError, throwError } from 'rxjs';
+import type { IsrService } from '@rx-angular/isr/browser';
 
 @Injectable()
 export class HttpErrorsInterceptor implements HttpInterceptor {

--- a/libs/isr/server/src/isr-handler.ts
+++ b/libs/isr/server/src/isr-handler.ts
@@ -1,18 +1,19 @@
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { InMemoryCacheHandler } from './cache-handlers/in-memory-cache-handler';
 import { CacheRegeneration } from './cache-regeneration';
 import { ISRLogger } from './isr-logger';
-import {
-  CacheHandler,
+import type {
   CacheISRConfig,
   InvalidateConfig,
   ISRHandlerConfig,
   RenderConfig,
   ServeFromCacheConfig,
 } from '@rx-angular/isr/models';
+import { CacheHandler } from '@rx-angular/isr/models';
 import { getRouteISRDataFromHTML } from './utils/get-isr-options';
-import { renderUrl, RenderUrlConfig } from './utils/render-url';
-import { RenderVariant, VariantRebuildItem } from '@rx-angular/isr/models';
+import type { RenderUrlConfig } from './utils/render-url';
+import { renderUrl } from './utils/render-url';
+import type { RenderVariant, VariantRebuildItem } from '@rx-angular/isr/models';
 
 export class ISRHandler {
   protected cache!: CacheHandler;

--- a/libs/isr/server/src/isr-server.service.ts
+++ b/libs/isr/server/src/isr-server.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { ChildActivationEnd, Router } from '@angular/router';
 import { filter, map, take } from 'rxjs/operators';
-import { HttpErrorResponse } from '@angular/common/http';
-import { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
+import type { HttpErrorResponse } from '@angular/common/http';
+import type { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
 
 const initialState: IsrState = {
   revalidate: null,

--- a/libs/isr/server/src/isr.module.ts
+++ b/libs/isr/server/src/isr.module.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  ModuleWithProviders,
-  NgModule,
-  PLATFORM_ID,
-} from '@angular/core';
+import type { ModuleWithProviders } from '@angular/core';
+import { Inject, NgModule, PLATFORM_ID } from '@angular/core';
 import { HTTP_ERROR_PROVIDER_ISR } from './http-errors.interceptor';
 import { BEFORE_APP_SERIALIZED } from '@angular/platform-server';
 import { addIsrDataBeforeSerialized } from './utils/add-isr-data-before-serialized';

--- a/libs/isr/server/src/provide-isr.ts
+++ b/libs/isr/server/src/provide-isr.ts
@@ -1,4 +1,5 @@
-import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import type { EnvironmentProviders } from '@angular/core';
+import { makeEnvironmentProviders } from '@angular/core';
 import { IsrServerService } from './isr-server.service';
 import { HTTP_ERROR_PROVIDER_ISR } from './http-errors.interceptor';
 import { BEFORE_APP_SERIALIZED } from '@angular/platform-server';

--- a/libs/isr/server/src/utils/add-isr-data-before-serialized.ts
+++ b/libs/isr/server/src/utils/add-isr-data-before-serialized.ts
@@ -1,4 +1,4 @@
-import { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
+import type { IsrServiceInterface, IsrState } from '@rx-angular/isr/models';
 
 export function addIsrDataBeforeSerialized(
   isrService: IsrServiceInterface,

--- a/libs/isr/server/src/utils/render-url.ts
+++ b/libs/isr/server/src/utils/render-url.ts
@@ -1,7 +1,7 @@
 import { APP_BASE_HREF } from '@angular/common';
-import { Provider } from '@angular/core';
+import type { Provider } from '@angular/core';
 import { ɵSERVER_CONTEXT as SERVER_CONTEXT } from '@angular/platform-server';
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
 
 export interface RenderUrlConfig {
   req: Request;

--- a/libs/state/actions/src/lib/actions.factory.ts
+++ b/libs/state/actions/src/lib/actions.factory.ts
@@ -1,7 +1,8 @@
-import { ErrorHandler, Injectable, OnDestroy, Optional } from '@angular/core';
-import { Subject } from 'rxjs';
+import type { ErrorHandler, OnDestroy } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
+import type { Subject } from 'rxjs';
 import { actionProxyHandler } from './proxy';
-import { Actions, ActionTransforms, EffectMap, RxActions } from './types';
+import type { Actions, ActionTransforms, EffectMap, RxActions } from './types';
 
 type SubjectMap<T> = { [K in keyof T]: Subject<T[K]> };
 

--- a/libs/state/actions/src/lib/docs.spec.ts
+++ b/libs/state/actions/src/lib/docs.spec.ts
@@ -1,5 +1,6 @@
 import { AsyncPipe, DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   Component,
   Inject,
@@ -11,7 +12,8 @@ import {
 import { By } from '@angular/platform-browser';
 import { take } from 'rxjs/operators';
 import { rxActions } from './rx-actions';
-import { exhaustMap, Observable, of, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { exhaustMap, of, Subject } from 'rxjs';
 
 @Injectable()
 class AuthService {

--- a/libs/state/actions/src/lib/proxy.ts
+++ b/libs/state/actions/src/lib/proxy.ts
@@ -1,6 +1,13 @@
-import { ErrorHandler } from '@angular/core';
-import { merge, OperatorFunction, Subject } from 'rxjs';
-import { EffectMap, KeysOf, RxActions, SubjectMap, ValuesOf } from './types';
+import type { ErrorHandler } from '@angular/core';
+import type { OperatorFunction } from 'rxjs';
+import { merge, Subject } from 'rxjs';
+import type {
+  EffectMap,
+  KeysOf,
+  RxActions,
+  SubjectMap,
+  ValuesOf,
+} from './types';
 
 /**
  * @internal

--- a/libs/state/actions/src/lib/rx-actions.spec.ts
+++ b/libs/state/actions/src/lib/rx-actions.spec.ts
@@ -1,9 +1,10 @@
 import { tap } from 'rxjs/operators';
 import { rxActions } from './rx-actions';
 import { debounceTime, isObservable } from 'rxjs';
-import { Component, ErrorHandler, Provider } from '@angular/core';
+import type { Provider } from '@angular/core';
+import { Component, ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ActionTransforms } from '@rx-angular/state/actions';
+import type { ActionTransforms } from '@rx-angular/state/actions';
 
 describe('actions fn', () => {
   it('should get created properly', () => {

--- a/libs/state/actions/src/lib/rx-actions.ts
+++ b/libs/state/actions/src/lib/rx-actions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Actions,
   ActionTransforms,
   EffectMap,

--- a/libs/state/actions/src/lib/types.ts
+++ b/libs/state/actions/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction, Subject, Subscription } from 'rxjs';
+import type { Observable, OperatorFunction, Subject, Subscription } from 'rxjs';
 
 export type ValuesOf<O> = O[keyof O];
 // type Keys = KeysOf<{ a: string, b: number }>; // "a" | "b"

--- a/libs/state/effects/src/lib/effects.service.spec.ts
+++ b/libs/state/effects/src/lib/effects.service.spec.ts
@@ -1,6 +1,7 @@
 import { Component, ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { BehaviorSubject, EMPTY, Observable, throwError, map, tap } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, EMPTY, throwError, map, tap } from 'rxjs';
 import { RxEffects } from './effects.service';
 
 // tslint:disable: max-classes-per-file

--- a/libs/state/effects/src/lib/effects.service.ts
+++ b/libs/state/effects/src/lib/effects.service.ts
@@ -1,14 +1,7 @@
-import { ErrorHandler, Injectable, OnDestroy, Optional } from '@angular/core';
-import {
-  EMPTY,
-  from,
-  Observable,
-  ObservableInput,
-  PartialObserver,
-  pipe,
-  Subject,
-  Subscription,
-} from 'rxjs';
+import type { ErrorHandler, OnDestroy } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
+import type { Observable, ObservableInput, PartialObserver } from 'rxjs';
+import { EMPTY, from, pipe, Subject, Subscription } from 'rxjs';
 import {
   catchError,
   filter,
@@ -18,7 +11,7 @@ import {
   takeUntil,
   tap,
 } from 'rxjs/operators';
-import { DestroyProp, OnDestroy$ } from './model';
+import type { DestroyProp, OnDestroy$ } from './model';
 import { toHook, untilDestroyed } from './utils';
 
 /**

--- a/libs/state/effects/src/lib/model.ts
+++ b/libs/state/effects/src/lib/model.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject } from 'rxjs';
+import type { Observable, Subject } from 'rxjs';
 
 /**
  * Interface to declare name and value of the OnDestroy lifecycle hook
@@ -11,13 +11,13 @@ export interface DestroyProp {
  * Interface to declare names and values of single shot lifecycle hook. e.g. init, afterViewInit, afterContentInit, destroy
  */
 // tslint:disable-next-line:no-empty-interface
-export interface SingleShotProps extends DestroyProp {}
+export type SingleShotProps = DestroyProp;
 
 /**
  * Interface to declare names and values of lifecycle hook. e.g. init, changes, afterViewInit, etc...
  */
 // tslint:disable-next-line:no-empty-interface
-export interface HookProps extends DestroyProp {}
+export type HookProps = DestroyProp;
 
 /**
  * Interface to specify an Observable channel for lifecycle hooks.

--- a/libs/state/effects/src/lib/rx-effects.spec.ts
+++ b/libs/state/effects/src/lib/rx-effects.spec.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Observable, of, Subject, tap, timer } from 'rxjs';
-import { rxEffects, RxEffectsSetupFn } from './rx-effects';
+import type { RxEffectsSetupFn } from './rx-effects';
+import { rxEffects } from './rx-effects';
 import { TestScheduler } from 'rxjs/testing';
 import { jestMatcher } from '@test-helpers/rx-angular';
 

--- a/libs/state/effects/src/lib/rx-effects.ts
+++ b/libs/state/effects/src/lib/rx-effects.ts
@@ -4,8 +4,9 @@ import {
   ErrorHandler,
   inject,
 } from '@angular/core';
-import { from, Subscription } from 'rxjs';
-import { SideEffectFnOrObserver, SideEffectObservable } from './types';
+import type { Subscription } from 'rxjs';
+import { from } from 'rxjs';
+import type { SideEffectFnOrObserver, SideEffectObservable } from './types';
 
 interface RxEffects {
   register<T>(

--- a/libs/state/effects/src/lib/types.ts
+++ b/libs/state/effects/src/lib/types.ts
@@ -1,12 +1,5 @@
-import {
-  EMPTY,
-  from,
-  ObservableInput,
-  PartialObserver,
-  pipe,
-  Subject,
-  Subscription,
-} from 'rxjs';
+import type { ObservableInput, PartialObserver } from 'rxjs';
+import { EMPTY, from, pipe, Subject, Subscription } from 'rxjs';
 
 export type SideEffectObservable<T> = ObservableInput<T>;
 export type SideEffectFnOrObserver<T> =

--- a/libs/state/effects/src/lib/utils.ts
+++ b/libs/state/effects/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import type { MonoTypeOperatorFunction, Observable } from 'rxjs';
 import { filter, map, shareReplay, take, takeUntil } from 'rxjs/operators';
-import { HookProps, OnDestroy$, SingleShotProps } from './model';
+import type { HookProps, OnDestroy$, SingleShotProps } from './model';
 
 export function isSingleShotHookNameGuard<T>(
   name: unknown

--- a/libs/state/perf/core/transformation-helpers/one-of.suite.ts
+++ b/libs/state/perf/core/transformation-helpers/one-of.suite.ts
@@ -1,4 +1,4 @@
-import { BenchmarkSuite } from '../../utils';
+import type { BenchmarkSuite } from '../../utils';
 
 export const oneOfSuite: BenchmarkSuite = {
   testSet: {
@@ -7,8 +7,8 @@ export const oneOfSuite: BenchmarkSuite = {
     expression: expression,
     'Array#includes2': arrayIncludes2,
     'Object#prop2': objectProperty2,
-    expression2: expression2
-  }
+    expression2: expression2,
+  },
 };
 
 function arrayIncludes() {
@@ -19,15 +19,15 @@ function objectProperty() {
   const obj: any = {
     string: true,
     symbol: true,
-    number: true
+    number: true,
   };
   obj[typeof 'test'];
 }
 
 function expression() {
   typeof 'test' === 'string' ||
-  typeof 'test' === 'symbol' ||
-  typeof 'test' === 'number';
+    typeof 'test' === 'symbol' ||
+    typeof 'test' === 'number';
 }
 
 const arr = ['string', 'symbol', 'number'];
@@ -39,7 +39,7 @@ function arrayIncludes2() {
 const obj: any = {
   string: true,
   symbol: true,
-  number: true
+  number: true,
 };
 
 function objectProperty2() {

--- a/libs/state/schematics/src/utils/dependency.ts
+++ b/libs/state/schematics/src/utils/dependency.ts
@@ -1,4 +1,2 @@
-import {
-  NodeDependency,
-} from '@schematics/angular/utility/dependencies';
+import type { NodeDependency } from '@schematics/angular/utility/dependencies';
 export type Dependency = Omit<NodeDependency, 'version'>;

--- a/libs/state/schematics/src/utils/format-files.ts
+++ b/libs/state/schematics/src/utils/format-files.ts
@@ -1,4 +1,11 @@
-import { CreateFileAction, noop, OverwriteFileAction, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type {
+  CreateFileAction,
+  OverwriteFileAction,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import { noop } from '@angular-devkit/schematics';
 import * as path from 'path';
 import { from } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';

--- a/libs/state/schematics/src/utils/read-json-in-tree.ts
+++ b/libs/state/schematics/src/utils/read-json-in-tree.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@angular-devkit/schematics';
+import type { Tree } from '@angular-devkit/schematics';
 
 export function readJsonInTree<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {

--- a/libs/state/schematics/src/utils/renaming-rule.ts
+++ b/libs/state/schematics/src/utils/renaming-rule.ts
@@ -1,11 +1,14 @@
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import type { Rule, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
+import type {
+  ImportSpecifier,
+  ImportSpecifierStructure,
+  Pattern,
+} from 'ng-morph';
 import {
   addImports,
   createProject,
   getImports,
-  ImportSpecifier,
-  ImportSpecifierStructure,
-  Pattern,
   saveActiveProject,
   setActiveProject,
 } from 'ng-morph';
@@ -43,7 +46,7 @@ export function renamingRule(packageName: Pattern, renames: RenameConfig) {
               .getSourceFile()
               .getFilePath()
               .toString();
-              const key = `${filePath}__${rename.moduleSpecifier}`;
+            const key = `${filePath}__${rename.moduleSpecifier}`;
             const namedImportConfig: ImportConfig = {
               name: rename.namedImport,
             };

--- a/libs/state/selections/spec/accumulation-observable.spec.ts
+++ b/libs/state/selections/spec/accumulation-observable.spec.ts
@@ -6,10 +6,8 @@ import {
   select,
   createAccumulationObservable,
 } from '@rx-angular/state/selections';
-import {
-  initialPrimitiveState,
-  PrimitiveState,
-} from '@test-helpers/rx-angular';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
+import { initialPrimitiveState } from '@test-helpers/rx-angular';
 
 function setupAccumulationObservable<T extends object>(cfg: {
   initialState?: T;

--- a/libs/state/selections/spec/distinctUntilSomeChanged.spec.ts
+++ b/libs/state/selections/spec/distinctUntilSomeChanged.spec.ts
@@ -2,10 +2,11 @@
 import { jestMatcher } from '@test-helpers/rx-angular';
 import { mergeMap } from 'rxjs/operators';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { KeyCompareMap } from '@rx-angular/state/selections';
+import type { KeyCompareMap } from '@rx-angular/state/selections';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { distinctUntilSomeChanged } from '@rx-angular/state/selections';
-import { Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 let testScheduler: TestScheduler;

--- a/libs/state/selections/spec/select.spec.ts
+++ b/libs/state/selections/spec/select.spec.ts
@@ -1,12 +1,12 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
+import type { NestedState, PrimitiveState } from '@test-helpers/rx-angular';
 import {
   initialNestedState,
   initialPrimitiveState,
   jestMatcher,
-  NestedState,
-  PrimitiveState,
 } from '@test-helpers/rx-angular';
-import { EMPTY, NEVER, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { EMPTY, NEVER, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { select } from '../src/lib/operators/select';

--- a/libs/state/selections/spec/selectSlice.spec.ts
+++ b/libs/state/selections/spec/selectSlice.spec.ts
@@ -1,11 +1,13 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { jestMatcher } from '@test-helpers/rx-angular';
-import { Observable, of } from 'rxjs';
-import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
+import type { Observable } from 'rxjs';
+import { of } from 'rxjs';
+import type { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
 import { map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { KeyCompareMap, selectSlice } from '@rx-angular/state/selections';
+import type { KeyCompareMap } from '@rx-angular/state/selections';
+import { selectSlice } from '@rx-angular/state/selections';
 
 let testScheduler: TestScheduler;
 

--- a/libs/state/selections/src/lib/accumulation-observable.ts
+++ b/libs/state/selections/src/lib/accumulation-observable.ts
@@ -1,13 +1,5 @@
-import {
-  BehaviorSubject,
-  ConnectableObservable,
-  EMPTY,
-  merge,
-  Observable,
-  queueScheduler,
-  Subject,
-  Subscription,
-} from 'rxjs';
+import type { ConnectableObservable, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, EMPTY, merge, queueScheduler, Subject } from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -19,7 +11,7 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
-import { AccumulationFn, Accumulator } from './model';
+import type { AccumulationFn, Accumulator } from './model';
 
 const defaultAccumulator: AccumulationFn = <T>(st: T, sl: Partial<T>): T => {
   return { ...st, ...sl };

--- a/libs/state/selections/src/lib/interfaces/key-compare-map.ts
+++ b/libs/state/selections/src/lib/interfaces/key-compare-map.ts
@@ -1,4 +1,4 @@
-import { CompareFn } from './compare-fn';
+import type { CompareFn } from './compare-fn';
 
 /**
  * @description

--- a/libs/state/selections/src/lib/model.ts
+++ b/libs/state/selections/src/lib/model.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscribable, Subscription } from 'rxjs';
+import type { Observable, Subscribable, Subscription } from 'rxjs';
 
 export type AccumulationFn = <T>(st: T, sl: Partial<T>) => T;
 

--- a/libs/state/selections/src/lib/operators/distinctUntilSomeChanged.ts
+++ b/libs/state/selections/src/lib/operators/distinctUntilSomeChanged.ts
@@ -1,6 +1,6 @@
-import { MonoTypeOperatorFunction } from 'rxjs';
+import type { MonoTypeOperatorFunction } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
-import { CompareFn, KeyCompareMap } from '../interfaces/index';
+import type { CompareFn, KeyCompareMap } from '../interfaces/index';
 import { safePluck } from '../utils/safe-pluck';
 
 /**

--- a/libs/state/selections/src/lib/operators/select.ts
+++ b/libs/state/selections/src/lib/operators/select.ts
@@ -1,6 +1,10 @@
-import { MonoTypeOperatorFunction, Observable, OperatorFunction } from 'rxjs';
+import type {
+  MonoTypeOperatorFunction,
+  Observable,
+  OperatorFunction,
+} from 'rxjs';
 import { map } from 'rxjs/operators';
-import { KeyCompareMap, PickSlice } from '../interfaces';
+import type { KeyCompareMap, PickSlice } from '../interfaces';
 import {
   isOperateFnArrayGuard,
   isStringAndFunctionTupleGuard,

--- a/libs/state/selections/src/lib/operators/selectSlice.ts
+++ b/libs/state/selections/src/lib/operators/selectSlice.ts
@@ -1,6 +1,6 @@
-import { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
-import { KeyCompareMap, PickSlice } from '../interfaces/index';
+import type { KeyCompareMap, PickSlice } from '../interfaces/index';
 import { distinctUntilSomeChanged } from './distinctUntilSomeChanged';
 
 /**
@@ -108,14 +108,12 @@ export function selectSlice<T extends object, K extends keyof T>(
         }
 
         // create the selected slice
-        return definedKeys
-          .reduce((vm, key) => {
-            vm[key] = state[key];
-            return vm;
-          }, {} as PickSlice<T, K>);
+        return definedKeys.reduce((vm, key) => {
+          vm[key] = state[key];
+          return vm;
+        }, {} as PickSlice<T, K>);
       }),
       filter((v) => v !== undefined),
       distinctUntilSomeChanged(keys, keyCompareMap)
     );
 }
-

--- a/libs/state/selections/src/lib/operators/stateful.ts
+++ b/libs/state/selections/src/lib/operators/stateful.ts
@@ -1,6 +1,6 @@
-import { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, OperatorFunction } from 'rxjs';
 import { distinctUntilChanged, filter, shareReplay } from 'rxjs/operators';
-import { NonUndefined } from '../interfaces';
+import type { NonUndefined } from '../interfaces';
 import { isOperateFnArrayGuard } from '../utils/guards';
 import { pipeFromArray } from '../utils/pipe-from-array';
 

--- a/libs/state/selections/src/lib/side-effect-observable.ts
+++ b/libs/state/selections/src/lib/side-effect-observable.ts
@@ -1,4 +1,5 @@
-import { merge, Observable, queueScheduler, Subject, Subscribable, Subscription } from 'rxjs';
+import type { Observable, Subscribable, Subscription } from 'rxjs';
+import { merge, queueScheduler, Subject } from 'rxjs';
 import { mergeAll, observeOn } from 'rxjs/operators';
 
 export function createSideEffectObservable<T>(
@@ -23,6 +24,6 @@ export function createSideEffectObservable<T>(
   return {
     effects$,
     nextEffectObservable,
-    subscribe
+    subscribe,
   };
 }

--- a/libs/state/selections/src/lib/utils/guards.ts
+++ b/libs/state/selections/src/lib/utils/guards.ts
@@ -1,4 +1,4 @@
-import { OperatorFunction } from 'rxjs';
+import type { OperatorFunction } from 'rxjs';
 
 export function isPromiseGuard<T>(value: unknown): value is Promise<T> {
   return (

--- a/libs/state/selections/src/lib/utils/pipe-from-array.ts
+++ b/libs/state/selections/src/lib/utils/pipe-from-array.ts
@@ -1,4 +1,5 @@
-import { noop, UnaryFunction } from 'rxjs';
+import type { UnaryFunction } from 'rxjs';
+import { noop } from 'rxjs';
 
 export function pipeFromArray<T, R>(
   fns: Array<UnaryFunction<T, R>>

--- a/libs/state/spec/rx-state.component-patterns.spec.ts
+++ b/libs/state/spec/rx-state.component-patterns.spec.ts
@@ -1,16 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  AfterViewInit,
-  Component,
-  Input,
-  Output,
-  ViewChild,
-} from '@angular/core';
-import {
-  initialPrimitiveState,
-  PrimitiveState,
-} from '@test-helpers/rx-angular';
-import { Observable, Subject } from 'rxjs';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { AfterViewInit } from '@angular/core';
+import { Component, Input, Output, ViewChild } from '@angular/core';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
+import { initialPrimitiveState } from '@test-helpers/rx-angular';
+import type { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { RxState } from '../src/lib/rx-state.service';
 import { select } from '@rx-angular/state/selections';
 

--- a/libs/state/spec/rx-state.component.spec.ts
+++ b/libs/state/spec/rx-state.component.spec.ts
@@ -1,8 +1,10 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { Component, Input, Output, ViewChild } from '@angular/core';
-import { PrimitiveState } from '@test-helpers/rx-angular';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
 import { createStateChecker } from './fixtures';
-import { Observable, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { RxState } from '../src/lib/rx-state.service';
 import { select } from '@rx-angular/state/selections';
 

--- a/libs/state/spec/rx-state.docs.spec.ts
+++ b/libs/state/spec/rx-state.docs.spec.ts
@@ -1,4 +1,5 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { rxState } from '../src/lib/rx-state';
 import { Component, Injectable } from '@angular/core';

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -2,11 +2,11 @@ import { Injector, runInInjectionContext } from '@angular/core';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { RxState } from '../src/lib/rx-state.service';
 import { select } from '@rx-angular/state/selections';
+import type { PrimitiveState } from '@test-helpers/rx-angular';
 import {
   initialNestedState,
   initialPrimitiveState,
   jestMatcher,
-  PrimitiveState,
 } from '@test-helpers/rx-angular';
 import { of, scheduled, Subject } from 'rxjs';
 import { map, switchMap, take, takeUntil } from 'rxjs/operators';

--- a/libs/state/spec/rx-state.spec.ts
+++ b/libs/state/spec/rx-state.spec.ts
@@ -1,7 +1,8 @@
 import { Component, isSignal, signal } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { delay, of, pipe, startWith } from 'rxjs';
-import { rxState, RxStateSetupFn } from '../src/lib/rx-state';
+import type { RxStateSetupFn } from '../src/lib/rx-state';
+import { rxState } from '../src/lib/rx-state';
 import { RxState } from '../src/lib/rx-state.service';
 import { selectSlice } from '@rx-angular/state/selections';
 import { filter, map } from 'rxjs/operators';

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -1,34 +1,34 @@
+import type { OnDestroy, Signal } from '@angular/core';
 import {
   computed,
   inject,
   Injectable,
   Injector,
   isSignal,
-  OnDestroy,
-  Signal,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import {
+import type {
   AccumulationFn,
+  KeyCompareMap,
+  PickSlice,
+} from '@rx-angular/state/selections';
+import {
   createAccumulationObservable,
   createSideEffectObservable,
   isKeyOf,
-  KeyCompareMap,
-  PickSlice,
   safePluck,
   select,
 } from '@rx-angular/state/selections';
-import {
-  EMPTY,
-  isObservable,
+import type {
   Observable,
   OperatorFunction,
   Subscribable,
-  Subscription,
   Unsubscribable,
 } from 'rxjs';
+import { EMPTY, isObservable, Subscription } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
-import { createSignalStateProxy, SignalStateProxy } from './signal-state-proxy';
+import type { SignalStateProxy } from './signal-state-proxy';
+import { createSignalStateProxy } from './signal-state-proxy';
 
 export type ProjectStateFn<T> = (oldState: T) => Partial<T>;
 export type ProjectValueFn<T, K extends keyof T> = (oldState: T) => T[K];

--- a/libs/state/src/lib/signal-state-proxy.ts
+++ b/libs/state/src/lib/signal-state-proxy.ts
@@ -1,12 +1,7 @@
-import {
-  DestroyRef,
-  inject,
-  signal,
-  Signal,
-  WritableSignal,
-} from '@angular/core';
+import type { Signal, WritableSignal } from '@angular/core';
+import { DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 import { select } from '@rx-angular/state/selections';
 
 export type SignalStateProxy<State extends object> = {

--- a/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
+++ b/libs/template/experimental/viewport-prio/src/lib/viewport-prio.directive.ts
@@ -1,15 +1,9 @@
-import {
-  Directive,
-  ElementRef,
-  Inject,
-  Input,
-  OnDestroy,
-  OnInit,
-  Optional,
-} from '@angular/core';
-import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import type { OnDestroy, OnInit } from '@angular/core';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { Directive, Input, ElementRef } from '@angular/core';
+import { type RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { coerceObservableWith } from '@rx-angular/cdk/coercing';
-import { RxNotification } from '@rx-angular/cdk/notifications';
+import type { RxNotification } from '@rx-angular/cdk/notifications';
 import { RxLet } from '@rx-angular/template/let';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
 import { filter, map, mergeAll, withLatestFrom } from 'rxjs/operators';

--- a/libs/template/experimental/virtual-scrolling/src/lib/model.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/model.ts
@@ -1,5 +1,4 @@
-import {
-  Directive,
+import type {
   ElementRef,
   EmbeddedViewRef,
   NgIterable,
@@ -7,8 +6,10 @@ import {
   TrackByFunction,
   ViewContainerRef,
 } from '@angular/core';
+import { Directive } from '@angular/core';
 import { RxDefaultListViewContext } from '@rx-angular/cdk/template';
-import { Observable, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 
 type CreateViewContext<Implicit, Context, ComputedContext> = (
   value: Implicit,

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -1,22 +1,14 @@
-import {
-  Directive,
+import type {
   EmbeddedViewRef,
-  inject,
-  Input,
   NgIterable,
   OnChanges,
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { Directive, inject, Input } from '@angular/core';
 import { coalesceWith } from '@rx-angular/cdk/coalescing';
-import {
-  combineLatest,
-  merge,
-  MonoTypeOperatorFunction,
-  Observable,
-  ReplaySubject,
-  Subject,
-} from 'rxjs';
+import type { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { combineLatest, merge, ReplaySubject, Subject } from 'rxjs';
 import {
   distinctUntilChanged,
   exhaustMap,
@@ -32,13 +24,13 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import {
+import type {
   ListRange,
   RxVirtualForViewContext,
-  RxVirtualScrollStrategy,
   RxVirtualScrollViewport,
   RxVirtualViewRepeater,
 } from '../model';
+import { RxVirtualScrollStrategy } from '../model';
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -1,19 +1,13 @@
-import {
-  Directive,
-  inject,
-  Input,
+import type {
   NgIterable,
   OnChanges,
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { Directive, inject, Input } from '@angular/core';
 import { coalesceWith } from '@rx-angular/cdk/coalescing';
-import {
-  combineLatest,
-  MonoTypeOperatorFunction,
-  ReplaySubject,
-  Subject,
-} from 'rxjs';
+import type { MonoTypeOperatorFunction } from 'rxjs';
+import { combineLatest, ReplaySubject, Subject } from 'rxjs';
 import {
   distinctUntilChanged,
   map,
@@ -23,12 +17,12 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import {
+import type {
   ListRange,
-  RxVirtualScrollStrategy,
   RxVirtualScrollViewport,
   RxVirtualViewRepeater,
 } from '../model';
+import { RxVirtualScrollStrategy } from '../model';
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
@@ -1,20 +1,14 @@
-import {
-  Directive,
+import type {
   EmbeddedViewRef,
-  inject,
-  Input,
   NgIterable,
   OnChanges,
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { Directive, inject, Input } from '@angular/core';
 import { coalesceWith } from '@rx-angular/cdk/coalescing';
-import {
-  combineLatest,
-  MonoTypeOperatorFunction,
-  ReplaySubject,
-  Subject,
-} from 'rxjs';
+import type { MonoTypeOperatorFunction } from 'rxjs';
+import { combineLatest, ReplaySubject, Subject } from 'rxjs';
 import {
   distinctUntilChanged,
   map,
@@ -24,13 +18,13 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import {
+import type {
   ListRange,
   RxVirtualForViewContext,
-  RxVirtualScrollStrategy,
   RxVirtualScrollViewport,
   RxVirtualViewRepeater,
 } from '../model';
+import { RxVirtualScrollStrategy } from '../model';
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-for.directive.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-for.directive.ts
@@ -1,36 +1,39 @@
+import type {
+  DoCheck,
+  EmbeddedViewRef,
+  IterableChanges,
+  IterableDiffer,
+  NgIterable,
+  OnDestroy,
+  OnInit,
+  TrackByFunction,
+} from '@angular/core';
 import {
   ChangeDetectorRef,
   Directive,
-  DoCheck,
-  EmbeddedViewRef,
   ErrorHandler,
   inject,
   Input,
-  IterableChanges,
-  IterableDiffer,
   IterableDiffers,
-  NgIterable,
   NgZone,
-  OnDestroy,
-  OnInit,
   TemplateRef,
-  TrackByFunction,
   ViewContainerRef,
 } from '@angular/core';
 import { coerceObservableWith } from '@rx-angular/cdk/coercing';
-import {
-  onStrategy,
+import type {
   RxStrategyCredentials,
   RxStrategyNames,
+} from '@rx-angular/cdk/render-strategies';
+import {
+  onStrategy,
   RxStrategyProvider,
   strategyHandling,
 } from '@rx-angular/cdk/render-strategies';
-import { RxListViewComputedContext } from '@rx-angular/cdk/template';
+import type { RxListViewComputedContext } from '@rx-angular/cdk/template';
+import type { MonoTypeOperatorFunction, Observable } from 'rxjs';
 import {
   isObservable,
-  MonoTypeOperatorFunction,
   NEVER,
-  Observable,
   ReplaySubject,
   Subject,
   of,
@@ -49,16 +52,14 @@ import {
   switchAll,
 } from 'rxjs/operators';
 
+import type { ListRange } from './model';
 import {
-  ListRange,
   RxVirtualForViewContext,
   RxVirtualScrollStrategy,
   RxVirtualViewRepeater,
 } from './model';
-import {
-  createVirtualListTemplateManager,
-  RxVirtualListTemplateManager,
-} from './virtual-list-template-manager';
+import type { RxVirtualListTemplateManager } from './virtual-list-template-manager';
+import { createVirtualListTemplateManager } from './virtual-list-template-manager';
 import {
   DEFAULT_TEMPLATE_CACHE_SIZE,
   RX_VIRTUAL_SCROLL_DEFAULT_OPTIONS,

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-list-template-manager.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-list-template-manager.ts
@@ -1,7 +1,7 @@
-import { EmbeddedViewRef, IterableChanges, ViewRef } from '@angular/core';
-import { RxListViewContext } from '@rx-angular/cdk/template';
+import type { EmbeddedViewRef, IterableChanges, ViewRef } from '@angular/core';
+import type { RxListViewContext } from '@rx-angular/cdk/template';
 
-import { TemplateSettings } from './model';
+import type { TemplateSettings } from './model';
 
 export interface RxVirtualListChange<T, C> {
   index?: number;

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -1,13 +1,11 @@
 import { NgIf } from '@angular/common';
+import type { AfterContentInit, AfterViewInit, OnDestroy } from '@angular/core';
 import {
-  AfterContentInit,
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ContentChild,
   ElementRef,
   inject,
-  OnDestroy,
   Output,
   ViewChild,
   ViewEncapsulation,

--- a/libs/template/experimental/virtual-scrolling/tests/autosize.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/autosize.cy.ts
@@ -1,9 +1,9 @@
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import type { ListRange } from '../src/index';
 import {
   RxVirtualFor,
   RxVirtualScrollViewportComponent,
-  ListRange,
   AutoSizeVirtualScrollStrategy,
   RxVirtualScrollWindowDirective,
   RxVirtualScrollElementDirective,
@@ -11,13 +11,12 @@ import {
 import { createOutputSpy, mount } from 'cypress/angular';
 import { By } from '@angular/platform-browser';
 import { DEFAULT_ITEM_SIZE } from '../src/lib/virtual-scroll.config';
+import type { Item, VirtualScrollMountConfig } from './fixtures';
 import {
   defaultMountConfig,
   generateItems,
   getDefaultMountConfig,
   getViewportComponent,
-  Item,
-  VirtualScrollMountConfig,
 } from './fixtures';
 
 interface AutoSizeVirtualScrollMountConfig

--- a/libs/template/experimental/virtual-scrolling/tests/dynamic-size.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/dynamic-size.cy.ts
@@ -1,21 +1,20 @@
 import { Subject } from 'rxjs';
+import type { ListRange } from '../src/index';
 import {
   RxVirtualFor,
   RxVirtualScrollViewportComponent,
-  ListRange,
   DynamicSizeVirtualScrollStrategy,
   RxVirtualScrollElementDirective,
   RxVirtualScrollWindowDirective,
 } from '../src/index';
 import { createOutputSpy, mount } from 'cypress/angular';
 import { By } from '@angular/platform-browser';
+import type { Item, VirtualScrollMountConfig } from './fixtures';
 import {
   defaultMountConfig,
   generateItems,
   getDefaultMountConfig,
   getViewportComponent,
-  Item,
-  VirtualScrollMountConfig,
 } from './fixtures';
 
 interface DynamicVirtualScrollMountConfig

--- a/libs/template/experimental/virtual-scrolling/tests/fixed-size.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/fixed-size.cy.ts
@@ -1,22 +1,21 @@
 import { Subject } from 'rxjs';
+import type { ListRange } from '../src/index';
 import {
   FixedSizeVirtualScrollStrategy,
   RxVirtualFor,
   RxVirtualScrollViewportComponent,
-  ListRange,
   RxVirtualScrollWindowDirective,
   RxVirtualScrollElementDirective,
 } from '../src/index';
 import { createOutputSpy, mount } from 'cypress/angular';
 import { By } from '@angular/platform-browser';
+import type { Item, VirtualScrollMountConfig } from './fixtures';
 import {
   defaultItemLength,
   defaultMountConfig,
   generateItems,
   getDefaultMountConfig,
   getViewportComponent,
-  Item,
-  VirtualScrollMountConfig,
 } from './fixtures';
 
 const defaultItemTemplate = `{{ item.id }}`;

--- a/libs/template/experimental/virtual-scrolling/tests/fixtures.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/fixtures.ts
@@ -1,14 +1,15 @@
-import { NgIterable } from '@angular/core';
+import type { NgIterable } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { createOutputSpy, mount } from 'cypress/angular';
-import { Observable, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import {
   FixedSizeVirtualScrollStrategy,
   ListRange,
   RxVirtualFor,
   RxVirtualScrollViewportComponent,
 } from '../src/index';
-import { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import type { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
 
 import {
   DEFAULT_ITEM_SIZE,

--- a/libs/template/for/src/lib/for-view-context.ts
+++ b/libs/template/for/src/lib/for-view-context.ts
@@ -1,4 +1,4 @@
-import { NgIterable } from '@angular/core';
+import type { NgIterable } from '@angular/core';
 import { RxDefaultListViewContext } from '@rx-angular/cdk/template';
 
 export class RxForViewContext<

--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -1,41 +1,36 @@
+import type {
+  DoCheck,
+  EmbeddedViewRef,
+  NgIterable,
+  OnDestroy,
+  OnInit,
+  TrackByFunction,
+} from '@angular/core';
 import {
   ChangeDetectorRef,
   Directive,
-  DoCheck,
-  EmbeddedViewRef,
   ErrorHandler,
   inject,
   Input,
   IterableDiffers,
-  NgIterable,
   NgZone,
-  OnDestroy,
-  OnInit,
   TemplateRef,
-  TrackByFunction,
   ViewContainerRef,
 } from '@angular/core';
 import {
   coerceDistinctWith,
   coerceObservableWith,
 } from '@rx-angular/cdk/coercing';
-import {
-  RxStrategyNames,
-  RxStrategyProvider,
-} from '@rx-angular/cdk/render-strategies';
-import {
-  createListTemplateManager,
+import type { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import type {
   RxListManager,
   RxListViewComputedContext,
 } from '@rx-angular/cdk/template';
+import { createListTemplateManager } from '@rx-angular/cdk/template';
 
-import {
-  isObservable,
-  Observable,
-  ReplaySubject,
-  Subject,
-  Subscription,
-} from 'rxjs';
+import type { Observable, Subject } from 'rxjs';
+import { isObservable, ReplaySubject, Subscription } from 'rxjs';
 import { shareReplay, switchAll } from 'rxjs/operators';
 import { RxForViewContext } from './for-view-context';
 

--- a/libs/template/for/src/lib/tests/fixtures.ts
+++ b/libs/template/for/src/lib/tests/fixtures.ts
@@ -1,5 +1,6 @@
 import { Component, ErrorHandler } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject, Subject } from 'rxjs';
 
 export let thisArg: any;

--- a/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.observable.spec.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ErrorHandler } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { Observable } from 'rxjs';

--- a/libs/template/for/src/lib/tests/for.directive.parent-notification.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.parent-notification.spec.ts
@@ -1,15 +1,9 @@
-import {
-  Component,
-  ElementRef,
-  ErrorHandler,
-  QueryList,
-  ViewChildren,
-} from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  RxRenderBehavior,
-  RxStrategyProvider,
-} from '@rx-angular/cdk/render-strategies';
+import type { ElementRef, ErrorHandler, QueryList } from '@angular/core';
+import { Component, ViewChildren } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { RxRenderBehavior } from '@rx-angular/cdk/render-strategies';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
 import { asapScheduler, delay } from 'rxjs';
 import { RxFor } from '../for.directive';

--- a/libs/template/for/src/lib/tests/for.directive.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.spec.ts
@@ -1,5 +1,6 @@
 import { ErrorHandler } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { RxFor } from '../for.directive';

--- a/libs/template/for/src/lib/tests/for.directive.strategy.spec.ts
+++ b/libs/template/for/src/lib/tests/for.directive.strategy.spec.ts
@@ -1,5 +1,6 @@
-import { ErrorHandler } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ErrorHandler } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { RxFor } from '../for.directive';
 import { createTestComponent, TestComponent } from './fixtures';

--- a/libs/template/if/src/lib/if.directive.ts
+++ b/libs/template/if/src/lib/if.directive.ts
@@ -1,12 +1,14 @@
+import type {
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import {
   ChangeDetectorRef,
   Directive,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  SimpleChanges,
   TemplateRef,
   ViewContainerRef,
   inject,
@@ -16,30 +18,15 @@ import {
   RxNotificationKind,
   createTemplateNotifier,
 } from '@rx-angular/cdk/notifications';
-import {
-  RxStrategyNames,
-  RxStrategyProvider,
-} from '@rx-angular/cdk/render-strategies';
-import {
-  RxTemplateManager,
-  createTemplateManager,
-} from '@rx-angular/cdk/template';
-import {
-  NEVER,
-  NextObserver,
-  Observable,
-  ObservableInput,
-  ReplaySubject,
-  Subject,
-  Subscription,
-  merge,
-} from 'rxjs';
+import type { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import type { RxTemplateManager } from '@rx-angular/cdk/template';
+import { createTemplateManager } from '@rx-angular/cdk/template';
+import type { NextObserver, Observable, ObservableInput } from 'rxjs';
+import { NEVER, ReplaySubject, Subject, Subscription, merge } from 'rxjs';
 import { filter, map, mergeAll } from 'rxjs/operators';
-import {
-  RxIfTemplateNames,
-  RxIfViewContext,
-  rxIfTemplateNames,
-} from './model/index';
+import type { RxIfViewContext, rxIfTemplateNames } from './model/index';
+import { RxIfTemplateNames } from './model/index';
 
 /**
  * @Directive IfDirective

--- a/libs/template/if/src/lib/model/template-names.ts
+++ b/libs/template/if/src/lib/model/template-names.ts
@@ -1,7 +1,5 @@
-import {
-  RxBaseTemplateNames,
-  rxBaseTemplateNames,
-} from '@rx-angular/cdk/template';
+import type { rxBaseTemplateNames } from '@rx-angular/cdk/template';
+import { RxBaseTemplateNames } from '@rx-angular/cdk/template';
 
 export type rxIfTemplateNames = 'rxThen' | 'rxElse' | rxBaseTemplateNames;
 

--- a/libs/template/if/src/lib/model/view-context.ts
+++ b/libs/template/if/src/lib/model/view-context.ts
@@ -1,4 +1,4 @@
-import { RxViewContext } from '@rx-angular/cdk/template';
+import type { RxViewContext } from '@rx-angular/cdk/template';
 
 export interface RxIfViewContext<T = unknown> extends RxViewContext<T> {
   // to enable `as` syntax we have to assign the directives selector (var as v)

--- a/libs/template/if/src/lib/tests/fixtures.ts
+++ b/libs/template/if/src/lib/tests/fixtures.ts
@@ -1,7 +1,9 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RxNotificationKind } from '@rx-angular/cdk/notifications';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
+import type { RxNotificationKind } from '@rx-angular/cdk/notifications';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 // eslint-disable-next-line @angular-eslint/component-selector
 @Component({ selector: 'test-cmp', template: '' })

--- a/libs/template/if/src/lib/tests/if.directive.context-templates.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.context-templates.spec.ts
@@ -1,9 +1,5 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RxNotificationKind } from '@rx-angular/cdk/notifications';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';

--- a/libs/template/if/src/lib/tests/if.directive.context.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.context.spec.ts
@@ -1,9 +1,5 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RxNotificationKind } from '@rx-angular/cdk/notifications';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';

--- a/libs/template/if/src/lib/tests/if.directive.observable.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.observable.spec.ts
@@ -1,4 +1,5 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { BehaviorSubject, of, startWith, throwError, tap } from 'rxjs';

--- a/libs/template/if/src/lib/tests/if.directive.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.spec.ts
@@ -1,4 +1,5 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { RxIf } from '../if.directive';

--- a/libs/template/if/src/lib/tests/if.directive.strategy.spec.ts
+++ b/libs/template/if/src/lib/tests/if.directive.strategy.spec.ts
@@ -1,5 +1,6 @@
-import { ErrorHandler } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ErrorHandler } from '@angular/core';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
 import { RxIf } from '../if.directive';
 import { createTestComponent, TestComponent } from './fixtures';

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -1,3 +1,9 @@
+import type {
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import {
   ChangeDetectorRef,
   Directive,
@@ -5,38 +11,32 @@ import {
   inject,
   Input,
   NgZone,
-  OnChanges,
-  OnDestroy,
-  OnInit,
   Output,
-  SimpleChanges,
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
+import type { RxNotification } from '@rx-angular/cdk/notifications';
 import {
   createTemplateNotifier,
-  RxNotification,
   RxNotificationKind,
 } from '@rx-angular/cdk/notifications';
-import {
-  RxStrategyNames,
-  RxStrategyProvider,
-} from '@rx-angular/cdk/render-strategies';
-import {
-  createTemplateManager,
-  RxBaseTemplateNames,
+import type { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
+import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
+import type {
   RxTemplateManager,
   RxViewContext,
 } from '@rx-angular/cdk/template';
+import {
+  createTemplateManager,
+  RxBaseTemplateNames,
+} from '@rx-angular/cdk/template';
 
+import type { NextObserver, Observable, ObservableInput } from 'rxjs';
 import {
   defer,
   merge,
   NEVER,
-  NextObserver,
-  Observable,
-  ObservableInput,
   ReplaySubject,
   Subject,
   Subscription,

--- a/libs/template/let/src/lib/tests/let.directive.complete.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.complete.spec.ts
@@ -7,7 +7,8 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { EMPTY, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 
 import { RxLet } from '../let.directive';
 import { MockChangeDetectorRef } from './fixtures';

--- a/libs/template/let/src/lib/tests/let.directive.context.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.context.spec.ts
@@ -4,20 +4,16 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
+import type { Observable } from 'rxjs';
 import {
   BehaviorSubject,
   EMPTY,
   interval,
   NEVER,
-  Observable,
   of,
   Subject,
   throwError,

--- a/libs/template/let/src/lib/tests/let.directive.error.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.error.spec.ts
@@ -7,7 +7,8 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { Observable, of, throwError } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { RxLet } from '../let.directive';
 import { MockChangeDetectorRef } from './fixtures';

--- a/libs/template/let/src/lib/tests/let.directive.next.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.next.spec.ts
@@ -5,7 +5,8 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
-import { EMPTY, interval, NEVER, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { EMPTY, interval, NEVER, of } from 'rxjs';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RxLet } from '../let.directive';
 import { take } from 'rxjs/operators';

--- a/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.parent-notification.spec.ts
@@ -1,13 +1,9 @@
-import {
-  Component,
-  ElementRef,
-  QueryList,
-  ViewChild,
-  ViewChildren,
-} from '@angular/core';
+import type { ElementRef, QueryList } from '@angular/core';
+import { Component, ViewChild, ViewChildren } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
-import { Observable, ReplaySubject, Subject, asapScheduler, delay } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { ReplaySubject, Subject, asapScheduler, delay } from 'rxjs';
 import { RxLet } from '../let.directive';
 
 @Component({

--- a/libs/template/let/src/lib/tests/let.directive.rendered.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.rendered.spec.ts
@@ -7,7 +7,8 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { RxLet } from '../let.directive';
 import { MockChangeDetectorRef } from './fixtures';
 

--- a/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.strategy.spec.ts
@@ -1,7 +1,9 @@
 import { Component, NgZone } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RxStrategyProvider } from '@rx-angular/cdk/render-strategies';
-import { BehaviorSubject, firstValueFrom, Observable, of, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of, Subject } from 'rxjs';
 
 import { RxLet } from '../let.directive';
 import Spy = jasmine.Spy;

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.all.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.all.spec.ts
@@ -4,21 +4,17 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RxNotificationKind } from '@rx-angular/cdk/notifications';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
+import type { Observable } from 'rxjs';
 import {
   BehaviorSubject,
   EMPTY,
   interval,
   NEVER,
-  Observable,
   of,
   Subject,
   throwError,

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-complete.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-complete.spec.ts
@@ -4,10 +4,12 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { EMPTY, Observable, of } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 
 import { RxLet } from '../let.directive';
 import { MockChangeDetectorRef } from './fixtures';

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-error.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-error.spec.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { Observable, of, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { RxLet } from '../let.directive';
 
 @Component({

--- a/libs/template/let/src/lib/tests/let.directive.template-binding.no-suspense.spec.ts
+++ b/libs/template/let/src/lib/tests/let.directive.template-binding.no-suspense.spec.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { RX_RENDER_STRATEGIES_CONFIG } from '@rx-angular/cdk/render-strategies';
 import { mockConsole } from '@test-helpers/rx-angular';
-import { Observable, of, Subject } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { RxLet } from '../let.directive';
 
 @Component({

--- a/libs/template/push/src/lib/push.pipe.ts
+++ b/libs/template/push/src/lib/push.pipe.ts
@@ -1,31 +1,29 @@
+import type { OnDestroy, PipeTransform } from '@angular/core';
 import {
   ChangeDetectorRef,
   NgZone,
-  OnDestroy,
   Pipe,
-  PipeTransform,
   inject,
   untracked,
 } from '@angular/core';
+import type { RxNotification } from '@rx-angular/cdk/notifications';
 import {
-  RxNotification,
   RxNotificationKind,
   createTemplateNotifier,
 } from '@rx-angular/cdk/notifications';
+import type { RxStrategyNames } from '@rx-angular/cdk/render-strategies';
 import {
-  RxStrategyNames,
   RxStrategyProvider,
   strategyHandling,
 } from '@rx-angular/cdk/render-strategies';
-import {
+import type {
   MonoTypeOperatorFunction,
   NextObserver,
-  Observable,
   ObservableInput,
   OperatorFunction,
-  Subscription,
   Unsubscribable,
 } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import {
   filter,
   shareReplay,

--- a/libs/template/push/src/lib/tests/push.pipe.spec.ts
+++ b/libs/template/push/src/lib/tests/push.pipe.spec.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectorRef, Component, computed, signal } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ComponentFixture } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   RX_RENDER_STRATEGIES_CONFIG,
   RxStrategyProvider,

--- a/libs/template/schematics/src/commands/ng-add/index.spec.ts
+++ b/libs/template/schematics/src/commands/ng-add/index.spec.ts
@@ -1,7 +1,5 @@
-import {
-  SchematicTestRunner,
-  UnitTestTree,
-} from '@angular-devkit/schematics/testing';
+import type { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { join } from 'path';
 import { readJsonInTree } from '../../utils/read-json-in-tree';
 

--- a/libs/template/schematics/src/commands/ng-add/index.ts
+++ b/libs/template/schematics/src/commands/ng-add/index.ts
@@ -1,16 +1,10 @@
-import {
-  chain,
-  Rule,
-  SchematicContext,
-  Tree,
-} from '@angular-devkit/schematics';
-import {
-  NodeDependencyType,
-} from '@schematics/angular/utility/dependencies';
+import type { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
+import { NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { addPackageJsonDependency } from '@schematics/angular/utility/dependencies';
 
-import { Dependency } from '../../utils/dependency';
+import type { Dependency } from '../../utils/dependency';
 import { getLatestNodeVersion } from '../../utils/get-latest-node-version';
 
 const dependencies: Dependency[] = [

--- a/libs/template/schematics/src/utils/dependency.ts
+++ b/libs/template/schematics/src/utils/dependency.ts
@@ -1,4 +1,2 @@
-import {
-  NodeDependency,
-} from '@schematics/angular/utility/dependencies';
+import type { NodeDependency } from '@schematics/angular/utility/dependencies';
 export type Dependency = Omit<NodeDependency, 'version'>;

--- a/libs/template/schematics/src/utils/format-files.ts
+++ b/libs/template/schematics/src/utils/format-files.ts
@@ -1,4 +1,11 @@
-import { CreateFileAction, noop, OverwriteFileAction, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import type {
+  CreateFileAction,
+  OverwriteFileAction,
+  Rule,
+  SchematicContext,
+  Tree,
+} from '@angular-devkit/schematics';
+import { noop } from '@angular-devkit/schematics';
 import * as path from 'path';
 import { from } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';

--- a/libs/template/schematics/src/utils/read-json-in-tree.ts
+++ b/libs/template/schematics/src/utils/read-json-in-tree.ts
@@ -1,4 +1,4 @@
-import { Tree } from '@angular-devkit/schematics';
+import type { Tree } from '@angular-devkit/schematics';
 
 export function readJsonInTree<T = any>(host: Tree, path: string): T {
   if (!host.exists(path)) {

--- a/libs/template/schematics/src/utils/renaming-rule.ts
+++ b/libs/template/schematics/src/utils/renaming-rule.ts
@@ -1,11 +1,14 @@
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
+import type { Rule, Tree } from '@angular-devkit/schematics';
+import { chain } from '@angular-devkit/schematics';
+import type {
+  ImportSpecifier,
+  ImportSpecifierStructure,
+  Pattern,
+} from 'ng-morph';
 import {
   addImports,
   createProject,
   getImports,
-  ImportSpecifier,
-  ImportSpecifierStructure,
-  Pattern,
   saveActiveProject,
   setActiveProject,
 } from 'ng-morph';
@@ -43,7 +46,7 @@ export function renamingRule(packageName: Pattern, renames: RenameConfig) {
               .getSourceFile()
               .getFilePath()
               .toString();
-              const key = `${filePath}__${rename.moduleSpecifier}`;
+            const key = `${filePath}__${rename.moduleSpecifier}`;
             const namedImportConfig: ImportConfig = {
               name: rename.namedImport,
             };

--- a/libs/template/unpatch/src/lib/unpatch.directive.ts
+++ b/libs/template/unpatch/src/lib/unpatch.directive.ts
@@ -1,12 +1,11 @@
-import {
+import type {
   AfterViewInit,
-  Directive,
-  ElementRef,
-  Input,
   OnChanges,
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { Directive, Input, ElementRef } from '@angular/core';
 import { getZoneUnPatchedApi } from '@rx-angular/cdk/internals/core';
 import {
   focusEvents,


### PR DESCRIPTION
See: [Benefits of Enforcing Type-only Imports/Exports](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/website/blog/2023-02-24-consistent-type-exports-and-imports-why-and-how.md#benefits-of-enforcing-type-only-importsexports) for more info