### PR TITLE
feat(cdk): improve RxStrategy typing and auto completion

### DIFF
--- a/libs/cdk/render-strategies/src/lib/model.ts
+++ b/libs/cdk/render-strategies/src/lib/model.ts
@@ -20,10 +20,6 @@ export interface RxStrategyCredentials<S = string> {
   behavior: RxRenderBehavior;
 }
 
-export type RxCustomStrategyCredentials<T extends string> = Record<
-  T,
-  RxStrategyCredentials
->;
 export type RxNativeStrategyNames = 'native' | 'local' | 'noop';
 export type RxConcurrentStrategyNames =
   | 'immediate'
@@ -37,10 +33,12 @@ export type RxDefaultStrategyNames =
 export type RxStrategyNames<T extends string = string> =
   | RxDefaultStrategyNames
   | T;
-export type RxStrategies<T extends string> = RxCustomStrategyCredentials<
-  RxStrategyNames<T>
+export type RxCustomStrategyCredentials<T extends RxStrategyNames> = Record<
+  T,
+  RxStrategyCredentials
 >;
-
+export type RxStrategies<T extends RxStrategyNames> =
+  RxCustomStrategyCredentials<RxStrategyNames<T>>;
 export interface ScheduleOnStrategyOptions<
   T extends RxStrategyNames = RxDefaultStrategyNames,
 > {

--- a/libs/cdk/render-strategies/src/lib/strategy-provider.service.ts
+++ b/libs/cdk/render-strategies/src/lib/strategy-provider.service.ts
@@ -59,7 +59,9 @@ import { onStrategy } from './onStrategy';
  * @docsPage RxStrategyProvider
  */
 @Injectable({ providedIn: 'root' })
-export class RxStrategyProvider<T extends string = RxDefaultStrategyNames> {
+export class RxStrategyProvider<
+  T extends RxStrategyNames = RxDefaultStrategyNames,
+> {
   private _strategies$ = new BehaviorSubject<RxStrategies<T>>(undefined);
   private _primaryStrategy$ = new BehaviorSubject<
     RxStrategyCredentials<RxStrategyNames<T>>


### PR DESCRIPTION
## Description

This MR improves the typing of the RxStrategyProvider by changing the type generics default parameter to the real default

## Motivation

Allow for better auto-completion and type correctness as well as preventing typos.

### Cases

#### 1. Injected in constructor without generic

**Before**

<img width="699" height="109" alt="Screenshot 2026-01-17 at 19 15 45" src="https://github.com/user-attachments/assets/7bbb6895-9a14-489f-9de2-40565684b043" />

<img width="476" height="221" alt="image" src="https://github.com/user-attachments/assets/f00d74c0-3da2-421b-82d6-22541247d723" />

**After**

<img width="829" height="122" alt="image" src="https://github.com/user-attachments/assets/7727f6ee-c5f6-4394-9e17-d227993c1aef" />

<img width="788" height="385" alt="image" src="https://github.com/user-attachments/assets/e47c7ce1-a8e5-4cd6-8ede-8d6c7a33409e" />

#### 2. Injected in constructor with generic

There is not behavior change here. 

<img width="698" height="138" alt="image" src="https://github.com/user-attachments/assets/bf6ca12a-185b-4efb-9806-c8d970ffac73" />

<img width="654" height="181" alt="image" src="https://github.com/user-attachments/assets/b4995262-d9bd-42db-8fee-4f429d906969" />

#### 3. Injected with inject without generic

There is not behavior change here.

<img width="601" height="144" alt="image" src="https://github.com/user-attachments/assets/e4f9fa33-7c12-49a1-a375-a629f7eb1150" />

<img width="612" height="185" alt="image" src="https://github.com/user-attachments/assets/6178b537-1ec4-4490-986c-fd257003fc63" />

#### 4. Injected with inject with generic

**Before**

**After**

<img width="811" height="195" alt="image" src="https://github.com/user-attachments/assets/cef9c283-588a-4daf-aab6-8eb1af6af98d" />


<img width="778" height="362" alt="image" src="https://github.com/user-attachments/assets/13898dcf-0ed1-4170-9a22-36684972bdd1" />

<img width="838" height="213" alt="image" src="https://github.com/user-attachments/assets/35a4ce3a-a572-4f1f-8a1f-8f12f430bb55" />

## Notes

It's important to consider the trade-off here; adding the real defaults will prevent typos but will force you to pass generics when you create custom strategies.

It's a question of if the user should have a default narrow type or wide type. 

To me, this seems like a reasonable choice, especially since the use of custom strategies is very advanced, so the requirement of passing an additional generic to widen the type seems reasonable, as it's only for that "niche" case.

Additionally, due to the current issue with the typing of the inject function without passing a generic, it would also be reasonable to expo a wrapping function mainly used to fix the generic typing, but that seems to be passing any. 
But to be honest, I have not investigated further as to why this is happening. 

