### PR TITLE
refactor(isr): use CacheKey instead of route / url  for naming

### DIFF
--- a/libs/isr/models/src/cache-handler.ts
+++ b/libs/isr/models/src/cache-handler.ts
@@ -30,16 +30,16 @@ export interface VariantRebuildItem {
 
 export abstract class CacheHandler {
   abstract add(
-    url: string,
+    cacheKey: string,
     html: string,
     config?: CacheISRConfig,
   ): Promise<void>;
 
-  abstract get(url: string): Promise<CacheData>;
+  abstract get(cacheKey: string): Promise<CacheData>;
 
-  abstract has(url: string): Promise<boolean>;
+  abstract has(cacheKey: string): Promise<boolean>;
 
-  abstract delete(url: string): Promise<boolean>;
+  abstract delete(cacheKey: string): Promise<boolean>;
 
   abstract getAll(): Promise<string[]>;
 

--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.spec.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.spec.ts
@@ -1,35 +1,35 @@
 import {
-  convertFileNameToRoute,
-  convertRouteToFileName,
+  convertCacheKeyToFileName,
+  convertFileNameToCacheKey,
 } from './filesystem-cache-handler';
 
 // Use the functions as needed
 describe('Route and File Name Conversion', () => {
-  describe('convertRouteToFileName', () => {
+  describe('convertCacheKeyToFileName', () => {
     it('should convert a simple route without query parameters', () => {
       const route = '/users/profile';
       const expectedFileName = '__users__profile';
-      expect(convertRouteToFileName(route)).toEqual(expectedFileName);
+      expect(convertCacheKeyToFileName(route)).toEqual(expectedFileName);
     });
 
     it('should convert a route with query parameters', () => {
       const route = '/search?query=test';
       const expectedFileName = '__search++query=test';
-      expect(convertRouteToFileName(route)).toEqual(expectedFileName);
+      expect(convertCacheKeyToFileName(route)).toEqual(expectedFileName);
     });
   });
 
-  describe('convertFileNameToRoute', () => {
+  describe('convertFileNameToCacheKey', () => {
     it('should convert a simple file name back to a route', () => {
       const fileName = '__users__profile';
       const expectedRoute = '/users/profile';
-      expect(convertFileNameToRoute(fileName)).toEqual(expectedRoute);
+      expect(convertFileNameToCacheKey(fileName)).toEqual(expectedRoute);
     });
 
     it('should convert a file name with "++" back to a route with a query parameter', () => {
       const fileName = '__search++query=test';
       const expectedRoute = '/search?query=test';
-      expect(convertFileNameToRoute(fileName)).toEqual(expectedRoute);
+      expect(convertFileNameToCacheKey(fileName)).toEqual(expectedRoute);
     });
   });
 });

--- a/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/in-memory-cache-handler.ts
@@ -16,7 +16,7 @@ export class InMemoryCacheHandler extends CacheHandler {
   }
 
   add(
-    url: string,
+    cacheKey: string,
     html: string,
     config: CacheISRConfig = defaultCacheISRConfig,
   ): Promise<void> {
@@ -26,15 +26,15 @@ export class InMemoryCacheHandler extends CacheHandler {
         options: config,
         createdAt: Date.now(),
       };
-      this.cache.set(url, cacheData);
+      this.cache.set(cacheKey, cacheData);
       resolve();
     });
   }
 
-  get(url: string): Promise<CacheData> {
+  get(cacheKey: string): Promise<CacheData> {
     return new Promise((resolve, reject) => {
-      if (this.cache.has(url)) {
-        resolve(this.cache.get(url) as CacheData);
+      if (this.cache.has(cacheKey)) {
+        resolve(this.cache.get(cacheKey) as CacheData);
       }
       reject('This url does not exist in cache!');
     });
@@ -46,15 +46,15 @@ export class InMemoryCacheHandler extends CacheHandler {
     });
   }
 
-  has(url: string): Promise<boolean> {
+  has(cacheKey: string): Promise<boolean> {
     return new Promise((resolve) => {
-      resolve(this.cache.has(url));
+      resolve(this.cache.has(cacheKey));
     });
   }
 
-  delete(url: string): Promise<boolean> {
+  delete(cacheKey: string): Promise<boolean> {
     return new Promise((resolve) => {
-      resolve(this.cache.delete(url));
+      resolve(this.cache.delete(cacheKey));
     });
   }
 


### PR DESCRIPTION
This is just a refactor for using the same term cacheKey across the code base. (Sometime I got confused.)

Feel free to make different suggestion. I don't really have strong opinion on changing it.