### PR TITLE
feat: add signal method overloads to select nested keys

### DIFF
--- a/libs/state/spec/rx-state.spec.ts
+++ b/libs/state/spec/rx-state.spec.ts
@@ -148,6 +148,46 @@ describe(rxState, () => {
       expect(count === count2).toBe(true);
     });
 
+    it('should create a signal from multiple nested keys', () => {
+      const { component } = setupComponent<NestedStateInterface>(({ set }) => {
+        set({
+          count: 1337,
+          depth1: {
+            depth2: {
+              depth3: {
+                depth4: {
+                  depth5: {
+                    test: 'works',
+                  },
+                },
+              },
+            },
+          },
+        });
+      });
+
+      const state = component.state;
+      const nestedSignal = state.signal(
+        'depth1',
+        'depth2',
+        'depth3',
+        'depth4',
+        'depth5',
+        'test'
+      );
+
+      expect(isSignal(nestedSignal)).toBe(true);
+      expect(nestedSignal()).toBe('works');
+
+      state.set({
+        depth1: {
+          depth2: { depth3: { depth4: { depth5: { test: 'works2' } } } },
+        },
+      });
+
+      expect(nestedSignal()).toBe('works2');
+    });
+
     it('signal should get updated', () => {
       const { component } = setupComponent<{ count: number }>(({ set }) => {
         set({ count: 1337 });
@@ -335,5 +375,20 @@ function setupComponent<State extends { count: number }>(
   return {
     fixture,
     component: fixture.componentInstance,
+  };
+}
+
+interface NestedStateInterface {
+  count: number;
+  depth1: {
+    depth2: {
+      depth3: {
+        depth4: {
+          depth5: {
+            test: string;
+          };
+        };
+      };
+    };
   };
 }

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -703,7 +703,65 @@ export class RxState<T extends object> implements OnDestroy, Subscribable<T> {
    * current keys value in RxState. Whenever the key gets updated, the signal
    * will also be updated accordingly.
    */
-  signal<K extends keyof T>(k: K): Signal<T[K]> {
+  signal<K1 extends keyof T>(k1: K1): Signal<T[K1]>;
+  /**
+   * @internal
+   */
+  signal<K1 extends keyof T, K2 extends keyof T[K1]>(
+    k1: K1,
+    k2: K2
+  ): Signal<T[K1][K2]>;
+  /**
+   * @internal
+   */
+  signal<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2]
+  >(k1: K1, k2: K2, k3: K3): Signal<T[K1][K2][K3]>;
+  /**
+   * @internal
+   */
+  signal<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3]
+  >(k1: K1, k2: K2, k3: K3, k4: K4): Signal<T[K1][K2][K3][K4]>;
+  /**
+   * @internal
+   */
+  signal<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3],
+    K5 extends keyof T[K1][K2][K3][K4]
+  >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): Signal<T[K1][K2][K3][K4][K5]>;
+  /**
+   * @internal
+   */
+  signal<
+    K1 extends keyof T,
+    K2 extends keyof T[K1],
+    K3 extends keyof T[K1][K2],
+    K4 extends keyof T[K1][K2][K3],
+    K5 extends keyof T[K1][K2][K3][K4],
+    K6 extends keyof T[K1][K2][K3][K4][K5]
+  >(
+    k1: K1,
+    k2: K2,
+    k3: K3,
+    k4: K4,
+    k5: K5,
+    k6: K6
+  ): Signal<T[K1][K2][K3][K4][K5][K6]>;
+
+  /**
+   * @internal
+   */
+  signal<R>(...args: string[]): Signal<R> {
+    const k = args.join('.');
     return this.signalStoreProxy[k];
   }
 


### PR DESCRIPTION
Enables signal method overloads 🚀

I went with this approach:
```ts
moviesLoading = this.state.signal('movies', 'loading');
```

TODO: add docs 

Fixes https://github.com/rx-angular/rx-angular/issues/1659

cc @hoebbelsB @edbzn 