### PR TITLE
docs: add warning when using Unpatch on elements that refer a FormControl

### DIFF
--- a/apps/docs/docs/template/api/unpatch-directive.md
+++ b/apps/docs/docs/template/api/unpatch-directive.md
@@ -36,7 +36,9 @@ The `unpatch` directive solves this problem in a convenient way:
 </button>
 ```
 
-> **Warning**: Do not use `[unpatch]` on elements that should trigger navigation (with `routerLink` directly or with method bound to `(click)` or other events). Otherwise you will end up having a 'Navigation triggered outside Angular zone, did you forget to call "ngZone.run()"?' warning.
+> **Warning**: Do not use `[unpatch]` on the following elements:
+> 1. Elements that should trigger navigation (with `routerLink` directly or with method bound to `(click)` or other events). Otherwise you will end up having a 'Navigation triggered outside Angular zone, did you forget to call "ngZone.run()"?' warning.
+> 2. Elements that reference a `FormControl`. Specify all events except the `blur` and `change` events. Otherwise user input is ignored, the `FormControl.valueChanges` observable will not emit and attached validations to the FormControl will not run until next change detection that affects the component in which the element is rendered.
 
 Included Features:
 

--- a/apps/docs/docs/template/api/unpatch-directive.md
+++ b/apps/docs/docs/template/api/unpatch-directive.md
@@ -37,6 +37,7 @@ The `unpatch` directive solves this problem in a convenient way:
 ```
 
 > **Warning**: Do not use `[unpatch]` on the following elements:
+>
 > 1. Elements that should trigger navigation (with `routerLink` directly or with method bound to `(click)` or other events). Otherwise you will end up having a 'Navigation triggered outside Angular zone, did you forget to call "ngZone.run()"?' warning.
 > 2. Elements that reference a `FormControl`. Specify all events except the `blur` and `change` events. Otherwise user input is ignored, the `FormControl.valueChanges` observable will not emit and attached validations to the FormControl will not run until next change detection that affects the component in which the element is rendered.
 


### PR DESCRIPTION
out of the additional context of #1663