### PR TITLE
refactor(cdk): drop unused scheduler APIs

### DIFF
--- a/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.spec.ts
@@ -17,9 +17,7 @@ describe('Scheduler', () => {
 
   const NormalPriority = 3;
   let scheduleCallback: typeof import('./scheduler').scheduleCallback;
-  let requestPaint: typeof import('./scheduler').requestPaint;
   let cancelCallback: typeof import('./scheduler').cancelCallback;
-  let shouldYield: typeof import('./scheduler').shouldYield;
 
   describe.each([['Browser'], ['Node'], ['NonBrowser']])('%p', (env) => {
     beforeEach(() => {
@@ -43,9 +41,7 @@ describe('Scheduler', () => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const Scheduler = require('./scheduler');
       scheduleCallback = Scheduler.scheduleCallback;
-      requestPaint = Scheduler.requestPaint;
       cancelCallback = Scheduler.cancelCallback;
-      shouldYield = Scheduler.shouldYield;
     });
 
     afterEach(() => {
@@ -74,33 +70,6 @@ describe('Scheduler', () => {
       runtime.assertLog([LogEvent.MessageEvent, LogEvent.Task]);
     });
 
-    it('task with continuation', () => {
-      let now: number;
-      scheduleCallback(NormalPriority, () => {
-        runtime.log(LogEvent.Task);
-        while (!shouldYield()) {
-          runtime.advanceTime(1);
-        }
-        now = performance.now();
-        runtime.log(`Yield at ${now}ms`);
-        return () => {
-          runtime.log(LogEvent.Continuation);
-        };
-      });
-      runtime.assertLog([schedulingMessageEvent]);
-
-      runtime.fireMessageEvent();
-      runtime.assertLog([
-        LogEvent.MessageEvent,
-        LogEvent.Task,
-        `Yield at ${now}ms`,
-        schedulingMessageEvent,
-      ]);
-
-      runtime.fireMessageEvent();
-      runtime.assertLog([LogEvent.MessageEvent, LogEvent.Continuation]);
-    });
-
     it('multiple tasks', () => {
       scheduleCallback(NormalPriority, () => {
         runtime.log('A');
@@ -111,26 +80,6 @@ describe('Scheduler', () => {
       runtime.assertLog([schedulingMessageEvent]);
       runtime.fireMessageEvent();
       runtime.assertLog([LogEvent.MessageEvent, 'A', 'B']);
-    });
-
-    it('request paint ', () => {
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('A');
-        requestPaint();
-      });
-      scheduleCallback(NormalPriority, () => {
-        runtime.log('B');
-      });
-      runtime.assertLog([schedulingMessageEvent]);
-      runtime.fireMessageEvent();
-      runtime.assertLog([
-        LogEvent.MessageEvent,
-        'A',
-        // A forced paint
-        schedulingMessageEvent,
-      ]);
-      runtime.fireMessageEvent();
-      runtime.assertLog([LogEvent.MessageEvent, 'B']);
     });
 
     it('multiple tasks with a yield in between', () => {
@@ -227,7 +176,7 @@ describe('Scheduler', () => {
           () => {
             runtime.log('A');
           },
-          { ngZone }
+          { ngZone },
         );
         runtime.assertLog([schedulingMessageEvent]);
         runtime.fireMessageEvent();
@@ -243,21 +192,21 @@ describe('Scheduler', () => {
           () => {
             runtime.log('A');
           },
-          { ngZone }
+          { ngZone },
         );
         scheduleCallback(
           NormalPriority,
           () => {
             runtime.log('B');
           },
-          { ngZone: ngZone2 }
+          { ngZone: ngZone2 },
         );
         scheduleCallback(
           NormalPriority,
           () => {
             runtime.log('C');
           },
-          { ngZone: ngZone }
+          { ngZone: ngZone },
         );
         runtime.assertLog([schedulingMessageEvent]);
         runtime.fireMessageEvent();
@@ -274,7 +223,7 @@ describe('Scheduler', () => {
           () => {
             runtime.log('A');
           },
-          { ngZone }
+          { ngZone },
         );
         scheduleCallback(
           NormalPriority,
@@ -282,14 +231,14 @@ describe('Scheduler', () => {
             runtime.log('B');
             runtime.advanceTime(4000);
           },
-          { ngZone: ngZone2 }
+          { ngZone: ngZone2 },
         );
         scheduleCallback(
           NormalPriority,
           () => {
             runtime.log('C');
           },
-          { ngZone }
+          { ngZone },
         );
         runtime.assertLog([schedulingMessageEvent]);
         runtime.fireMessageEvent();
@@ -322,7 +271,7 @@ describe('Scheduler', () => {
           () => {
             runtime.log('A');
           },
-          { ngZone }
+          { ngZone },
         );
         runtime.assertLog([schedulingMessageEvent]);
         runtime.fireMessageEvent();

--- a/libs/cdk/internals/scheduler/src/lib/scheduler.ts
+++ b/libs/cdk/internals/scheduler/src/lib/scheduler.ts
@@ -51,9 +51,6 @@ const timerQueue = [];
 // Incrementing id counter. Used to maintain insertion order.
 let taskIdCounter = 1;
 
-// Pausing the scheduler is useful for debugging.
-let isSchedulerPaused = false;
-
 let currentTask: ReactSchedulerTask = null;
 let currentPriorityLevel = PriorityLevel.NormalPriority;
 
@@ -69,18 +66,10 @@ const clearTimeout = ɵglobal.clearTimeout;
 const setImmediate = ɵglobal.setImmediate; // IE and Node.js + jsdom
 const messageChannel = ɵglobal.MessageChannel;
 
-const isInputPending =
-  typeof ɵglobal.navigator !== 'undefined' &&
-  ɵglobal.navigator.scheduling !== undefined &&
-  ɵglobal.navigator.scheduling.isInputPending !== undefined
-    ? ɵglobal.navigator.scheduling.isInputPending.bind(
-        ɵglobal.navigator.scheduling
-      )
-    : null;
-
 const defaultZone = {
   run: (fn) => fn(),
 };
+
 function advanceTimers(currentTime) {
   // Check for tasks that are no longer delayed and add them to the queue.
   let timer = peek(timerQueue);
@@ -141,7 +130,7 @@ function flushWork(hasTimeRemaining, initialTime) {
 function workLoop(
   hasTimeRemaining: boolean,
   initialTime: number,
-  _currentTask?: ReactSchedulerTask
+  _currentTask?: ReactSchedulerTask,
 ) {
   let currentTime = initialTime;
   if (_currentTask) {
@@ -214,78 +203,15 @@ function workLoop(
   }
 }
 
-function runWithPriority(priorityLevel, eventHandler) {
-  switch (priorityLevel) {
-    case PriorityLevel.ImmediatePriority:
-    case PriorityLevel.UserBlockingPriority:
-    case PriorityLevel.NormalPriority:
-    case PriorityLevel.LowPriority:
-    case PriorityLevel.IdlePriority:
-      break;
-    default:
-      priorityLevel = PriorityLevel.NormalPriority;
-  }
-
-  const previousPriorityLevel = currentPriorityLevel;
-  currentPriorityLevel = priorityLevel;
-
-  try {
-    return eventHandler();
-  } finally {
-    currentPriorityLevel = previousPriorityLevel;
-  }
-}
-
-function next(eventHandler) {
-  let priorityLevel;
-  switch (currentPriorityLevel) {
-    case PriorityLevel.ImmediatePriority:
-    case PriorityLevel.UserBlockingPriority:
-    case PriorityLevel.NormalPriority:
-      // Shift down to normal priority
-      priorityLevel = PriorityLevel.NormalPriority;
-      break;
-    default:
-      // Anything lower than normal priority should remain at the current level.
-      priorityLevel = currentPriorityLevel;
-      break;
-  }
-
-  const previousPriorityLevel = currentPriorityLevel;
-  currentPriorityLevel = priorityLevel;
-
-  try {
-    return eventHandler();
-  } finally {
-    currentPriorityLevel = previousPriorityLevel;
-  }
-}
-
-function wrapCallback(callback: VoidFunction) {
-  const parentPriorityLevel = currentPriorityLevel;
-  return () => {
-    // This is a fork of runWithPriority, inlined for performance.
-    const previousPriorityLevel = currentPriorityLevel;
-    currentPriorityLevel = parentPriorityLevel;
-
-    try {
-      // eslint-disable-next-line prefer-rest-params
-      return callback.apply(this, arguments);
-    } finally {
-      currentPriorityLevel = previousPriorityLevel;
-    }
-  };
-}
-
 interface ScheduleCallbackOptions {
   delay?: number;
   ngZone?: SchedulerTaskZone;
 }
 
-function scheduleCallback(
+export function scheduleCallback(
   priorityLevel: PriorityLevel,
   callback: VoidFunction,
-  options?: ScheduleCallbackOptions
+  options?: ScheduleCallbackOptions,
 ): ReactSchedulerTask {
   const currentTime = getCurrentTime();
 
@@ -362,31 +288,11 @@ function scheduleCallback(
   return newTask;
 }
 
-function pauseExecution() {
-  isSchedulerPaused = true;
-}
-
-function continueExecution() {
-  isSchedulerPaused = false;
-  if (!isHostCallbackScheduled && !isPerformingWork) {
-    isHostCallbackScheduled = true;
-    requestHostCallback(flushWork);
-  }
-}
-
-function getFirstCallbackNode() {
-  return peek(taskQueue);
-}
-
-function cancelCallback(task) {
+export function cancelCallback(task) {
   // Null out the callback to indicate the task has been canceled. (Can't
   // remove from the queue because you can't remove arbitrary nodes from an
   // array based heap, only the first one.)
   task.callback = null;
-}
-
-function getCurrentPriorityLevel() {
-  return currentPriorityLevel;
 }
 
 let isMessageLoopRunning = false;
@@ -398,10 +304,6 @@ let taskTimeoutID = -1;
 // It does not attempt to align with frame boundaries, since most tasks don't
 // need to be frame aligned; for those that do, use requestAnimationFrame.
 let yieldInterval = 16;
-
-// TODO: Make this configurable
-// TODO: Adjust this based on priority?
-const maxYieldInterval = 300;
 let needsPaint = false;
 let queueStartTime = -1;
 
@@ -417,64 +319,20 @@ function shouldYieldToHost() {
     return false;
   }
 
-  // The main thread has been blocked for a non-negligible amount of time. We
-  // may want to yield control of the main thread, so the browser can perform
-  // high priority tasks. The main ones are painting and user input. If there's
-  // a pending paint or a pending input, then we should yield. But if there's
-  // neither, then we can yield less often while remaining responsive. We'll
-  // eventually yield regardless, since there could be a pending paint that
-  // wasn't accompanied by a call to `requestPaint`, or other main thread tasks
-  // like network events.
-
-  // we don't support isInputPending currently
-  /*if (enableIsInputPending) {
-    if (needsPaint) {
-      // There's a pending paint (signaled by `requestPaint`). Yield now.
-      return true;
-    }
-    if (timeElapsed < continuousInputInterval) {
-      // We haven't blocked the thread for that long. Only yield if there's a
-      // pending discrete input (e.g. click). It's OK if there's pending
-      // continuous input (e.g. mouseover).
-      if (isInputPending !== null) {
-        return isInputPending();
-      }
-    } else if (timeElapsed < maxInterval) {
-      // Yield if there's either a pending discrete or continuous input.
-      if (isInputPending !== null) {
-        return isInputPending(continuousOptions);
-      }
-    } else {
-      // We've blocked the thread for a long time. Even if there's no pending
-      // input, there may be some other scheduled work that we don't know about,
-      // like a network event. Yield now.
-      return true;
-    }
-  }*/
-
   // `isInputPending` isn't available. Yield now.
   return true;
 }
 
 function requestPaint() {
   needsPaint = true;
-  // we don't support isInputPending currently
-  /*if (
-    enableIsInputPending &&
-    navigator !== undefined &&
-    (navigator as any).scheduling !== undefined &&
-    (navigator as any).scheduling.isInputPending !== undefined
-  ) {
-    needsPaint = true;
-  }*/
 }
 
-function forceFrameRate(fps) {
+export function forceFrameRate(fps) {
   if (fps < 0 || fps > 125) {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       console.error(
         'forceFrameRate takes a positive int between 0 and 125, ' +
-          'forcing frame rates higher than 125 fps is not supported'
+          'forcing frame rates higher than 125 fps is not supported',
       );
     }
     return;
@@ -575,21 +433,3 @@ function cancelHostTimeout() {
   clearTimeout(taskTimeoutID);
   taskTimeoutID = -1;
 }
-
-const _requestPaint = requestPaint;
-
-export {
-  cancelCallback,
-  continueExecution,
-  forceFrameRate as forceFrameRate,
-  getCurrentPriorityLevel,
-  getFirstCallbackNode,
-  next,
-  getCurrentTime as now,
-  pauseExecution,
-  _requestPaint as requestPaint,
-  runWithPriority,
-  scheduleCallback,
-  shouldYieldToHost as shouldYield,
-  wrapCallback,
-};

--- a/libs/cdk/internals/scheduler/src/lib/schedulerFeatureFlags.ts
+++ b/libs/cdk/internals/scheduler/src/lib/schedulerFeatureFlags.ts
@@ -1,1 +1,0 @@
-export const enableIsInputPending = false;


### PR DESCRIPTION
Clean-up unused scheduler APIs, only `forceFramerate`, `scheduleCallback`, and `cancelCallback` are effectively used.