### PR TITLE
fix(eslint): added license to package.json

### DIFF
--- a/libs/eslint-plugin/package.json
+++ b/libs/eslint-plugin/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@rx-angular/eslint-plugin",
   "version": "2.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://rx-angular.io/",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rx-angular/rx-angular.git"
+  },
   "peerDependencies": {
     "@typescript-eslint/parser": "^6.13.2 || ^7.0.0",
     "eslint": ">=8.0.0",


### PR DESCRIPTION
### Bug
The published version of @rx-angular/eslint-plugin doesn't contain a license (See image). When using automated dependency scanning, you always get an error, that there is an invalid licence.

### Fix
Adapted the package.json, so that the licence should be published.

![image](https://github.com/user-attachments/assets/7545ec62-e19c-4f30-a4f3-07d539dd9024)