### PR TITLE
feat(eslint): update dependencies to be compatible to nx 18

### DIFF
--- a/libs/eslint-plugin/package.json
+++ b/libs/eslint-plugin/package.json
@@ -4,9 +4,9 @@
   "peerDependencies": {
     "eslint": ">=8.0.0",
     "typescript": ">=4.3.5",
-    "@typescript-eslint/parser": "^6.10.0"
+    "@typescript-eslint/parser": "^6.13.2 || ^7.0.0"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^6.10.0"
+    "@typescript-eslint/utils": "^6.13.2 || ^7.0.0"
   }
 }


### PR DESCRIPTION
Update @typescript-eslint/parser & utils dependencies for the eslint-plugin package to be in line with nx 18

Fixes #1707 