### PR TITLE
fix(template): move import in virtual scrolling to rxjs/operators

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -15,7 +15,6 @@ import {
   MonoTypeOperatorFunction,
   Observable,
   of,
-  pairwise,
   ReplaySubject,
   Subject,
 } from 'rxjs';
@@ -27,6 +26,7 @@ import {
   groupBy,
   map,
   mergeMap,
+  pairwise,
   startWith,
   switchMap,
   take,


### PR DESCRIPTION
Fixes https://github.com/rx-angular/rx-angular/issues/1846

I only checked for virtual scrolling and not other parts of the template package. With that change my app built successfully.