### PR TITLE
fix(template): keep scroll offset when using keepScrolledIndexOnPrepend (#1857)

### DIFF
--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/dynamic-size-virtual-scroll-strategy.ts
@@ -273,13 +273,17 @@ export class DynamicSizeVirtualScrollStrategy<
     this.detached$.next();
   }
 
-  scrollToIndex(index: number, behavior?: ScrollBehavior): void {
+  scrollToIndex(
+    index: number,
+    behavior?: ScrollBehavior,
+    offset: number = 0,
+  ): void {
     const _index = Math.min(Math.max(index, 0), this.contentLength - 1);
     let scrollTo = 0;
     for (let i = 0; i < _index; i++) {
       scrollTo += this._virtualItems[i].size;
     }
-    this.scrollTo(scrollTo, behavior);
+    this.scrollTo(scrollTo + offset, behavior);
   }
 
   private scrollTo(scrollTo: number, behavior?: ScrollBehavior): void {
@@ -394,7 +398,7 @@ export class DynamicSizeVirtualScrollStrategy<
         valueCache = {};
         valueArray.forEach((v, i) => (valueCache[trackBy(i, v)] = v));
         if (scrollTo !== this.scrolledIndex) {
-          this.scrollToIndex(scrollTo);
+          this.scrollToIndex(scrollTo, undefined, this.anchorItem.offset);
         }
       });
   }

--- a/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
+++ b/libs/template/experimental/virtual-scrolling/src/lib/scroll-strategies/fixed-size-virtual-scroll-strategy.ts
@@ -265,7 +265,11 @@ export class FixedSizeVirtualScrollStrategy<
         valueCache = {};
         valueArray.forEach((v, i) => (valueCache[trackBy(i, v)] = v));
         if (scrollTo !== this.scrolledIndex) {
-          this.scrollToIndex(scrollTo);
+          this.scrollToIndex(
+            scrollTo,
+            undefined,
+            this.scrollTop % this._itemSize,
+          );
         }
       });
     const dataLengthChanged$ = valueArray$.pipe(
@@ -359,9 +363,13 @@ export class FixedSizeVirtualScrollStrategy<
       .subscribe((range) => (this.renderedRange = range));
   }
 
-  scrollToIndex(index: number, behavior?: ScrollBehavior): void {
+  scrollToIndex(
+    index: number,
+    behavior?: ScrollBehavior,
+    offset: number = 0,
+  ): void {
     const scrollTop = this.itemSize * index;
-    this.viewport!.scrollTo(this.viewportOffset + scrollTop, behavior);
+    this.viewport!.scrollTo(this.viewportOffset + scrollTop + offset, behavior);
   }
 
   private untilDetached$<A>(): MonoTypeOperatorFunction<A> {


### PR DESCRIPTION
This fix prevents items from jumping from the anchor items current offset to it's top edge when prepending items during an upwards scroll.