### PR TITLE
feat(template): introduce appendOnly mode, initialScrollIndex & bugfixes

### DIFF
--- a/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-demo.component.ts
+++ b/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-demo.component.ts
@@ -127,6 +127,8 @@ import { RxVirtualScrollViewportComponent } from '@rx-angular/template/experimen
         </div>
       </div>
       <rxa-array-provider
+        numberOfItems="1000"
+        [initialNumberOfItems]="1000"
         [unpatched]="[]"
         [buttons]="true"
       ></rxa-array-provider>
@@ -134,16 +136,31 @@ import { RxVirtualScrollViewportComponent } from '@rx-angular/template/experimen
         <div class="w-50" *rxIf="showRxa$">
           <h2 class="mat-subheading-2">*rxVirtualFor</h2>
           <div class="d-flex">
-            <input
-              style="width: 200px"
-              matInput
-              #scrollToInput
-              placeholder="scrollToIndex"
-              type="number"
-            />
-            <button mat-button (click)="scrollToIndex(scrollToInput.value)">
-              ScrollTo
-            </button>
+            <div class="d-flex">
+              <input
+                style="width: 200px"
+                matInput
+                #scrollToInput
+                placeholder="scrollToIndex"
+                type="number"
+              />
+              <button mat-button (click)="scrollToIndex(scrollToInput.value)">
+                ScrollTo
+              </button>
+            </div>
+            <div class="d-flex">
+              <input
+                style="width: 200px"
+                matInput
+                #initialScrollToInput
+                [value]="initialScrollTo"
+                (change)="
+                  setInitialScrollTo(initialScrollToInput.valueAsNumber)
+                "
+                placeholder="initialScrollTo"
+                type="number"
+              />
+            </div>
           </div>
           <h2 class="mat-subheading-1">Stats</h2>
           <div class="stats">
@@ -166,6 +183,7 @@ import { RxVirtualScrollViewportComponent } from '@rx-angular/template/experimen
             <rx-virtual-scroll-viewport
               (scrolledIndexChange)="rxaScrolledIndex$.next($event)"
               *ngIf="state.scrollStrategy === 'fixed'"
+              [initialScrollIndex]="initialScrollTo"
               [itemSize]="itemSize"
               [runwayItemsOpposite]="state.runwayItemsOpposite"
               [runwayItems]="state.runwayItems"
@@ -189,6 +207,7 @@ import { RxVirtualScrollViewportComponent } from '@rx-angular/template/experimen
               *ngIf="state.scrollStrategy === 'auto'"
               (scrolledIndexChange)="rxaScrolledIndex$.next($event)"
               autosize
+              [initialScrollIndex]="initialScrollTo"
               withSyncScrollbar
               [resizeObserverConfig]="{
                 extractSize: extractSize
