### PR TITLE
fix(template): using tombstoneSize for non-cached items with 0 height

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/autosize-virtual-scroll-strategy.ts
@@ -1013,7 +1013,7 @@ export class AutoSizeVirtualScrollStrategy<
     const isCached = this._virtualItems[index].cached;
     const size = isCached
       ? oldSize
-      : this.getElementSize(this.getElement(view));
+      : this.getElementSize(this.getElement(view)) || this.tombstoneSize;
     this._virtualItems[index].size = size;
     this._virtualItems[index].cached = true;
     return [size, size - oldSize];


### PR DESCRIPTION
Fixes #1812

I have looked into the issue I had with ionic components, where the height of the virtual scroll container was wrong. (#1812)

Ionic's `ion-item` component, which I used in my example, is having an height of 0px initially, which leads to `_virtualItems` being an array of `size: 0` and `cached: true` items (set in the `renderingStart$` observable).

Shortly after the initialization, the resize observer emits the actual height of the ionic item, and will add the difference in height to the `contentSize` (line 861). That will happen for each ionic item in my view. 
But before the second item difference will be calculated, the `positionByResizeObserver$` observable in `positionElements()` will call `updateElementSize()` for any further item. The `updateElementSize()` function will then take the cached size by calling `getItemSize()`, which will replace the size of `0` with the `tombstoneSize`  and update `_virtualItems()`. After that, any further calculated differences will be wrong.

Ive added a simple `|| this.tombstoneSize` to in the size ternary in updateElementSize to fix this. This could have also be added in the `getElementSize` function, but I thought it may be unexpected if that function wouldn't return the actual element size.

I hope I didn't miss anything here, the autosize strategy code is actually quite complex.