### PR TITLE
fix(isr): filter urlsOnHold by cacheKey instead of url

### DIFF
--- a/libs/isr/server/src/cache-regeneration.ts
+++ b/libs/isr/server/src/cache-regeneration.ts
@@ -62,7 +62,7 @@ export class CacheRegeneration {
       // if there are errors, don't add the page to cache
       if (errors?.length && this.isrConfig.skipCachingOnHttpError) {
         // remove url from urlsOnHold because we want to try to regenerate it again
-        this.urlsOnHold = this.urlsOnHold.filter((x) => x !== url);
+        this.urlsOnHold = this.urlsOnHold.filter((x) => x !== cacheKey);
         logger.log(
           '💥 ERROR: Url: ' + cacheKey + ' was not regenerated!',
           errors,


### PR DESCRIPTION
This pull request fixes a bug in the CacheRegeneration class where the filtering of urlsOnHold was done based on the wrong variable. Instead of filtering by cacheKey, it was filtering by url. This caused incorrect removal of urls from urlsOnHold. The fix updates the filtering logic to use cacheKey instead, ensuring that the correct urls are removed from urlsOnHold.