### PR TITLE
refactor(state): drop untilDestroyed operator

### DIFF
--- a/libs/state/effects/src/lib/effects.service.ts
+++ b/libs/state/effects/src/lib/effects.service.ts
@@ -1,10 +1,4 @@
-import {
-  DestroyRef,
-  ErrorHandler,
-  inject,
-  Injectable,
-  Optional,
-} from '@angular/core';
+import { DestroyRef, ErrorHandler, inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   EMPTY,
@@ -75,6 +69,7 @@ import { toHook } from './utils';
 export class RxEffects implements OnDestroy$ {
   private static nextId = 0;
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorHandler = inject(ErrorHandler, { optional: true });
   readonly _hooks$ = new Subject<DestroyProp>();
   private readonly observables$ = new Subject<Observable<unknown>>();
   // we have to use publish here to make it hot (composition happens without subscriber)
@@ -83,10 +78,7 @@ export class RxEffects implements OnDestroy$ {
   onDestroy$: Observable<boolean> = this._hooks$.pipe(toHook('destroy'));
   private readonly destroyers: Record<number, Subject<void>> = {};
 
-  constructor(
-    @Optional()
-    private readonly errorHandler: ErrorHandler | null,
-  ) {
+  constructor() {
     this.destroyRef.onDestroy(() => {
       this._hooks$.next({ destroy: true });
       this.subscription.unsubscribe();

--- a/libs/state/effects/src/lib/effects.service.ts
+++ b/libs/state/effects/src/lib/effects.service.ts
@@ -13,7 +13,7 @@ import {
 import {
   catchError,
   filter,
-  mapTo,
+  map,
   mergeAll,
   share,
   takeUntil,
@@ -165,7 +165,10 @@ export class RxEffects implements OnDestroy$ {
     }
     const effectId = RxEffects.nextId++;
     const destroy$ = (this.destroyers[effectId] = new Subject<void>());
-    const applyBehavior = pipe(mapTo(effectId), takeUntil(destroy$));
+    const applyBehavior = pipe(
+      map(() => effectId),
+      takeUntil(destroy$),
+    );
     if (fnOrObj != null) {
       this.observables$.next(
         from(obsOrSub).pipe(

--- a/libs/state/effects/src/lib/utils.ts
+++ b/libs/state/effects/src/lib/utils.ts
@@ -1,9 +1,9 @@
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
-import { filter, map, shareReplay, take, takeUntil } from 'rxjs/operators';
-import { HookProps, OnDestroy$, SingleShotProps } from './model';
+import { Observable } from 'rxjs';
+import { filter, map, shareReplay, take } from 'rxjs/operators';
+import { HookProps, SingleShotProps } from './model';
 
 export function isSingleShotHookNameGuard<T>(
-  name: unknown
+  name: unknown,
 ): name is keyof SingleShotProps {
   return !!name && typeof name === 'string' && name !== '';
 }
@@ -16,7 +16,7 @@ const singleShotOperators = (o$: Observable<true>): Observable<true> =>
   o$.pipe(
     filter((v) => v === true),
     take(1),
-    shareReplay()
+    shareReplay(),
   );
 
 /**
@@ -32,19 +32,6 @@ export function toHook<H extends keyof HookProps>(name: H) {
   return (o$: Observable<HookProps>): Observable<HookProps[H]> =>
     o$.pipe(
       map((p) => p[name]),
-      operators
+      operators,
     );
-}
-
-/**
- * This operator can be used to take instances that implements `OnDestroy$` and unsubscribes from the given Observable when the instances
- * `onDestroy$` Observable emits.
- *
- * @param instanceWithLifecycle
- */
-export function untilDestroyed<V>(
-  instanceWithLifecycle: OnDestroy$
-): MonoTypeOperatorFunction<V> {
-  return (source) =>
-    source.pipe(takeUntil<V>(instanceWithLifecycle.onDestroy$));
 }


### PR DESCRIPTION
Drops `untilDestroyed` operator in favor of `takeUntilDestroyed`