### PR TITLE
fix(template): fix possibly undefined `_virtualItems` in autosize and dynamic strategies

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -802,6 +802,9 @@ export class AutoSizeVirtualScrollStrategy<
         map((event) => {
           const index = viewRef.context.index;
           const size = Math.round(this.extractSize(event));
+          if (!this._virtualItems[index]) {
+            return null as unknown as [number, number];
+          }
           const diff = size - this._virtualItems[index].size;
           if (diff !== 0) {
             this._virtualItems[index].size = size;

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -969,7 +969,7 @@ export class AutoSizeVirtualScrollStrategy<
 
   /** @internal */
   private getItemSize(index: number): number {
-    return this._virtualItems[index].size || this.tombstoneSize;
+    return this._virtualItems[index]?.size || this.tombstoneSize;
   }
   /** @internal */
   private getElementSize(element: HTMLElement): number {

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -536,7 +536,7 @@ export class DynamicSizeVirtualScrollStrategy<
   }
   /** @internal */
   private getItemSize(index: number): number {
-    return this._virtualItems[index].size;
+    return this._virtualItems[index]?.size || 0;
   }
 
   /** @internal */


### PR DESCRIPTION
Fixes #1744. See that issue to find out the steps to reproduce the problem.

If merged, please make sure to also release fix versions for rx-angular 17.x