### PR TITLE
refactor(state): use DestroyRef instead of OnDestroy life cycle hook

### DIFF
--- a/apps/demos/src/app/features/tutorials/basics/5-side-effects/side-effects.solution.component.ts
+++ b/apps/demos/src/app/features/tutorials/basics/5-side-effects/side-effects.solution.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
-  OnDestroy,
   OnInit,
   Output,
 } from '@angular/core';
@@ -74,7 +73,7 @@ const initComponentState = {
 })
 export class SideEffectsSolution
   extends RxState<ComponentState>
-  implements OnInit, OnDestroy
+  implements OnInit
 {
   model$ = this.select();
 

--- a/apps/demos/src/app/shared/debug-helper/value-provider/primitives-provider.service.ts
+++ b/apps/demos/src/app/shared/debug-helper/value-provider/primitives-provider.service.ts
@@ -59,7 +59,6 @@ export class PrimitivesProviderService {
   };
 
   private resetObservables = () => {
-    this.state.ngOnDestroy();
     runInInjectionContext(
       this.injector,
       () => (this.state = new RxState<ProvidedValues>()),

--- a/apps/demos/src/app/shared/viewport.service.ts
+++ b/apps/demos/src/app/shared/viewport.service.ts
@@ -1,5 +1,9 @@
-import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
-import { Injectable, OnDestroy } from '@angular/core';
+import {
+  BreakpointObserver,
+  Breakpoints,
+  BreakpointState,
+} from '@angular/cdk/layout';
+import { Injectable } from '@angular/core';
 import { RxState } from '@rx-angular/state';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 
@@ -20,7 +24,7 @@ interface ViewportServiceState {
 @Injectable({
   providedIn: 'root',
 })
-export class ViewportService implements OnDestroy {
+export class ViewportService {
   private readonly state = new RxState<ViewportServiceState>();
 
   readonly viewport$ = this.state.select('viewport');
@@ -52,15 +56,10 @@ export class ViewportService implements OnDestroy {
       );
     this.state.connect(viewport$, (oldState, viewportChange) => ({
       viewport: viewportChange,
-      isHandset:
-        viewportChange === 'mobile' || viewportChange === 'tablet',
+      isHandset: viewportChange === 'mobile' || viewportChange === 'tablet',
       isMobile: viewportChange === 'mobile',
       isTablet: viewportChange === 'tablet',
       isDesktop: viewportChange === 'desktop',
     }));
-  }
-
-  ngOnDestroy() {
-    this.state.ngOnDestroy();
   }
 }

--- a/libs/state/spec/rx-state.component.spec.ts
+++ b/libs/state/spec/rx-state.component.spec.ts
@@ -136,7 +136,7 @@ describe('InheritanceTestComponent', () => {
 
   it('should create', () => {
     stateChecker.checkSubscriptions(component, 1);
-    component.ngOnDestroy();
+    fixture.destroy();
     stateChecker.checkSubscriptions(component, 0);
   });
 });

--- a/libs/state/spec/rx-state.service.spec.ts
+++ b/libs/state/spec/rx-state.service.spec.ts
@@ -63,7 +63,7 @@ describe('RxStateService', () => {
 
   it('should unsubscribe on ngOnDestroy call', () => {
     stateChecker.checkSubscriptions(service, 1);
-    service.ngOnDestroy();
+    TestBed.resetTestingModule();
     stateChecker.checkSubscriptions(service, 0);
   });
 
@@ -550,7 +550,7 @@ describe('RxStateService', () => {
         const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect(tick$.pipe(map((num) => ({ num }))));
-        state.ngOnDestroy();
+        TestBed.resetTestingModule();
         expectObservable(state.select()).toBe('');
         expectSubscriptions(tick$.subscriptions).toBe(subs);
       });
@@ -562,7 +562,7 @@ describe('RxStateService', () => {
         const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect('num' as any, tick$);
-        state.ngOnDestroy();
+        TestBed.resetTestingModule();
         expectSubscriptions(tick$.subscriptions).toBe(subs);
         expectObservable(state.select()).toBe('');
       });
@@ -574,7 +574,7 @@ describe('RxStateService', () => {
         const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect(tick$, (s, v) => ({ num: v * 42 }));
-        state.ngOnDestroy();
+        TestBed.resetTestingModule();
         expectObservable(state.select()).toBe('');
         expectSubscriptions(tick$.subscriptions).toBe(subs);
       });
@@ -586,7 +586,7 @@ describe('RxStateService', () => {
         const tick$ = hot('aaaaaaaaaaaaaaa|', { a: 1 });
         const subs = '(^!)';
         state.connect('num', tick$, (s, v) => v * 42);
-        state.ngOnDestroy();
+        TestBed.resetTestingModule();
         expectObservable(state.select()).toBe('');
         expectSubscriptions(tick$.subscriptions).toBe(subs);
       });
@@ -608,7 +608,7 @@ describe('RxStateService', () => {
           ),
         ).toBe('');
         expectSubscriptions(interval$.subscriptions).toBe(subs);
-        state.ngOnDestroy();
+        TestBed.resetTestingModule();
       });
     });
 

--- a/libs/state/spec/rx-state.spec.ts
+++ b/libs/state/spec/rx-state.spec.ts
@@ -21,7 +21,6 @@ import {
   rxState,
   RxStateSetupFn,
 } from '../src/lib/rx-state';
-import { RxState } from '../src/lib/rx-state.service';
 
 describe(rxState, () => {
   it('should create rxState', () => {
@@ -134,14 +133,6 @@ describe(rxState, () => {
       /// @ts-expect-error Observable<{ fail: boolean }> is not assignable to Observable<{ count: number }>
       connect(of({ fail: true }));
     });
-  });
-
-  it('should call ngOnDestroy', () => {
-    RxState.prototype.ngOnDestroy = jest.fn();
-    const { fixture } = setupComponent();
-    expect(RxState.prototype.ngOnDestroy).not.toHaveBeenCalled();
-    fixture.destroy();
-    expect(RxState.prototype.ngOnDestroy).toHaveBeenCalled();
   });
 
   describe('signals', () => {

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -1,10 +1,10 @@
 import {
   computed,
+  DestroyRef,
   inject,
   Injectable,
   Injector,
   isSignal,
-  OnDestroy,
   Signal,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -75,9 +75,8 @@ export type ReadOnly = 'get' | 'select' | 'computed' | 'signal';
  * @docsPage RxState
  */
 @Injectable()
-export class RxState<State extends object>
-  implements OnDestroy, Subscribable<State>
-{
+export class RxState<State extends object> implements Subscribable<State> {
+  private readonly destroyRef = inject(DestroyRef);
   private subscription = new Subscription();
 
   protected scheduler = inject(RX_STATE_SCHEDULER, { optional: true });
@@ -109,6 +108,8 @@ export class RxState<State extends object>
    */
   constructor() {
     this.subscription.add(this.subscribe());
+
+    this.destroyRef.onDestroy(() => this.ngOnDestroy());
   }
 
   /**

--- a/libs/state/src/lib/rx-state.service.ts
+++ b/libs/state/src/lib/rx-state.service.ts
@@ -76,7 +76,6 @@ export type ReadOnly = 'get' | 'select' | 'computed' | 'signal';
  */
 @Injectable()
 export class RxState<State extends object> implements Subscribable<State> {
-  private readonly destroyRef = inject(DestroyRef);
   private subscription = new Subscription();
 
   protected scheduler = inject(RX_STATE_SCHEDULER, { optional: true });
@@ -109,14 +108,7 @@ export class RxState<State extends object> implements Subscribable<State> {
   constructor() {
     this.subscription.add(this.subscribe());
 
-    this.destroyRef.onDestroy(() => this.ngOnDestroy());
-  }
-
-  /**
-   * @internal
-   */
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
+    inject(DestroyRef).onDestroy(() => this.subscription.unsubscribe());
   }
 
   /**

--- a/libs/state/src/lib/rx-state.ts
+++ b/libs/state/src/lib/rx-state.ts
@@ -1,4 +1,4 @@
-import { assertInInjectionContext, DestroyRef, inject } from '@angular/core';
+import { assertInInjectionContext } from '@angular/core';
 import { RxState as LegacyState } from './rx-state.service';
 
 export type RxState<T extends object> = Pick<
@@ -52,9 +52,6 @@ export function rxState<State extends object>(
   assertInInjectionContext(rxState);
 
   const legacyState = new LegacyState<State>();
-  const destroyRef = inject(DestroyRef);
-
-  destroyRef.onDestroy(() => legacyState.ngOnDestroy());
 
   const state: RxState<State> = {
     get: legacyState.get.bind(legacyState),


### PR DESCRIPTION
Use modern `DestroyRef` instead of `OnDestroy` lifecycle hook