### PR TITLE
fix: split addPrerenderedPagesToCache intp two methods

### DIFF
--- a/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
+++ b/libs/isr/server/src/cache-handlers/filesystem-cache-handler.ts
@@ -138,8 +138,11 @@ export class FileSystemCacheHandler extends CacheHandler {
 
     if (this.options.addPrerenderedPagesToCache) {
       console.log('Adding prerendered pages to cache...');
-      this.addPrerenderedPagesToCache();
+      // move all prerendered pages to cache folder
+      this.transferPrerenderedPagesToCacheFolder();
     }
+
+    this.loadCachedFilesMetadata();
   }
 
   override clearCache(): Promise<boolean> {
@@ -155,10 +158,7 @@ export class FileSystemCacheHandler extends CacheHandler {
     });
   }
 
-  private addPrerenderedPagesToCache() {
-    // move all prerendered pages to cache folder
-    this.transferPrerenderedPagesToCacheFolder();
-
+  private loadCachedFilesMetadata() {
     // read all files in cache folder and add them to cache
     const files: string[] = fs.readdirSync(this.cacheFolderPath);
 


### PR DESCRIPTION
Built-in FileSystemCacheHandler does not read cached files after server restart if addPrerenderedPagesToCache is disabled