### PR TITLE
fix(template): properly calculate anchorItem when removing items

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -504,10 +504,13 @@ export class AutoSizeVirtualScrollStrategy<
               index: dataLength,
               offset: 0,
             },
-            -calculateVisibleContainerSize(
-              this.containerSize,
-              this.scrollTopWithOutOffset,
-              this.scrollTopAfterOffset,
+            Math.max(
+              -size,
+              -calculateVisibleContainerSize(
+                this.containerSize,
+                this.scrollTopWithOutOffset,
+                this.scrollTopAfterOffset,
+              ),
             ),
           );
           this.calcAnchorScrollTop();


### PR DESCRIPTION
This PR fixes an issue where the autosize strategy wrongly calculates the anchorItem when items get deleted