### PR TITLE
docs: update version compatibility table

### DIFF
--- a/libs/cdk/README.md
+++ b/libs/cdk/README.md
@@ -36,11 +36,13 @@ npm install @rx-angular/cdk
 ## Version Compatibility
 
 | RxAngular | Angular    |
-| --------- | ---------- |
-| `^1.0.0`  | `>=12.0.0` |
-| `^2.0.0`  | `>=13.0.0` |
-| `^14.0.0` | `^14.0.0`  |
-| `^15.0.0` | `^15.0.0`  |
+|-----------|------------|
+| `^18.0.0` | `^18.0.0`  |
+| `^17.0.0` | `^17.0.0`  |
 | `^16.0.0` | `^16.0.0`  |
+| `^15.0.0` | `^15.0.0`  |
+| `^14.0.0` | `^14.0.0`  |
+| `^2.0.0`  | `>=13.0.0` |
+| `^1.0.0`  | `>=12.0.0` |
 
-Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.io/guide/versions).
+Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.dev/reference/versions).

--- a/libs/state/README.md
+++ b/libs/state/README.md
@@ -146,14 +146,16 @@ Optimize state selections and data transfer, ensure only the necessary data is t
 ## Version Compatibility
 
 | RxAngular | Angular    |
-| --------- | ---------- |
-| `^1.0.0`  | `>=12.0.0` |
-| `^2.0.0`  | `>=13.0.0` |
-| `^14.0.0` | `^14.0.0`  |
-| `^15.0.0` | `^15.0.0`  |
+|-----------|------------|
+| `^18.0.0` | `^18.0.0`  |
+| `^17.0.0` | `^17.0.0`  |
 | `^16.0.0` | `^16.0.0`  |
+| `^15.0.0` | `^15.0.0`  |
+| `^14.0.0` | `^14.0.0`  |
+| `^2.0.0`  | `>=13.0.0` |
+| `^1.0.0`  | `>=12.0.0` |
 
-Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.io/guide/versions).
+Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.dev/reference/versions).
 
 ## Contribution
 

--- a/libs/template/README.md
+++ b/libs/template/README.md
@@ -67,11 +67,14 @@ export class AnyComponent {}
 ## Version Compatibility
 
 | RxAngular | Angular    |
-| --------- | ---------- |
-| `^1.0.0`  | `>=12.0.0` |
-| `^2.0.0`  | `>=13.0.0` |
-| `^14.0.0` | `^14.0.0`  |
-| `^15.0.0` | `^15.0.0`  |
+|-----------|------------|
+| `^18.0.0` | `^18.0.0`  |
+| `^17.0.0` | `^17.0.0`  |
 | `^16.0.0` | `^16.0.0`  |
+| `^15.0.0` | `^15.0.0`  |
+| `^14.0.0` | `^14.0.0`  |
+| `^2.0.0`  | `>=13.0.0` |
+| `^1.0.0`  | `>=12.0.0` |
 
-Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.io/guide/versions).
+Regarding the compatibility with RxJS, we generally stick to the compatibilities of the Angular framework itself, for more information about the compatibilities of Angular itself see the [official guide](https://angular.dev/reference/versions).
+


### PR DESCRIPTION
Update version compatibility table and link to official angular docs for cdk, state and template.
