### PR TITLE
fix: replace toObservableMicrotask private API with proper solution

### DIFF
--- a/libs/cdk/internals/core/src/index.ts
+++ b/libs/cdk/internals/core/src/index.ts
@@ -2,3 +2,4 @@ export { accumulateObservables } from './lib/accumulateObservables';
 export { getZoneUnPatchedApi } from './lib/get-zone-unpatched-api';
 export { ObservableAccumulation, ObservableMap } from './lib/model';
 export { timeoutSwitchMapWith } from './lib/timeout';
+export { toObservableMicrotaskInternal } from './lib/toObservableMicrotask';

--- a/libs/cdk/internals/core/src/lib/toObservableMicrotask.ts
+++ b/libs/cdk/internals/core/src/lib/toObservableMicrotask.ts
@@ -1,0 +1,47 @@
+import {
+  assertInInjectionContext,
+  DestroyRef,
+  effect,
+  inject,
+  Injector,
+  Signal,
+  untracked,
+} from '@angular/core';
+import { toObservable, ToObservableOptions } from '@angular/core/rxjs-interop';
+import { Observable, ReplaySubject } from 'rxjs';
+
+// Copied from angular/core/rxjs-interop/src/to_observable.ts -> because it's a private API
+// https://github.com/angular/angular/blob/46f00f951842dd117653df6cca3bfd5ee5baa0f1/packages/core/rxjs-interop/src/to_observable.ts#L72
+export function toObservableMicrotaskInternal<T>(
+  source: Signal<T>,
+  options?: ToObservableOptions,
+): Observable<T> {
+  if (!options?.injector) {
+    assertInInjectionContext(toObservable);
+  }
+
+  const injector = options?.injector ?? inject(Injector);
+  const subject = new ReplaySubject<T>(1);
+
+  const watcher = effect(
+    () => {
+      let value: T;
+      try {
+        value = source();
+      } catch (err) {
+        untracked(() => subject.error(err));
+        return;
+      }
+      untracked(() => subject.next(value));
+    },
+    // forceRoot will ensure that the effect will be scheduled as a microtask
+    { injector, manualCleanup: true, forceRoot: true },
+  );
+
+  injector.get(DestroyRef).onDestroy(() => {
+    watcher.destroy();
+    subject.complete();
+  });
+
+  return subject.asObservable();
+}

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -7,7 +7,8 @@ import {
   OnDestroy,
   Signal,
 } from '@angular/core';
-import { ɵtoObservableMicrotask, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservableMicrotaskInternal } from '@rx-angular/cdk/internals/core';
 import {
   AccumulationFn,
   createAccumulationObservable,
@@ -570,7 +571,9 @@ export class RxState<State extends object>
 
     if (isSignal(keyOrInputOrSlice$) && !projectOrSlices$ && !projectValueFn) {
       this.accumulator.nextSliceObservable(
-        ɵtoObservableMicrotask(keyOrInputOrSlice$, { injector: this.injector }),
+        toObservableMicrotaskInternal(keyOrInputOrSlice$, {
+          injector: this.injector,
+        }),
       );
       return;
     }
@@ -596,7 +599,7 @@ export class RxState<State extends object>
       !projectValueFn
     ) {
       const projectionStateFn = projectOrSlices$;
-      const slice$ = ɵtoObservableMicrotask(keyOrInputOrSlice$, {
+      const slice$ = toObservableMicrotaskInternal(keyOrInputOrSlice$, {
         injector: this.injector,
       }).pipe(
         map((v) => projectionStateFn(this.accumulator.state, v as Value)),
@@ -622,7 +625,7 @@ export class RxState<State extends object>
       isSignal(projectOrSlices$) &&
       !projectValueFn
     ) {
-      const slice$ = ɵtoObservableMicrotask(projectOrSlices$, {
+      const slice$ = toObservableMicrotaskInternal(projectOrSlices$, {
         injector: this.injector,
       }).pipe(map((value) => ({ ...{}, [keyOrInputOrSlice$]: value })));
       this.accumulator.nextSliceObservable(slice$);
@@ -653,7 +656,7 @@ export class RxState<State extends object>
       isSignal(projectOrSlices$)
     ) {
       const key: Key = keyOrInputOrSlice$;
-      const slice$ = ɵtoObservableMicrotask(projectOrSlices$, {
+      const slice$ = toObservableMicrotaskInternal(projectOrSlices$, {
         injector: this.injector,
       }).pipe(
         map((value) => ({

--- a/libs/template/for/src/lib/for.directive.ts
+++ b/libs/template/for/src/lib/for.directive.ts
@@ -18,11 +18,11 @@ import {
   TrackByFunction,
   ViewContainerRef,
 } from '@angular/core';
-import { ɵtoObservableMicrotask } from '@angular/core/rxjs-interop';
 import {
   coerceDistinctWith,
   coerceObservableWith,
 } from '@rx-angular/cdk/coercing';
+import { toObservableMicrotaskInternal } from '@rx-angular/cdk/internals/core';
 import {
   RxStrategyNames,
   RxStrategyProvider,
@@ -132,7 +132,7 @@ export class RxFor<T, U extends NgIterable<T> = NgIterable<T>>
       this.staticValue = undefined;
       this.renderStatic = false;
       this.observables$.next(
-        ɵtoObservableMicrotask(potentialSignalOrObservable, {
+        toObservableMicrotaskInternal(potentialSignalOrObservable, {
           injector: this.injector,
         }),
       );

--- a/libs/template/if/src/lib/if.directive.ts
+++ b/libs/template/if/src/lib/if.directive.ts
@@ -14,8 +14,8 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import { ɵtoObservableMicrotask } from '@angular/core/rxjs-interop';
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
+import { toObservableMicrotaskInternal } from '@rx-angular/cdk/internals/core';
 import {
   createTemplateNotifier,
   RxNotificationKind,
@@ -558,7 +558,7 @@ export class RxIf<T = unknown>
     if (changes.rxIf) {
       if (isSignal(this.rxIf)) {
         this.templateNotifier.next(
-          ɵtoObservableMicrotask(this.rxIf, { injector: this.injector }),
+          toObservableMicrotaskInternal(this.rxIf, { injector: this.injector }),
         );
       } else {
         this.templateNotifier.next(this.rxIf);

--- a/libs/template/let/src/lib/let.directive.ts
+++ b/libs/template/let/src/lib/let.directive.ts
@@ -16,8 +16,8 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import { ɵtoObservableMicrotask } from '@angular/core/rxjs-interop';
 import { coerceAllFactory } from '@rx-angular/cdk/coercing';
+import { toObservableMicrotaskInternal } from '@rx-angular/cdk/internals/core';
 import {
   createTemplateNotifier,
   RxNotification,
@@ -590,7 +590,9 @@ export class RxLet<U> implements OnInit, OnDestroy, OnChanges {
     if (changes.rxLet) {
       if (isSignal(this.rxLet)) {
         this.observablesHandler.next(
-          ɵtoObservableMicrotask(this.rxLet, { injector: this.injector }),
+          toObservableMicrotaskInternal(this.rxLet, {
+            injector: this.injector,
+          }),
         );
       } else {
         this.observablesHandler.next(this.rxLet);


### PR DESCRIPTION
Instead of relying on a private API, I copied the impl and replace the private API with public & supported alternative. 