@@ -376,7 +395,7 @@ export class VirtualForDemoComponent implements OnInit, AfterViewInit {
   strategy$ = new Subject<RxStrategyNames<string>>();
   scrollStrategy$ = this.state.select('scrollStrategy');
   rxVirtualForState$ = this.state.select();
-  components$ = new BehaviorSubject<'cdk' | 'rxa' | 'both'>('both');
+  components$ = new BehaviorSubject<'cdk' | 'rxa' | 'both'>('rxa');
 
   showRxa$ = this.components$.pipe(
     map((components) => components === 'rxa' || components === 'both')
@@ -433,6 +452,8 @@ export class VirtualForDemoComponent implements OnInit, AfterViewInit {
     item: TestItem & { tmpl: TemplateRef<any>; content: string }
   ): number => item.id;
 
+  initialScrollTo = parseInt(localStorage.getItem('vs-initialScrollTo') ?? '0');
+
   constructor(
     public state: RxState<{
       data: any[];
@@ -451,6 +472,7 @@ export class VirtualForDemoComponent implements OnInit, AfterViewInit {
   ngOnInit() {}
 
   ngAfterViewInit() {
+    this.arrayProvider.addItemsImmutable(1000);
     this.state.connect(
       'data',
       this.arrayProvider.array$.pipe(
@@ -469,6 +491,11 @@ export class VirtualForDemoComponent implements OnInit, AfterViewInit {
         )
       )
     );
+  }
+
+  setInitialScrollTo(index: number) {
+    localStorage.setItem('vs-initialScrollTo', index.toString());
+    this.initialScrollTo = index;
   }
 
   scrollToIndex(index: string): void {

--- a/apps/demos/src/app/shared/debug-helper/value-provider/array-provider.service.ts
+++ b/apps/demos/src/app/shared/debug-helper/value-provider/array-provider.service.ts
@@ -27,7 +27,7 @@ export class ArrayProviderService extends RxState<ProvidedValues> {
     })
   );
   protected completeSubject = new Subject<any>();
-  protected resetSubject = new Subject<any>();
+  protected resetSubject = new Subject<number | undefined>();
 
   protected addItemsImmutableSubject = new Subject<number | undefined>();
   protected moveItemsImmutableSubject = new Subject<number | undefined>();
@@ -42,7 +42,6 @@ export class ArrayProviderService extends RxState<ProvidedValues> {
 
   private resetAll = () => {
     this.resetObservables();
-    this.cdRef.markForCheck();
   };
 
   private resetObservables = () => {
@@ -93,6 +92,10 @@ export class ArrayProviderService extends RxState<ProvidedValues> {
       removeItemsMutable(state?.array || [], ids)
     );
 
+    this.connect('array', this.resetSubject, (state, itemsToAdd) =>
+      addItemImmutable([], itemsToAdd ?? 0)
+    );
+
     this.resetAll();
   }
 
@@ -105,9 +108,9 @@ export class ArrayProviderService extends RxState<ProvidedValues> {
   }
 
   shuffleAttack(): void {
-    from([0, 1, 2]).subscribe(v => {
+    from([0, 1, 2]).subscribe((v) => {
       this.shuffleItemsImmutable();
-    })
+    });
   }
 
   shuffleItemsImmutable(): void {
@@ -146,7 +149,7 @@ export class ArrayProviderService extends RxState<ProvidedValues> {
     this.completeSubject.next(undefined);
   }
 
-  reset(): void {
-    this.resetSubject.next(undefined);
+  reset(num?: number): void {
+    this.resetSubject.next(num);
   }
 }

--- a/apps/demos/src/app/shared/debug-helper/value-provider/array-provider/array-provider.component.ts
+++ b/apps/demos/src/app/shared/debug-helper/value-provider/array-provider/array-provider.component.ts
@@ -1,57 +1,121 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
 import { ArrayProviderService } from '../array-provider.service';
 
 @Component({
   selector: 'rxa-array-provider',
   exportAs: 'rxaArrayProvider',
-  template: `
-    <ng-container *ngIf="buttons">
-      <div class="row">
-        <div class="col">
-          <p>Immutable Operations</p>
-          <button mat-raised-button [unpatch]="unpatched" (click)="addItemsImmutable(1)">
-            Add
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="moveItemsImmutable(1)">
-            Move
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="updateItemsImmutable(1)">
-            Update
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="removeItemsImmutable(1)">
-            Remove
-          </button>
-          <br/>
-          <button mat-raised-button [unpatch]="unpatched" (click)="addItemsImmutable(numberOfItems)">
-            Add Many
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="moveItemsImmutable(numberOfItems/2)">
-            Move Many
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="shuffleItemsImmutable()">
-            Shuffle
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="shuffleAttack()">
-            Shuffle Attack
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="updateItemsImmutable(numberOfItems/2)">
-            Update Many
-          </button>
-          <button mat-raised-button [unpatch]="unpatched" (click)="removeItemsImmutable(numberOfItems/2)">
-            Remove Many
-          </button>
+  template: ` <div *ngIf="buttons">
+      <p>Immutable Operations</p>
+      <div class="d-flex align-items-center">
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="addItemsImmutable(1)"
+        >
+          Add
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="moveItemsImmutable(1)"
+        >
+          Move
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="updateItemsImmutable(1)"
+        >
+          Update
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="removeItemsImmutable(1)"
+        >
+          Remove
+        </button>
+        <div class="d-flex align-items-center">
           <mat-form-field>
             <mat-label>Number of items</mat-label>
-            <input matInput [(ngModel)]="numberOfItems" type="number">
+            <input matInput value="10" #resetInput type="number" />
           </mat-form-field>
+          <button
+            mat-raised-button
+            [unpatch]="unpatched"
+            (click)="reset(resetInput.valueAsNumber)"
+          >
+            Reset
+          </button>
         </div>
       </div>
-    </ng-container>
+      <div class="d-flex align-items-center">
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="addItemsImmutable(numberOfItems)"
+        >
+          Add Many
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="moveItemsImmutable(numberOfItems / 2)"
+        >
+          Move Many
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="shuffleItemsImmutable()"
+        >
+          Shuffle
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="shuffleAttack()"
+        >
+          Shuffle Attack
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="updateItemsImmutable(numberOfItems / 2)"
+        >
+          Update Many
+        </button>
+        <button
+          mat-raised-button
+          [unpatch]="unpatched"
+          (click)="removeItemsImmutable(numberOfItems / 2)"
+        >
+          Remove Many
+        </button>
+        <mat-form-field>
+          <mat-label>Number of items</mat-label>
+          <input matInput [(ngModel)]="numberOfItems" type="number" />
+        </mat-form-field>
+      </div>
+    </div>
     <ng-content></ng-content>`,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ArrayProviderComponent extends ArrayProviderService {
-  numberOfItems = 10
+export class ArrayProviderComponent
+  extends ArrayProviderService
+  implements OnInit
+{
+  @Input()
+  initialNumberOfItems = 0;
+
+  @Input()
+  numberOfItems = 10;
 
   @Input()
   buttons = false;
@@ -66,5 +130,13 @@ export class ArrayProviderComponent extends ArrayProviderService {
 
   constructor(protected cdRef: ChangeDetectorRef) {
     super(cdRef);
+  }
+
+  ngOnInit() {
+    if (this.initialNumberOfItems) {
+      Promise.resolve().then(() =>
+        this.addItemsImmutable(this.initialNumberOfItems)
+      );
+    }
   }
 }

--- a/apps/docs/docs/template/api/virtual-scrolling.mdx
+++ b/apps/docs/docs/template/api/virtual-scrolling.mdx
@@ -197,6 +197,28 @@ export class AnyComponent {
 
 > 💡 See examples for other scroll strategies [here](#rxvirtualscrollstrategy)
 
+### appendOnly mode
+
+Append items to the list as the user scrolls without removing rendered views. The appendOnly input ensures views that are already rendered persist in the DOM after they scroll out of view.
+
+This might be useful when integrating with the [`@angular/cdk/drag-drop`](https://material.angular.io/cdk/drag-drop/overview) package.
+
+```html
+<rx-virtual-scroll-viewport [itemSize]="50" appendOnly>
+  <div class="hero" *rxVirtualFor="let hero of heroes; trackBy: 'id'">
+    <div>
+      <div><strong>{{ hero.name }}</strong></div>
+      <div>{{ hero.id }}</div>
+      <div>{{ hero.description }}</div>
+    </div>
+  </div>
+</rx-virtual-scroll-viewport>
+```
+
+> 💡 the [appendOnly] input reacts to changes, you can toggle it on runtime
+
+> 💡 see the [angular/cdk implementation](https://material.angular.io/cdk/scrolling/overview#append-only-mode)
+
 ### Using `trackBy` shortcut to reduce boilerplate
 
 The `trackBy` input either takes a `keyof T` or the regular `TrackByFunction` (`(index: number, item: T) => any`) as a value.
@@ -486,6 +508,12 @@ Container component comparable to CdkVirtualScrollViewport acting as viewport fo
 Its main purpose is to implement the `RxVirtualScrollViewport` interface as well as maintaining the scroll runways'
 height in order to give the provided `RxVirtualScrollStrategy` room to position items. Furthermore, it will gather and forward
 all events to the consumer of `rxVirtualFor`.
+
+#### Inputs
+
+| Output               | Type     | description                                                                                                                          |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `initialScrollIndex` | `number` | Sets the first view to be visible to the user. The viewport waits for the data to arrive and scrolls to the given index immediately. |
 
 #### Outputs
 

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -42,6 +42,7 @@ import {
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,
+  toBoolean,
   unpatchedMicroTask,
 } from '../util';
 import { RX_VIRTUAL_SCROLL_DEFAULT_OPTIONS } from '../virtual-scroll.config';
@@ -160,6 +161,14 @@ export class AutoSizeVirtualScrollStrategy<
     return this._withResizeObserver;
   }
   private _withResizeObserver = true;
+
+  /**
+   * @description
+   * When enabled, the scroll strategy stops removing views from the viewport,
+   * instead it only adds views. This setting can be changed on the fly. Views will be added in both directions
+   * according to the user interactions.
+   */
+  @Input({ transform: toBoolean }) appendOnly = false;
 
   /**
    * @description
@@ -538,6 +547,10 @@ export class AutoSizeVirtualScrollStrategy<
               this.contentLength,
               this.lastScreenItem.index + this.runwayItems
             );
+          }
+          if (this.appendOnly) {
+            range.start = Math.min(this._renderedRange.start, range.start);
+            range.end = Math.max(this._renderedRange.end, range.end);
           }
           return range;
         })

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -209,7 +209,7 @@ export class AutoSizeVirtualScrollStrategy<
   }
 
   /** @internal */
-  private readonly _renderedRange$ = new ReplaySubject<ListRange>(1);
+  private readonly _renderedRange$ = new Subject<ListRange>();
   /** @internal */
   readonly renderedRange$ = this._renderedRange$.asObservable();
   /** @internal */
@@ -446,6 +446,23 @@ export class AutoSizeVirtualScrollStrategy<
           });
         }
         existingIds.clear();
+        if (dataLength < this._renderedRange.end) {
+          const rangeDiff = this._renderedRange.end - this._renderedRange.start;
+          const anchorDiff = this.anchorItem.index - this._renderedRange.start;
+          this._renderedRange.end = Math.min(
+            dataLength,
+            this._renderedRange.end
+          );
+          this._renderedRange.start = Math.max(
+            0,
+            this._renderedRange.end - rangeDiff
+          );
+          // this.anchorItem.offset = 0;
+          this.anchorItem.index = Math.max(
+            0,
+            this._renderedRange.start + anchorDiff
+          );
+        }
         this.contentLength = dataLength;
         this.contentSize = size;
       }),

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -31,6 +31,7 @@ import {
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,
+  toBoolean,
   unpatchedMicroTask,
 } from '../util';
 import {
@@ -98,6 +99,14 @@ export class DynamicSizeVirtualScrollStrategy<
    */
   @Input() runwayItemsOpposite =
     this.defaults?.runwayItemsOpposite ?? DEFAULT_RUNWAY_ITEMS_OPPOSITE;
+
+  /**
+   * @description
+   * When enabled, the scroll strategy stops removing views from the viewport,
+   * instead it only adds views. This setting can be changed on the fly. Views will be added in both directions
+   * according to the user interactions.
+   */
+  @Input({ transform: toBoolean }) appendOnly = false;
 
   /**
    * @description
@@ -353,6 +362,10 @@ export class DynamicSizeVirtualScrollStrategy<
               length,
               this.lastScreenItem.index + this.runwayItems
             );
+          }
+          if (this.appendOnly) {
+            range.start = Math.min(this._renderedRange.start, range.start);
+            range.end = Math.max(this._renderedRange.end, range.end);
           }
           return range;
         })

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
@@ -33,6 +33,7 @@ import {
 import {
   calculateVisibleContainerSize,
   parseScrollTopBoundaries,
+  toBoolean,
   unpatchedAnimationFrameTick,
 } from '../util';
 import {
@@ -91,6 +92,14 @@ export class FixedSizeVirtualScrollStrategy<
   }
 
   private _itemSize = DEFAULT_ITEM_SIZE;
+
+  /**
+   * @description
+   * When enabled, the scroll strategy stops removing views from the viewport,
+   * instead it only adds views. This setting can be changed on the fly. Views will be added in both directions
+   * according to the user interactions.
+   */
+  @Input({ transform: toBoolean }) appendOnly = false;
 
   /**
    * @description
@@ -284,6 +293,10 @@ export class FixedSizeVirtualScrollStrategy<
                   this.itemSize
               )
             );
+          }
+          if (this.appendOnly) {
+            range.start = Math.min(this._renderedRange.start, range.start);
+            range.end = Math.max(this._renderedRange.end, range.end);
           }
           this.scrolledIndex = Math.floor(this.scrollTop / this.itemSize);
           return range;

--- a/libs/template/experimental/virtual-scrolling/src/lib/util.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/util.ts
@@ -6,6 +6,10 @@ import {
 } from '@rx-angular/cdk/zone-less/browser';
 import { from, Observable } from 'rxjs';
 
+export function toBoolean(input: null | boolean | string | undefined): boolean {
+  return input != null && `${input}` !== 'false';
+}
+
 export function unpatchedAnimationFrameTick(): Observable<void> {
   return new Observable<void>((observer) => {
     const tick = requestAnimationFrame(() => {

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-list-template-manager.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-list-template-manager.ts
@@ -274,40 +274,48 @@ export function createVirtualListTemplateManager<
         changedIdxs.add(item);
         listChanges.push([
           itemIndex,
-          () => {
-            const view = _updateView(
-              item,
+          () =>
+            maybeUpdateView(
               itemIndex,
               count,
-              itemIndex + adjustIndexWith
-            );
-            return {
-              view,
-              index: itemIndex,
-              item,
-            };
-          },
+              itemIndex + adjustIndexWith,
+              item
+            ),
         ]);
       }
     }
-    if (itemCount !== count && changedIdxs.size < items.length) {
+    if (changedIdxs.size < items.length) {
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         if (!changedIdxs.has(item)) {
           listChanges.push([
             i,
-            () => {
-              const view = _updateView(item, i, count, i + adjustIndexWith);
-              return {
-                view,
-                index: i,
-                item,
-              };
-            },
+            () => maybeUpdateView(i, count, i + adjustIndexWith, item),
           ]);
         }
       }
     }
     return [listChanges, notifyParent];
+  }
+
+  function maybeUpdateView(
+    viewIndex: number,
+    count: number,
+    itemIndex: number,
+    item: T
+  ) {
+    const view = <EmbeddedViewRef<C>>viewContainerRef.get(viewIndex);
+    if (view.context.count !== count || view.context.index !== itemIndex) {
+      return {
+        view: _updateView(item, viewIndex, count, itemIndex),
+        index: viewIndex,
+        item,
+      };
+    }
+    return {
+      index: viewIndex,
+      view,
+      item,
+    };
   }
 }

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -228,7 +228,9 @@ export class RxVirtualScrollViewportComponent
     if (this.scrollElement) {
       this.elementRef.nativeElement.style.height = `${size}px`;
     } else {
-      this.scrollSentinel.nativeElement.style.transform = `translate(0, ${size}px)`;
+      this.scrollSentinel.nativeElement.style.transform = `translate(0, ${
+        size - 1
+      }px)`;
     }
   }
 }

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -7,13 +7,15 @@ import {
   ContentChild,
   ElementRef,
   inject,
+  Input,
   OnDestroy,
   Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
 import { defer, ReplaySubject, Subject } from 'rxjs';
-import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
+
 import {
   RxVirtualScrollElement,
   RxVirtualScrollStrategy,
@@ -92,6 +94,8 @@ export class RxVirtualScrollViewportComponent
     optional: true,
   });
   protected scrollElement = inject(RxVirtualScrollElement, { optional: true });
+
+  @Input() initialScrollIndex = 0;
 
   /** @internal */
   @ViewChild('sentinel')
@@ -176,6 +180,17 @@ export class RxVirtualScrollViewportComponent
         this.contentSize = size;
         this.updateContentSize(size);
       });
+    if (this.initialScrollIndex != null && this.initialScrollIndex > 0) {
+      this.scrollStrategy.contentSize$
+        .pipe(
+          filter((size) => size > 0),
+          take(1),
+          takeUntil(this.destroy$)
+        )
+        .subscribe(() => {
+          this.scrollToIndex(this.initialScrollIndex);
+        });
+    }
   }
 
   /** @internal */

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -15,7 +15,6 @@ import {
 } from '@angular/core';
 import { defer, ReplaySubject, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
-
 import {
   RxVirtualScrollElement,
   RxVirtualScrollStrategy,

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -95,6 +95,13 @@ export class RxVirtualScrollViewportComponent
   });
   protected scrollElement = inject(RxVirtualScrollElement, { optional: true });
 
+  /**
+   * @description
+   *
+   * Sets the first view to be visible to the user.
+   * The viewport waits for the data to arrive and scrolls to the given index immediately.
+   *
+   * */
   @Input() initialScrollIndex = 0;
 
   /** @internal */

--- a/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/virtual-scroll-viewport.component.ts
@@ -151,8 +151,6 @@ export class RxVirtualScrollViewportComponent
   /** @internal */
   private readonly destroy$ = new Subject<void>();
 
-  private contentSize = 0;
-
   /** @internal */
   constructor() {
     if (NG_DEV_MODE && !this.scrollStrategy) {
@@ -184,7 +182,6 @@ export class RxVirtualScrollViewportComponent
     this.scrollStrategy.contentSize$
       .pipe(distinctUntilChanged(), takeUntil(this.destroy$))
       .subscribe((size) => {
-        this.contentSize = size;
         this.updateContentSize(size);
       });
     if (this.initialScrollIndex != null && this.initialScrollIndex > 0) {

--- a/libs/template/experimental/virtual-scrolling/tests/autosize.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/autosize.cy.ts
@@ -176,7 +176,7 @@ describe('viewport', () => {
       );
       const initialHeight = items.length * component.tombstoneSize;
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${initialHeight}px)`
+        `translate(0px, ${initialHeight - 1}px)`
       );
       cy.get('@viewRange').should('have.been.calledWith', initialRange);
       cy.get('@renderCallback')
@@ -197,7 +197,7 @@ describe('viewport', () => {
             .then(() => {
               expect(
                 (sentinel.nativeElement as HTMLElement).style.transform
-              ).eq(`translate(0px, ${runwayHeight}px)`);
+              ).eq(`translate(0px, ${runwayHeight - 1}px)`);
             });
         });
     });
@@ -228,12 +228,12 @@ describe('viewport', () => {
           items.push(...generateItems(1));
           fixture.detectChanges();
           expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-            `translate(0px, ${runwayHeight + component.tombstoneSize}px)`
+            `translate(0px, ${runwayHeight + component.tombstoneSize - 1}px)`
           );
           items.splice(100, 1);
           fixture.detectChanges();
           expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-            `translate(0px, ${runwayHeight}px)`
+            `translate(0px, ${runwayHeight - 1}px)`
           );
         });
     });

