### PR TITLE
fix(template): properly calc sizes when resizeobserver adjust viewport

### DIFF
--- a/apps/demos/src/app/features/template/rx-virtual-for/rx-virtual-for.menu.ts
+++ b/apps/demos/src/app/features/template/rx-virtual-for/rx-virtual-for.menu.ts
@@ -19,4 +19,8 @@ export const RX_VIRTUAL_FOR_MENU_ITEMS = [
     label: 'Reverse Infinite Scroll',
     link: 'reverse-infinite-scroll',
   },
+  {
+    label: 'Crazy Update',
+    link: 'crazy-update',
+  },
 ];

--- a/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-crazy-update.component.ts
+++ b/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-crazy-update.component.ts
@@ -1,0 +1,59 @@
+import { Component, signal } from '@angular/core';
+import {
+  AutoSizeVirtualScrollStrategy,
+  RxVirtualScrollViewportComponent,
+  RxVirtualFor,
+} from '@rx-angular/template/experimental/virtual-scrolling';
+import { BehaviorSubject, Subject } from 'rxjs';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [
+    RxVirtualFor,
+    RxVirtualScrollViewportComponent,
+    AutoSizeVirtualScrollStrategy,
+  ],
+  template: `
+    <rx-virtual-scroll-viewport autosize [tombstoneSize]="63">
+      <div
+        *rxVirtualFor="
+          let item of items$;
+          trackBy: 'id';
+          renderCallback: renderedItems
+        "
+        style="width: 100%;"
+      >
+        <p>{{ item.name }}</p>
+      </div>
+    </rx-virtual-scroll-viewport>
+  `,
+})
+export class VirtualForCrazyUpdateComponent {
+  items = signal(
+    Array.from({ length: 200 }).map((_item, index) => ({
+      id: index,
+      name: `item #${index}`,
+    })),
+  );
+  items$ = new BehaviorSubject(
+    Array.from({ length: 200 }).map((_item, index) => ({
+      id: index,
+      name: `item #${index}`,
+    })),
+  );
+
+  renderedItems = new Subject<any[]>();
+
+  constructor() {
+    this.renderedItems.subscribe(() => console.log('Completed rendering'));
+
+    setTimeout(() => {
+      this.items$.next(
+        this.items$.getValue().filter((item) => item.id % 2 === 0),
+      );
+      this.items.update((items) => items.filter((item) => item.id % 2 === 0));
+      console.log('Updating items');
+    }, 350);
+  }
+}

--- a/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-experiments.module.ts
+++ b/apps/demos/src/app/features/template/rx-virtual-for/virtual-rendering/virtual-for-experiments.module.ts
@@ -21,6 +21,7 @@ import { RxIf } from '@rx-angular/template/if';
 import { RxLet } from '@rx-angular/template/let';
 import { StrategySelectModule } from '../../../../shared/debug-helper/strategy-select/index';
 import { ValueProvidersModule } from '../../../../shared/debug-helper/value-provider/index';
+import { VirtualForCrazyUpdateComponent } from './virtual-for-crazy-update.component';
 import { VirtualForDemoComponent } from './virtual-for-demo.component';
 import { VirtualForMonkeyTestComponent } from './virtual-for-monkey-test.component';
 import { VirtualForReverseInfiniteScrollComponent } from './virtual-for-reverse-infinite-scroll.component';
@@ -54,6 +55,10 @@ import { VirtualForCustomScrollableDemoComponent } from './virtual-for-scrollabl
       {
         path: 'monkey-test',
         component: VirtualForMonkeyTestComponent,
+      },
+      {
+        path: 'crazy-update',
+        component: VirtualForCrazyUpdateComponent,
       },
     ]),
     ValueProvidersModule,

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -780,6 +780,7 @@ export class AutoSizeVirtualScrollStrategy<
               const itemIndex = view.context.index;
               const virtualItem = this._virtualItems[itemIndex];
               const element = this.getElement(view);
+              this.updateElementSize(view, itemIndex);
               virtualItem.position = position;
               this.positionElement(element, position);
               position += virtualItem.size;


### PR DESCRIPTION
thx to @FelixMuehling who noticed a nasty race condition in the resize observer implementation. Looks like the re-adjusting of the viewport based on the resizeObserver was sometimes using improper size values - causing views to get positioned out of order.

fixes #1746 