### PR TITLE
fix: properly include files in tsconfig

### DIFF
--- a/libs/cdk/tsconfig.lib.json
+++ b/libs/cdk/tsconfig.lib.json
@@ -17,6 +17,7 @@
     "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
+  "include": ["**/*.ts"],
   "exclude": [
     "src/test-setup.ts",
     "**/*.spec.ts",

--- a/libs/state/tsconfig.lib.json
+++ b/libs/state/tsconfig.lib.json
@@ -18,6 +18,7 @@
     "strictMetadataEmit": true,
     "enableResourceInlining": true
   },
+  "include": ["**/*.ts"],
   "exclude": [
     "./test-setup.ts",
     "**/*.spec.ts",

--- a/libs/template/tsconfig.lib.json
+++ b/libs/template/tsconfig.lib.json
@@ -20,6 +20,7 @@
     "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
+  "include": ["**/*.ts"],
   "exclude": [
     "src/test-setup.ts",
     "**/*.spec.ts",


### PR DESCRIPTION
somehow a misconfiguration sneaked in and our ts files weren't properly included in the tsconfig setup. this PR fixes all of those weird IDE issues @eneajaho and me were noticing recently:

* import paths not resolving
* `#` private marking not supported
* ...