--- a/libs/template/experimental/virtual-scrolling/tests/dynamic-size.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/dynamic-size.cy.ts
@@ -138,7 +138,7 @@ describe('viewport', () => {
       );
       const items = fixture.componentInstance.items as Item[];
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${totalItemHeight(items)}px)`
+        `translate(0px, ${totalItemHeight(items) - 1}px)`
       );
     });
   });
@@ -151,12 +151,12 @@ describe('viewport', () => {
         By.css('.rx-virtual-scroll__sentinel')
       );
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${totalItemHeight(items)}px)`
+        `translate(0px, ${totalItemHeight(items) - 1}px)`
       );
       items.splice(0, 1);
       fixture.detectChanges();
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${totalItemHeight(items)}px)`
+        `translate(0px, ${totalItemHeight(items) - 1}px)`
       );
     });
   });

--- a/libs/template/experimental/virtual-scrolling/tests/fixed-size.cy.ts
+++ b/libs/template/experimental/virtual-scrolling/tests/fixed-size.cy.ts
@@ -102,7 +102,7 @@ describe('viewport', () => {
       );
       cy.get('@renderCallback').should('have.been.called');
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${defaultItemLength * itemSize}px)`
+        `translate(0px, ${defaultItemLength * itemSize - 1}px)`
       );
     });
   });
