### PR TITLE
Change `ui.greet()` to `ui.greet($event.target.value)` in actions.mdx

### DIFF
--- a/apps/docs/docs/state/actions/actions.mdx
+++ b/apps/docs/docs/state/actions/actions.mdx
@@ -264,7 +264,7 @@ import { rxActions } from '@rx-angular/state/actions';
 
 @Component({
   template: `
-    <input name="name" (input)="ui.greet()" />
+    <input name="name" (input)="ui.greet($event.target.value)" />
     <div>{{ ui.greet$ | async }}</div>
   `,
   /**/


### PR DESCRIPTION
[The docs are incorrect](https://www.rx-angular.io/docs/state/actions#use-custom-transform-functions)! My code looked like this:

```
<input name="name" (input)="ui.greet()" />
<div>{{ ui.greet$ | async }}</div>
```

However, I got an `Expected 1 arguments, but got 0.` error, yet I followed the docs perfectly! 
Turns out, I was missing `$event.target.value`. So here's how it should've looked like in the docs (or something similar to this):

```
<input name="name" (input)="ui.greet($event.target.value)" />
<div>{{ ui.greet$ | async }}</div>
```

And now it works. Hopefully, other devs won't be left discouraged to try this amazing tool because of this silly doc discrepancy!