### PR TITLE
feat(isr): add AngularNodeAppEngine as a render engine option

### DIFF
--- a/libs/isr/models/src/isr-handler-config.ts
+++ b/libs/isr/models/src/isr-handler-config.ts
@@ -1,5 +1,9 @@
 import { Provider } from '@angular/core';
-import { CommonEngine, CommonEngineRenderOptions } from '@angular/ssr/node';
+import {
+  AngularNodeAppEngine,
+  CommonEngine,
+  CommonEngineRenderOptions,
+} from '@angular/ssr/node';
 import { Request } from 'express';
 import { CacheHandler, RenderVariant } from './cache-handler';
 
@@ -31,6 +35,12 @@ export interface ISRHandlerConfig {
    * rendering the HTML of the application.
    */
   commonEngine?: CommonEngine;
+
+  /**
+   * An instance of an Angular App Engine. This engine is responsible for
+   * rendering the HTML of the application.
+   */
+  angularAppEngine?: AngularNodeAppEngine;
 
   /**
    * The bootstrap function of the application. This function is responsible for

--- a/libs/isr/server/src/cache-generation.ts
+++ b/libs/isr/server/src/cache-generation.ts
@@ -85,6 +85,7 @@ export class CacheGeneration {
       indexHtml: this.isrConfig.indexHtml,
       providers,
       commonEngine: this.isrConfig.commonEngine,
+      angularAppEngine: this.isrConfig.angularAppEngine,
       bootstrap: this.isrConfig.bootstrap,
       browserDistFolder: this.isrConfig.browserDistFolder,
       inlineCriticalCss: this.isrConfig.inlineCriticalCss,


### PR DESCRIPTION
This PR adds AngularNodeAppEngine as an additional render engine option for ISR.
THis allows angular apps that use new AngularNodeAppEngine yo use ISR easily

For now it supports only express.js but the big goal to add support of different server frameworks in future, but this require much more code changes.