@@ -116,12 +116,12 @@ describe('viewport', () => {
         By.css('.rx-virtual-scroll__sentinel')
       );
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${items.length * itemSize}px)`
+        `translate(0px, ${items.length * itemSize - 1}px)`
       );
       items.splice(0, 1);
       fixture.detectChanges();
       expect((sentinel.nativeElement as HTMLElement).style.transform).eq(
-        `translate(0px, ${items.length * itemSize}px)`
+        `translate(0px, ${items.length * itemSize - 1}px)`
       );
     });
   });


### PR DESCRIPTION
# Description

Sorry for delivering multiple things within a single PR...

This PR introduces the following new features:

* appendOnly mode
* initialScrollIndex input

as well as a bugfix for the virtual list template manager that sometimes produced bad diffs and a fix for a viewglitch caused by a mispositioned sentinel.

## AppendOnly

There is a new input `appendOnly: boolean` on the scroll strategies. Enabling this mode causes the rendered range to only increase - in any direction. See https://material.angular.io/cdk/scrolling/overview#append-only-mode

I hope this addresses https://github.com/rx-angular/rx-angular/issues/1686

##  InitialScrollIndex

There is a new input `initialScrollIndex: number` on the `RxVirtualScrollViewportComponent` which lets users define an initial index to scroll to. fixes https://github.com/rx-angular/rx-angular/issues/1689

> the virtual-scroll-viewport now accepts an index as input which sets the first view to be visible to the user. The viewport waits for the data to arrive and scrolls to the given index immediately.

## Bugfix

Fixes https://github.com/rx-angular/rx-angular/issues/1679

I've recorded the following demo ( I did move the logic from the demo stackblitz to our demo repo for this purpose )

![fix-bug](https://github.com/rx-angular/rx-angular/assets/4904455/a478b4a2-4ff1-46b7-96fa-c18b2b63b921)


