### PR TITLE
docs: fix broken CI status badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![RxAngular logo](https://raw.githubusercontent.com/rx-angular/rx-angular/main/docs/images/rx-angular_logo.png)](https://rx-angular.io/)
 
-# RxAngular ![RxAngular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+# RxAngular ![RxAngular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > RxAngular offers a comprehensive toolkit for handling fully reactive Angular applications with the main focus on runtime performance, template rendering, and Developer eXperience.
 

--- a/apps/docs/docs/cdk/coalescing/coalescing.mdx
+++ b/apps/docs/docs/cdk/coalescing/coalescing.mdx
@@ -254,12 +254,8 @@ The wanted behavior should execute change detection only once per component.
 This can be achieved by scoping the flag that maintains coalescing to a specific thing. e.g. the component.
 
 ```typescript
-from([1, 2, 3])
-  .pipe(coalesceWith(queueMicroTask, this))
-  .subscribe(detectChanges); // 0 x detectChanges no render
-from([1, 2, 3])
-  .pipe(coalesceWith(queueMicroTask, this))
-  .subscribe(detectChanges); // 1 x detectChanges renders 3
+from([1, 2, 3]).pipe(coalesceWith(queueMicroTask, this)).subscribe(detectChanges); // 0 x detectChanges no render
+from([1, 2, 3]).pipe(coalesceWith(queueMicroTask, this)).subscribe(detectChanges); // 1 x detectChanges renders 3
 ```
 
 With this in mind, we can go one step further and look at change detection across multiple components.

--- a/apps/docs/docs/cdk/coalescing/coalescing.mdx
+++ b/apps/docs/docs/cdk/coalescing/coalescing.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/coalescing
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small typed and documented convenience helper to apply performance improvements over coalescing techniques.
 

--- a/apps/docs/docs/cdk/coercing/coercing.mdx
+++ b/apps/docs/docs/cdk/coercing/coercing.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/coercing
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > Convenience helper to easily coerce reactive values.
 

--- a/apps/docs/docs/cdk/coercing/coercing.mdx
+++ b/apps/docs/docs/cdk/coercing/coercing.mdx
@@ -64,8 +64,7 @@ In general when we apply those techniques our code base starts to maintain repet
 As an example let's look at this snippet of code here:
 
 ```typescript
-const num =
-  !isNaN(parseFloat(valueFromInput)) && !isNaN(Number(valueFromInput));
+const num = !isNaN(parseFloat(valueFromInput)) && !isNaN(Number(valueFromInput));
 ```
 
 Because we receive the value from an input the type is always string. We have to care every time the when we want to pass the value to get a proper number type of it.
@@ -204,9 +203,7 @@ This comes in handy for later processing and improves performance.
 })
 export class AppComponent {
   _prop1 = new Subject<number | Observable<number>>();
-  prop1Observables$: Observable<number> = this._prop1.pipe(
-    coerceDistinctWith()
-  );
+  prop1Observables$: Observable<number> = this._prop1.pipe(coerceDistinctWith());
 
   @Input()
   set prop1(val: Observable<number> | number) {
@@ -241,10 +238,7 @@ A minimal implementation if it would look like this:
 })
 export class AppComponent {
   _prop1 = new Subject<number | Observable<number>>();
-  prop1Changes$: Observable<number> = this._prop1.pipe(
-    coerceDistinctWith(),
-    switchAll()
-  );
+  prop1Changes$: Observable<number> = this._prop1.pipe(coerceDistinctWith(), switchAll());
 
   @Input()
   set prop1(val: Observable<number> | number) {

--- a/apps/docs/docs/cdk/notifications/notifications.mdx
+++ b/apps/docs/docs/cdk/notifications/notifications.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/notifications
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small typed convenience helper to handle contextual state.
 

--- a/apps/docs/docs/cdk/render-strategies/render-strategies.mdx
+++ b/apps/docs/docs/cdk/render-strategies/render-strategies.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 # @rx-angular/cdk/render-strategies
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small typed convenience helper to handle contextual state.
 

--- a/apps/docs/docs/cdk/template-management/template-management.mdx
+++ b/apps/docs/docs/cdk/template-management/template-management.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/template
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small typed convenience helper to handle contextual state.
 

--- a/apps/docs/docs/cdk/transformations/transformations.mdx
+++ b/apps/docs/docs/cdk/transformations/transformations.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/transformations
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A set of functions to manipulate the state in an efficient way.
 

--- a/apps/docs/docs/cdk/zone-configurations/zone-configurations.mdx
+++ b/apps/docs/docs/cdk/zone-configurations/zone-configurations.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/zone-configurations
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small typed and documented convenience helper to configure `zone.js` patching over zone-flags.
 

--- a/apps/docs/docs/cdk/zone-less/zone-less.mdx
+++ b/apps/docs/docs/cdk/zone-less/zone-less.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/cdk/zone-less
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A set of wrappers for Browser native as well as RxJS functions to avoid unnecessary change detection and zone interference in Angular.
 

--- a/apps/docs/docs/cdk/zone-less/zone-less.mdx
+++ b/apps/docs/docs/cdk/zone-less/zone-less.mdx
@@ -112,9 +112,7 @@ export class AppComponent {
 
   doOtherStuff() {
     // unpatched method of an HTML element
-    getZoneUnPatchedApi(elem, 'addEventListener')('click', () =>
-      console.log('tada!')
-    );
+    getZoneUnPatchedApi(elem, 'addEventListener')('click', () => console.log('tada!'));
   }
 }
 ```

--- a/apps/docs/docs/state/actions/actions.mdx
+++ b/apps/docs/docs/state/actions/actions.mdx
@@ -81,7 +81,7 @@ import { exhaustMap } from 'rxjs';
       (click)="
         actions.login({
           username: username.value,
-          password: password.value
+          password: password.value,
         })
       "
     >
@@ -124,7 +124,7 @@ import { exhaustMap } from 'rxjs';
       (click)="
         actions.login({
           username: username.value,
-          password: password.value
+          password: password.value,
         })
       "
     >
@@ -347,7 +347,7 @@ import { exhaustMap } from 'rxjs';
       (click)="
         actions.login({
           username: username.value,
-          password: password.value
+          password: password.value,
         })
       "
     >

--- a/apps/docs/docs/state/actions/actions.mdx
+++ b/apps/docs/docs/state/actions/actions.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 # @rx-angular/state/actions
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > `RxActions` is a powerful yet simple tool to manage action throughout your application.
 > It can be seen as the glue between user based events and your applications state.

--- a/apps/docs/docs/state/effects/effects.mdx
+++ b/apps/docs/docs/state/effects/effects.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 # @rx-angular/state/effects
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A small convenience helper to handle side effects based on Observable inputs.
 

--- a/apps/docs/docs/state/selections/selections.mdx
+++ b/apps/docs/docs/state/selections/selections.mdx
@@ -8,7 +8,7 @@ hide_title: true
 # @rx-angular/state/selections
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > This package provides a set of RxJS operators to select the state in an efficient way.
 

--- a/libs/cdk/README.md
+++ b/libs/cdk/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/cdk
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/rx-angular/rx-angular/branch/main/graph/badge.svg?token=Jxy4xLJSs1&flag=cdk)](https://codecov.io/gh/rx-angular/rx-angular)
 
 > A Component Development Kit for High performance and ergonomic Angular UI libs and large scale applications.

--- a/libs/cdk/zone-less/browser/README.md
+++ b/libs/cdk/zone-less/browser/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/cdk/zone-less/browse
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fcdk.svg)](https://www.npmjs.com/package/%40rx-angular%2Fcdk)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > A set of wrappers for Browser native functions to avoid unnecessary change detection and zone interference in Angular.
 

--- a/libs/state/README.md
+++ b/libs/state/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
 [![npm](https://img.shields.io/npm/dt/%40rx-angular%2Fstate.svg)](https://www.npmjs.com/package/%40rx-angular%2Fstate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/rx-angular/rx-angular/branch/main/graph/badge.svg?token=Jxy4xLJSs1&flag=state)](https://codecov.io/gh/rx-angular/rx-angular)
 
 ![state logo](https://raw.githubusercontent.com/rx-angular/rx-angular/main/libs/state/docs/images/state_logo.png)

--- a/libs/template/README.md
+++ b/libs/template/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/template
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Ftemplate.svg)](https://www.npmjs.com/package/%40rx-angular%2Ftemplate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/rx-angular/rx-angular/branch/main/graph/badge.svg?token=Jxy4xLJSs1&flag=template)](https://codecov.io/gh/rx-angular/rx-angular)
 
 > A lib for handling data streams in templates for high performance and ergonomic Angular UI's in large-scale applications

--- a/libs/template/for/src/lib/README.md
+++ b/libs/template/for/src/lib/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/template/for
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Ftemplate.svg)](https://www.npmjs.com/package/%40rx-angular%2Ftemplate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > This package provides a quick way to create an action channel and some configuration options.
 

--- a/libs/template/let/src/lib/README.md
+++ b/libs/template/let/src/lib/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/template/let
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Ftemplate.svg)](https://www.npmjs.com/package/%40rx-angular%2Ftemplate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > This package provides a quick way to create an action channel and some configuration options.
 

--- a/libs/template/unpatch/src/lib/README.md
+++ b/libs/template/unpatch/src/lib/README.md
@@ -1,7 +1,7 @@
 # @rx-angular/template/unpatch
 
 [![npm](https://img.shields.io/npm/v/%40rx-angular%2Ftemplate.svg)](https://www.npmjs.com/package/%40rx-angular%2Ftemplate)
-![rx-angular CI](https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=master)
+![rx-angular CI](https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main)
 
 > This package provides a quick way to create an action channel and some configuration options.
 


### PR DESCRIPTION
## What this PR does

Updates the CI status badge URL across all READMEs and docs pages.

The badge was broken for two reasons:

1. Deprecated URL format
2. Renamed workflow

Also normalizes a few stale `?branch=master` references to `?branch=main`.

- Before: `https://github.com/rx-angular/rx-angular/workflows/rx-angular%20CI/badge.svg?branch=main`
- After:  `https://github.com/rx-angular/rx-angular/actions/workflows/build-and-test.yml/badge.svg?branch=main`

The new URL returns `HTTP 200 / image/svg+xml`.