### PR TITLE
fix(isr): handle response sent in render

### DIFF
--- a/apps/ssr-isr/project.json
+++ b/apps/ssr-isr/project.json
@@ -20,7 +20,9 @@
         "styles": ["apps/ssr-isr/src/styles.scss"],
         "scripts": [],
         "server": "apps/ssr-isr/src/main.server.ts",
-        "prerender": true,
+        "prerender": {
+          "discoverRoutes": false
+        },
         "ssr": {
           "entry": "apps/ssr-isr/server.ts"
         }

--- a/apps/ssr-isr/server.ts
+++ b/apps/ssr-isr/server.ts
@@ -3,6 +3,7 @@ import { ISRHandler } from '@rx-angular/isr/server';
 import express from 'express';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { RESPONSE } from './src/app/redirect.component';
 import bootstrap from './src/main.server';
 // import { FileSystemCacheHandler } from '@rx-angular/isr/server';
 
@@ -36,7 +37,7 @@ export function app(): express.Express {
 
   server.post(
     '/api/invalidate',
-    async (req, res) => await isr.invalidate(req, res)
+    async (req, res) => await isr.invalidate(req, res),
   );
 
   server.set('view engine', 'html');
@@ -49,7 +50,7 @@ export function app(): express.Express {
     '*.*',
     express.static(browserDistFolder, {
       maxAge: '1y',
-    })
+    }),
   );
 
   server.get(
@@ -57,7 +58,15 @@ export function app(): express.Express {
     // Serve page if it exists in cache
     async (req, res, next) => await isr.serveFromCache(req, res, next),
     // Server side render the page and add to cache if needed
-    async (req, res, next) => await isr.render(req, res, next)
+    async (req, res, next) =>
+      await isr.render(req, res, next, {
+        providers: [
+          {
+            provide: RESPONSE,
+            useValue: res,
+          },
+        ],
+      }),
   );
 
   return server;

--- a/apps/ssr-isr/src/app/app.routes.ts
+++ b/apps/ssr-isr/src/app/app.routes.ts
@@ -15,6 +15,11 @@ export const appRoutes: Route[] = [
     },
   },
   {
+    path: 'needs-redirect',
+    loadComponent: () =>
+      import('./redirect.component').then((m) => m.RedirectComponent),
+  },
+  {
     path: '**',
     redirectTo: '/static',
   },

--- a/apps/ssr-isr/src/app/redirect.component.ts
+++ b/apps/ssr-isr/src/app/redirect.component.ts
@@ -1,0 +1,34 @@
+import { CommonModule, isPlatformServer } from '@angular/common';
+import {
+  Component,
+  Inject,
+  InjectionToken,
+  Optional,
+  PLATFORM_ID,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { Response } from 'express';
+
+export const RESPONSE = new InjectionToken<Response>('RESPONSE');
+
+@Component({
+  selector: 'app-redirect',
+  standalone: true,
+  imports: [CommonModule],
+  template: ``,
+  styles: ``,
+})
+export class RedirectComponent {
+  constructor(
+    private readonly router: Router,
+    @Inject(PLATFORM_ID) private platformId: object,
+    @Optional() @Inject(RESPONSE) private response: Response,
+  ) {
+    if (isPlatformServer(this.platformId) && this.response) {
+      this.response.redirect(301, '/');
+      this.response.end();
+    } else {
+      this.router.navigate(['/']);
+    }
+  }
+}

--- a/libs/isr/server/src/isr-handler.ts
+++ b/libs/isr/server/src/isr-handler.ts
@@ -255,6 +255,11 @@ export class ISRHandler {
     };
 
     renderUrl(renderUrlConfig).then(async (html) => {
+      // If headers are already sent, we can't send the response
+      if (res.headersSent) {
+        return;
+      }
+
       const { revalidate, errors } = getRouteISRDataFromHTML(html);
 
       // Apply the callback if given


### PR DESCRIPTION
The main reason for this change is described in the issue https://github.com/rx-angular/rx-angular/issues/1738.  With this change, render exits if the `renderUrl` already handles the server response.  