### PR TITLE
fix(template): virtual-for: properly calculate stable state

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -359,8 +359,11 @@ export class AutoSizeVirtualScrollStrategy<
   }
 
   private scrollTo(scrollTo: number, behavior?: ScrollBehavior): void {
-    this.waitForScroll = true;
-    this.isStable$.next(false);
+    this.waitForScroll =
+      scrollTo !== this.scrollTop && this.contentSize > this.containerSize;
+    if (this.waitForScroll) {
+      this.isStable$.next(false);
+    }
     this.viewport!.scrollTo(this.viewportOffset + scrollTo, behavior);
   }
 

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -284,8 +284,11 @@ export class DynamicSizeVirtualScrollStrategy<
     for (let i = 0; i < _index; i++) {
       scrollTo += this._virtualItems[i].size;
     }
-    this.waitForScroll = true;
-    this.isStable$.next(false);
+    this.waitForScroll =
+      scrollTo !== this.scrollTop && this.contentSize > this.containerSize;
+    if (this.waitForScroll) {
+      this.isStable$.next(false);
+    }
     this.viewport!.scrollTo(this.viewportOffset + scrollTo, behavior);
   }
 


### PR DESCRIPTION
# Description

as figured out by @KevinBelien in #1727 , the dynamic & autosize scroll strategies would not display anything on data sets smaller than the container height.

This PR fixes the calculation of the stable state.

Closing #1727 