### PR TITLE
feat(template): set the parent flag to false by default

### DIFF
--- a/apps/docs/docs/template/api/rx-for-directive.mdx
+++ b/apps/docs/docs/template/api/rx-for-directive.mdx
@@ -359,9 +359,7 @@ Learn more about the general concept of [`RenderStrategies`](../../cdk/render-st
 
 #### Local strategies and view/content queries (`parent`)
 
-:::warning
-
-**Deprecation warning**
+:::warning **Deprecation warning**
 
 The `parent` flag being true is not needed anymore with the new [signal based view queries](https://angular.io/guide/signal-queries).
 

--- a/libs/cdk/render-strategies/src/lib/config.ts
+++ b/libs/cdk/render-strategies/src/lib/config.ts
@@ -30,7 +30,7 @@ export const RX_RENDER_STRATEGIES_DEFAULTS: Required<
     ...RX_CONCURRENT_STRATEGIES,
   },
   patchZone: true,
-  parent: true,
+  parent: false,
 } as const;
 
 export function mergeDefaultConfig<T extends string>(


### PR DESCRIPTION
BREAKING CHANGE: It is possible that this change breaks the integration with 3rd party libraries, that are not up to date. If you are using the @rx-angular/template directives to project content into other components which don't use the new signal queries, they might not work properly anymore.
In order to fix this, you might want to set the parent flag to true on a global scope by providing an `RX_RENDER_STRATEGIES_CONFIG`. Another option is to set `parent: true` on a per directive basis.
Read more about this here: https://www.rx-angular.io/docs/template/performance-issues/handling-view-and-content-queries & here: https://push-based.io/article/new-features-for-rxangular-native-signal-support-and-improved-state#the-parent-flag-gets-deprecated