### PR TITLE
refactor(state): use DestroyRef within EffectsService

### DIFF
--- a/libs/state/effects/src/lib/effects.service.spec.ts
+++ b/libs/state/effects/src/lib/effects.service.spec.ts
@@ -364,7 +364,7 @@ describe('RxEffects', () => {
 
     service.method1.mockClear();
 
-    (component as any).effects.ngOnDestroy();
+    fixture.destroy();
 
     store.state$.next('bar');
 


### PR DESCRIPTION
Use modern `DestroyRef` also within `RxEffects`