### PR TITLE
feat: add speculative route preloading

### DIFF
--- a/libs/speculative-link/.eslintrc.json
+++ b/libs/speculative-link/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../.eslintrc.json",
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": "off",
+        "@angular-eslint/directive-class-suffix": "off",
+        "@angular-eslint/no-input-rename": "off",
+        "@angular-eslint/prefer-standalone": "off",
+        "@angular-eslint/prefer-inject": "off"
+      }
+    }
+  ]
+}

--- a/libs/speculative-link/jest.config.ts
+++ b/libs/speculative-link/jest.config.ts
@@ -1,0 +1,21 @@
+export default {
+  displayName: 'speculative-link',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../coverage/speculative-link',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/speculative-link/ng-package.json
+++ b/libs/speculative-link/ng-package.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/speculative-link",
+  "lib": {
+    "flatModuleFile": "speculative-link",
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/speculative-link/package.json
+++ b/libs/speculative-link/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@rx-angular/speculative-link",
+  "version": "21.0.0",
+  "description": "Viewport-aware route preloading and pre-resolution for Angular applications.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Michael Hladky <michael.hladky@push-based.io>",
+  "homepage": "https://rx-angular.io/",
+  "keywords": [
+    "angular",
+    "router",
+    "preloading",
+    "performance",
+    "speculative loading"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rx-angular/rx-angular/tree/main/libs/speculative-link"
+  },
+  "peerDependencies": {
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/router": "^21.0.0",
+    "rxjs": "^6.5.3 || ^7.4.0"
+  },
+  "dependencies": {
+    "tslib": "^2.4.1"
+  }
+}

--- a/libs/speculative-link/project.json
+++ b/libs/speculative-link/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "speculative-link",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/speculative-link/src",
+  "prefix": "rx",
+  "tags": ["type:lib", "speculative-link"],
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:package",
+      "options": {
+        "tsConfig": "libs/speculative-link/tsconfig.lib.json",
+        "project": "libs/speculative-link/ng-package.json"
+      },
+      "outputs": ["{workspaceRoot}/dist/libs/speculative-link"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "libs/speculative-link/jest.config.ts",
+        "codeCoverage": true,
+        "tsConfig": "libs/speculative-link/tsconfig.spec.json"
+      },
+      "outputs": ["{workspaceRoot}/coverage/speculative-link"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/libs/speculative-link/src/index.ts
+++ b/libs/speculative-link/src/index.ts
@@ -1,0 +1,2 @@
+export { withSpeculativeLinkPreloading } from './lib/provide';
+export { SpeculativeLink } from './lib/speculative-link.directive';

--- a/libs/speculative-link/src/lib/find-path.utils.spec.ts
+++ b/libs/speculative-link/src/lib/find-path.utils.spec.ts
@@ -1,0 +1,75 @@
+import { Route } from '@angular/router';
+import { findPath } from './find-path.utils';
+
+const BASE_ROUTE: Route = {
+  path: 'home',
+};
+const NAMED_OUTLET_ROUTE: Route = {
+  path: 'aside',
+  outlet: 'side',
+};
+
+describe('findPath', () => {
+  it('should correctly build base route', () => {
+    expect(findPath([BASE_ROUTE], BASE_ROUTE)).toBe('/home');
+  });
+
+  it('should correctly build route with named outlet', () => {
+    expect(findPath([NAMED_OUTLET_ROUTE], NAMED_OUTLET_ROUTE)).toBe(
+      '/(side:aside)',
+    );
+  });
+
+  it('should correctly build route with one empty parent path', () => {
+    expect(
+      findPath(
+        [
+          {
+            path: '',
+            children: [BASE_ROUTE],
+          },
+        ],
+        BASE_ROUTE,
+      ),
+    ).toBe('/home');
+  });
+
+  it('should correctly build route with more than one empty parent path', () => {
+    expect(
+      findPath(
+        [
+          {
+            path: '',
+            children: [
+              {
+                path: '',
+                children: [BASE_ROUTE],
+              },
+            ],
+          },
+        ],
+        BASE_ROUTE,
+      ),
+    ).toBe('/home');
+  });
+
+  it('should correctly build route with more than one empty parent path and nested outlet', () => {
+    expect(
+      findPath(
+        [
+          {
+            path: '',
+            children: [
+              {
+                path: '',
+                children: [BASE_ROUTE],
+              },
+              NAMED_OUTLET_ROUTE,
+            ],
+          },
+        ],
+        NAMED_OUTLET_ROUTE,
+      ),
+    ).toBe('/(side:aside)');
+  });
+});

--- a/libs/speculative-link/src/lib/find-path.utils.ts
+++ b/libs/speculative-link/src/lib/find-path.utils.ts
@@ -1,0 +1,74 @@
+import { PRIMARY_OUTLET, Route } from '@angular/router';
+
+export function findPath(config: Route[], route: Route): string {
+  const reverseMap = bfsReverseMap(config, route);
+
+  return constructPath(route, reverseMap);
+}
+
+function bfsReverseMap(config: Route[], route: Route): Map<Route, Route> {
+  const reverseMap = new Map<Route, Route>();
+  const visited = new Set<Route>();
+  const queue: Route[] = [];
+
+  for (let i = 0; i < config.length; i++) {
+    queue.push(config[i]);
+  }
+
+  let index = 0;
+  while (index < queue.length) {
+    const el = queue[index++];
+    if (!el) continue;
+
+    visited.add(el);
+    if (el === route) return reverseMap;
+
+    const children = el.children || [];
+    const current = (el as any)._loadedRoutes || [];
+
+    for (let i = 0; i < current.length; i++) {
+      const child = current[i];
+      if (child && child.children) {
+        addAllChildren(child, children);
+      }
+    }
+
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (!visited.has(child)) {
+        reverseMap.set(child, el);
+        queue.push(child);
+      }
+    }
+  }
+
+  return reverseMap;
+}
+
+function addAllChildren(route: Route, children: Route[]): void {
+  if (!route.children) return;
+  for (let i = 0; i < route.children.length; i++) {
+    const child = route.children[i];
+    children.push(child);
+    addAllChildren(child, children);
+  }
+}
+
+function constructPath(route: Route, reverseMap: Map<Route, Route>): string {
+  let path = '';
+  let current: Route | undefined = route;
+
+  do {
+    if (isPrimaryRoute(current)) {
+      path = `/${current.path}${path}`;
+    } else {
+      path = `/(${current.outlet}:${current.path}${path})`;
+    }
+  } while ((current = reverseMap.get(current!)));
+
+  return path.replace(/\/+/g, '/');
+}
+
+function isPrimaryRoute(route: Route): boolean {
+  return route.outlet === PRIMARY_OUTLET || !route.outlet;
+}

--- a/libs/speculative-link/src/lib/matcher.service.ts
+++ b/libs/speculative-link/src/lib/matcher.service.ts
@@ -1,0 +1,199 @@
+import { inject, Injectable } from '@angular/core';
+import {
+  Params,
+  PRIMARY_OUTLET,
+  Route,
+  Router,
+  Routes,
+  UrlMatchResult,
+  UrlSegment,
+  UrlSegmentGroup,
+  UrlTree,
+} from '@angular/router';
+import { findPathDetails, PATTERN_ALIAS } from './util';
+
+type UrlSegmentWithRoute = UrlSegment & { route: Route };
+
+@Injectable({ providedIn: 'root' })
+export class MatcherService {
+  readonly #router = inject(Router);
+
+  matches(route: Route, tree: UrlTree): Params | null {
+    const routeTree = this.#getExtendedTree(route);
+    const matchingSegments = matchingSegmentGroups(
+      tree.root,
+      routeTree.root,
+      routeTree.root.segments,
+    );
+
+    if (matchingSegments) {
+      return matchResultToParams(matchingSegments);
+    }
+
+    return null;
+  }
+
+  #getExtendedTree(route: Route) {
+    const { url, matcherRoutes } = findPathDetails(this.#router.config, route);
+
+    return extendTreeWithMatcherRoutes(
+      this.#router.parseUrl(url),
+      matcherRoutes,
+    );
+  }
+}
+
+export function matchResultToParams(
+  matches: boolean | UrlMatchResult[],
+): Params {
+  if (typeof matches === 'boolean') return {};
+  return Object.fromEntries(
+    matches
+      .flatMap(({ posParams }) => Object.entries(posParams || {}))
+      .map(([key, value]) => [key, value.path]),
+  );
+}
+
+export function matchingSegmentGroups(
+  container: UrlSegmentGroup,
+  containee: UrlSegmentGroup,
+  containeePaths: UrlSegment[],
+): boolean | UrlMatchResult[] {
+  if (container.segments.length > containeePaths.length) {
+    const current = container.segments.slice(0, containeePaths.length);
+    return (
+      !containee.hasChildren() &&
+      matchesSegmentGroup(current, container, containeePaths)
+    );
+  }
+  if (container.segments.length !== containeePaths.length) {
+    const current = containeePaths.slice(0, container.segments.length);
+    const matchResults = matchesSegmentGroup(
+      container.segments,
+      container,
+      current,
+    );
+    if (!matchResults || !container.children[PRIMARY_OUTLET]) return false;
+    const next = containeePaths.slice(container.segments.length);
+    const matchedChildren = matchingSegmentGroups(
+      container.children[PRIMARY_OUTLET],
+      containee,
+      next,
+    ); //@TODO needs to concat results
+    if (matchedChildren) {
+      if (matchResults === true) {
+        return matchedChildren;
+      }
+      if (matchedChildren === true) {
+        return matchedChildren;
+      }
+      return matchResults.concat(matchedChildren);
+    }
+  }
+  const matchResults = matchesSegmentGroup(
+    container.segments,
+    container,
+    containeePaths,
+  );
+  if (!matchResults) return false;
+  if (!containee.hasChildren()) return matchResults;
+
+  const results: UrlMatchResult[] =
+    typeof matchResults === 'boolean' ? [] : matchResults;
+  let result = false;
+  for (const c in containee.children) {
+    if (!container.children[c]) break;
+    const matchedChildren = matchingSegmentGroups(
+      container.children[c]!,
+      containee.children[c]!,
+      containee.children[c]!.segments,
+    );
+    if (typeof matchedChildren !== 'boolean') {
+      results.push(...matchedChildren);
+    } else if (matchedChildren) {
+      result = matchedChildren;
+    }
+  }
+  if (results.length > 0) {
+    return results;
+  }
+  return result;
+}
+
+function matchesSegmentGroup(
+  registered: UrlSegment[],
+  registeredGroup: UrlSegmentGroup,
+  current: (UrlSegment | UrlSegmentWithRoute)[],
+): boolean | UrlMatchResult[] {
+  if (registered.length !== current.length) return false;
+
+  return registered.reduce<true | UrlMatchResult[] | false>(
+    (accumulator, registeredItem, index) => {
+      if (accumulator === false) return false; // Early termination
+
+      const currentItem = current[index]!;
+
+      if (registeredItem.path === currentItem.path) return accumulator;
+
+      if (
+        currentItem.path.startsWith(':') ||
+        registeredItem.path.startsWith(':')
+      ) {
+        const urlMatch: UrlMatchResult = {
+          consumed: [registeredItem],
+          posParams: { [currentItem.path.replace(':', '')]: registeredItem },
+        };
+        if (typeof accumulator === 'boolean') {
+          return [urlMatch];
+        }
+        accumulator.push(urlMatch);
+        return accumulator;
+      }
+
+      if (currentItem.path !== PATTERN_ALIAS) return false;
+
+      const urlMatch: UrlMatchResult | null = (<UrlSegmentWithRoute>(
+        currentItem
+      ))['route'].matcher!(
+        [registeredItem],
+        registeredGroup,
+        (<UrlSegmentWithRoute>currentItem)['route'],
+      );
+
+      if (!urlMatch) return false;
+
+      return accumulator === true ? [urlMatch] : [...accumulator, urlMatch];
+    },
+    true,
+  );
+}
+
+export function extendTreeWithMatcherRoutes(
+  tree: UrlTree,
+  matcherRoutes: Routes,
+) {
+  if (!matcherRoutes.length) return tree;
+
+  extendUrlSegmentGroup(tree.root, matcherRoutes);
+
+  return tree;
+}
+
+function extendUrlSegmentGroup(
+  group: UrlSegmentGroup,
+  matcherRoutes: Routes,
+  currentMatcher = 0,
+) {
+  for (const segment of group.segments) {
+    if (segment.path === PATTERN_ALIAS) {
+      (<UrlSegment & { route: Route | undefined }>segment)['route'] =
+        matcherRoutes[currentMatcher];
+      currentMatcher++;
+    }
+  }
+  if (group.hasChildren()) {
+    Object.values(group.children).forEach((child) =>
+      extendUrlSegmentGroup(child, matcherRoutes, currentMatcher),
+    );
+  }
+}

--- a/libs/speculative-link/src/lib/pre-resolver-registry.service.ts
+++ b/libs/speculative-link/src/lib/pre-resolver-registry.service.ts
@@ -1,0 +1,96 @@
+import { inject, Injectable, Injector } from '@angular/core';
+import {
+  Data,
+  Params,
+  Route,
+  RouteConfigLoadEnd,
+  Router,
+  Routes,
+  UrlTree,
+} from '@angular/router';
+import { filter, map, Observable, ReplaySubject, tap } from 'rxjs';
+import { MatcherService } from './matcher.service';
+import schedule from './schedule';
+
+export type PreResolver = {
+  route: RouteWithPreResolver;
+  params: Params;
+  injector: Injector;
+};
+
+export type RouteWithPreResolver = Route & {
+  data: {
+    preResolve: (route: { data: Data; params: Params }) => void;
+  };
+  _injector?: Injector;
+};
+
+@Injectable({ providedIn: 'root' })
+export class PreResolverRegistry {
+  readonly #injector = inject(Injector);
+
+  readonly #matcher = inject(MatcherService);
+
+  readonly #loaded$ = new ReplaySubject<RouteWithPreResolver>();
+  readonly loadedPreResolvers$ = this.#loaded$.asObservable();
+  readonly #preResolverRoutes = new Set<RouteWithPreResolver>();
+
+  constructor(router: Router) {
+    router.events
+      .pipe(
+        filter(
+          (event): event is RouteConfigLoadEnd =>
+            event instanceof RouteConfigLoadEnd,
+        ),
+        tap(({ route }) => {
+          /**
+           * The idleCallback is necessary because routes have loaded but not yet processed, the fields we
+           * access to load the preResolvers and the required data like _loadRoutes are only present after
+           * it's done processing.
+           */
+          schedule(() => {
+            // Check if preResolver already loaded to prevent over execution due to scheduling
+            if (!this.#preResolverRoutes.has(route as any)) {
+              this.#registerPreResolverRoutes(route);
+            }
+          });
+        }),
+      )
+      .subscribe();
+  }
+
+  #registerPreResolverRoutes(route: Route): void {
+    if (this.#routeHasPreResolver(route)) {
+      this.#preResolverRoutes.add(route);
+      this.#loaded$.next(route);
+    }
+
+    // @TODO note about missing type...
+    const children: Routes = route.children ?? (<any>route)['_loadedRoutes'];
+    if (children?.length) {
+      children.forEach((child) => {
+        this.#registerPreResolverRoutes(child);
+      });
+    }
+  }
+
+  #routeHasPreResolver(route: Route): route is RouteWithPreResolver {
+    return (
+      route.data?.['preResolve'] &&
+      typeof route.data['preResolve'] === 'function'
+    );
+  }
+
+  matchingPreResolver(tree: UrlTree): Observable<PreResolver> {
+    return this.loadedPreResolvers$.pipe(
+      map((route: RouteWithPreResolver) => ({
+        route,
+        params: this.#matcher.matches(route, tree),
+        injector: route['_injector'] ?? this.#injector,
+      })),
+      filter((preResolver): preResolver is PreResolver => {
+        return preResolver.params !== null;
+      }),
+    );
+  }
+}

--- a/libs/speculative-link/src/lib/provide.ts
+++ b/libs/speculative-link/src/lib/provide.ts
@@ -1,0 +1,6 @@
+import { withPreloading } from '@angular/router';
+import { SpeculativeLinkPreloader } from './speculative-link-preloader.service';
+
+export function withSpeculativeLinkPreloading() {
+  return withPreloading(SpeculativeLinkPreloader);
+}

--- a/libs/speculative-link/src/lib/schedule.ts
+++ b/libs/speculative-link/src/lib/schedule.ts
@@ -1,0 +1,9 @@
+const hasIdleCallback =
+  'window' in globalThis && typeof window.requestIdleCallback === 'function';
+
+const schedule = !hasIdleCallback
+  ? (cb: () => void, options?: IdleRequestOptions) =>
+      globalThis.setTimeout(cb, options?.timeout ?? 0)
+  : window.requestIdleCallback;
+
+export default schedule;

--- a/libs/speculative-link/src/lib/speculative-link-observer.service.ts
+++ b/libs/speculative-link/src/lib/speculative-link-observer.service.ts
@@ -1,0 +1,77 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import type { SpeculativeLink } from '../index';
+import schedule from './schedule';
+import { SpeculativeLinkRegistry } from './speculative-link-registry.service';
+
+@Injectable({ providedIn: 'root' })
+export class SpeculativeLinkObserver {
+  readonly #ngZone = inject(NgZone);
+  readonly #platformId = inject(PLATFORM_ID);
+  readonly #linkRegistry = inject(SpeculativeLinkRegistry);
+
+  readonly observer = this.#createObserver();
+
+  register(el: SpeculativeLink): void {
+    if (!this.observer) {
+      return;
+    }
+
+    if (!this.#linkRegistry.registeredElements.has(el.element)) {
+      this.#linkRegistry.registeredElements.set(el.element, el);
+
+      this.#ngZone.runOutsideAngular(() => {
+        this.observer?.observe(el.element);
+      });
+    } else if (this.#linkRegistry.intersectingElements.has(el)) {
+      el.onEnterViewport();
+    }
+  }
+
+  unregister(el: SpeculativeLink): void {
+    this.observer?.unobserve(el.element);
+    this.#linkRegistry.registeredElements.delete(el.element);
+
+    if (this.#linkRegistry.intersectingElements.has(el)) {
+      this.#linkRegistry.intersectingElements.delete(el);
+
+      el.onExitViewport();
+    }
+  }
+
+  #createObserver(): IntersectionObserver | null {
+    if (
+      !isPlatformBrowser(this.#platformId) ||
+      typeof IntersectionObserver === 'undefined'
+    ) {
+      return null;
+    }
+
+    return new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const target = this.#linkRegistry.registeredElements.get(
+            entry.target,
+          );
+
+          if (!target) {
+            return;
+          }
+
+          if (entry.isIntersecting) {
+            this.#linkRegistry.intersectingElements.add(target);
+
+            schedule(() => target.onEnterViewport());
+          } else if (this.#linkRegistry.intersectingElements.has(target)) {
+            this.#linkRegistry.intersectingElements.delete(target);
+
+            schedule(() => target.onExitViewport());
+          }
+        });
+      },
+      {
+        threshold: 0.1,
+      },
+    );
+  }
+}

--- a/libs/speculative-link/src/lib/speculative-link-preloader.service.ts
+++ b/libs/speculative-link/src/lib/speculative-link-preloader.service.ts
@@ -1,0 +1,37 @@
+import { inject, Injectable } from '@angular/core';
+import { PreloadingStrategy, Route } from '@angular/router';
+import { EMPTY, Observable } from 'rxjs';
+import { SpeculativeLinkRegistry } from './speculative-link-registry.service';
+
+@Injectable({ providedIn: 'root' })
+export class SpeculativeLinkPreloader implements PreloadingStrategy {
+  #loading = new Set<Route>();
+  #registry = inject(SpeculativeLinkRegistry);
+
+  preload(route: Route, load: () => Observable<void>): Observable<void> {
+    if (this.#loading.has(route)) {
+      // Don't preload the same route twice
+      return EMPTY;
+    }
+    const conn =
+      typeof navigator !== 'undefined'
+        ? (navigator as any).connection
+        : undefined;
+    if (conn) {
+      // Don't preload if the user is on 2G. or if Save-Data is enabled.
+      if ((conn.effectiveType || '').includes('2g') || conn.saveData)
+        return EMPTY;
+    }
+    // Prevent from preloading
+    if (route.data && route.data['preload'] === false) {
+      return EMPTY;
+    }
+
+    if (this.#registry.shouldPrefetch(route)) {
+      this.#loading.add(route);
+      return load();
+    }
+
+    return EMPTY;
+  }
+}

--- a/libs/speculative-link/src/lib/speculative-link-registry.service.ts
+++ b/libs/speculative-link/src/lib/speculative-link-registry.service.ts
@@ -1,0 +1,131 @@
+import { inject, Injectable } from '@angular/core';
+import {
+  Params,
+  PRIMARY_OUTLET,
+  Route,
+  Router,
+  Routes,
+  UrlSegment,
+  UrlSegmentGroup,
+  UrlTree,
+} from '@angular/router';
+import type { SpeculativeLink } from '../index';
+import { findPathDetails, PathDetails, PATTERN_ALIAS } from './util';
+
+@Injectable({ providedIn: 'root' })
+export class SpeculativeLinkRegistry {
+  readonly #router = inject(Router);
+
+  readonly registeredElements = new WeakMap<Element, SpeculativeLink>();
+  readonly intersectingElements = new Set<SpeculativeLink>();
+
+  shouldPrefetch(route: Route) {
+    if (this.intersectingElements.size === 0) return false; // Do not check if in prefetch trees if is empty
+    const { url, matcherRoutes } = findPathDetails(this.#router.config, route);
+    const tree = this.#router.parseUrl(url);
+    (<TreeWithRoutes>tree)['matchers'] = matcherRoutes;
+    for (const link of this.intersectingElements) {
+      const urlTree = link.urlTree();
+      if (urlTree && containsTree(tree, urlTree)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+function containsQueryParams(container: Params, containee: Params): boolean {
+  // TODO: This does not handle array params correctly.
+  return (
+    Object.keys(containee).length <= Object.keys(container).length &&
+    Object.keys(containee).every((key) => containee[key] === container[key])
+  );
+}
+
+function containsTree(containee: UrlTree, container: UrlTree): boolean {
+  return (
+    containsQueryParams(container.queryParams, containee.queryParams) &&
+    containsSegmentGroup(
+      container.root,
+      containee.root,
+      containee.root.segments,
+      (<TreeWithRoutes>containee)['matchers'],
+    )
+  );
+}
+
+type TreeWithRoutes = UrlTree & { matchers: Routes };
+
+function containsSegmentGroup(
+  container: UrlSegmentGroup,
+  containee: UrlSegmentGroup,
+  containeePaths: UrlSegment[],
+  matchers: PathDetails['matcherRoutes'],
+): boolean {
+  if (container.segments.length > containeePaths.length) {
+    const current = container.segments.slice(0, containeePaths.length);
+    if (!equalPath(current, containeePaths, matchers)) return false;
+    return !containee.hasChildren();
+  } else if (container.segments.length === containeePaths.length) {
+    if (!equalPath(container.segments, containeePaths, matchers)) return false;
+    if (!containee.hasChildren()) return true;
+
+    for (const c in containee.children) {
+      if (!container.children[c]) break;
+      if (
+        containsSegmentGroup(
+          container.children[c]!,
+          containee.children[c]!,
+          containee.children[c]!.segments,
+          matchers,
+        )
+      )
+        return true;
+    }
+    return false;
+  } else {
+    const current = containeePaths.slice(0, container.segments.length);
+    const next = containeePaths.slice(container.segments.length);
+    if (!equalPath(container.segments, current, matchers)) return false;
+    if (!container.children[PRIMARY_OUTLET]) return false;
+    return containsSegmentGroup(
+      container.children[PRIMARY_OUTLET],
+      containee,
+      next,
+      matchers,
+    );
+  }
+}
+
+function equalPath(
+  as: UrlSegment[],
+  bs: UrlSegment[],
+  matchers: PathDetails['matcherRoutes'],
+): boolean {
+  if (as.length !== bs.length) return false;
+  return as.every(
+    (a, i) =>
+      a.path === bs[i]!.path ||
+      a.path.startsWith(':') ||
+      bs[i]!.path.startsWith(':') ||
+      matchesMatcher(a, bs, i, matchers),
+  );
+}
+
+function matchesMatcher(
+  a: UrlSegment,
+  bs: UrlSegment[],
+  i: number,
+  matchers?: PathDetails['matcherRoutes'],
+): boolean {
+  if (
+    matchers &&
+    matchers.length &&
+    matchers[0]!.matcher &&
+    bs[i]!.path === PATTERN_ALIAS
+  ) {
+    // @TODO: This does not remove the matcher so it does not work properly if route contains multiple URL matchers
+    return !!matchers[0]!.matcher([a], [] as any, matchers[0]!);
+  }
+  return false;
+}

--- a/libs/speculative-link/src/lib/speculative-link.directive.ts
+++ b/libs/speculative-link/src/lib/speculative-link.directive.ts
@@ -1,0 +1,127 @@
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import {
+  computed,
+  DestroyRef,
+  Directive,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  NgZone,
+  PLATFORM_ID,
+  runInInjectionContext,
+} from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Router, RouterPreloader } from '@angular/router';
+import { filter, switchMap, tap } from 'rxjs';
+import {
+  PreResolver,
+  PreResolverRegistry,
+} from './pre-resolver-registry.service';
+import schedule from './schedule';
+import { SpeculativeLinkObserver } from './speculative-link-observer.service';
+
+/**
+ *
+ * Inspired by the [Speculation Rules API]{@link https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API}
+ *
+ * @whatItDoes When the link is observed in the viewport it will preload its route and execute its preResolvers.
+ *
+ */
+
+@Directive({
+  standalone: true,
+  selector: '[speculativeLink]',
+})
+export class SpeculativeLink {
+  readonly ref = input.required<string>({ alias: 'speculativeLink' });
+
+  readonly #router = inject(Router);
+  readonly #ngZone = inject(NgZone);
+  readonly #document = inject(DOCUMENT);
+  readonly #platformId = inject(PLATFORM_ID);
+  readonly #loader = inject(RouterPreloader);
+  public readonly element: HTMLElement = inject(ElementRef).nativeElement;
+
+  readonly #observer = inject(SpeculativeLinkObserver);
+  readonly #preResolverRegistry = inject(PreResolverRegistry);
+
+  constructor(destroyRef: DestroyRef) {
+    toObservable(this.urlTree)
+      .pipe(
+        tap(() => this.#preResolvers.clear()),
+        filter(Boolean),
+        switchMap((urlTree) => {
+          return this.#preResolverRegistry.matchingPreResolver(urlTree);
+        }),
+        tap((preResolver) => this.#addPreResolver(preResolver)),
+        takeUntilDestroyed(),
+      )
+      .subscribe();
+
+    destroyRef.onDestroy(() => {
+      this.#observer.unregister(this);
+    });
+
+    effect(() => {
+      const tree = this.urlTree();
+
+      if (!tree) {
+        this.#observer.unregister(this);
+        return;
+      }
+
+      this.#observer.register(this);
+    });
+  }
+
+  readonly #preResolvers = new Set<PreResolver>();
+
+  onEnterViewport() {
+    this.#loader.preload().subscribe(() => void 0);
+
+    this.#preResolvers.forEach((preResolver) => {
+      this.#executePreResolver(preResolver);
+    });
+  }
+
+  onExitViewport(): void {
+    return;
+  }
+
+  urlTree = computed(() => {
+    if (isPlatformServer(this.#platformId)) {
+      return null;
+    }
+    const href = this.ref();
+    if (href === null) {
+      return null;
+    }
+    if (!href.includes('http')) {
+      return this.#router.parseUrl(href);
+    }
+    const url = new URL(href);
+    if (this.#document.location.hostname !== url.hostname) {
+      return null;
+    }
+    return this.#router.parseUrl(url.pathname);
+  });
+
+  #addPreResolver(preResolver: PreResolver): void {
+    this.#preResolvers.add(preResolver);
+    this.#executePreResolver(preResolver);
+  }
+
+  #executePreResolver(preResolver: PreResolver): void {
+    schedule(() => {
+      runInInjectionContext(preResolver.injector, () => {
+        this.#ngZone.run(() => {
+          preResolver.route.data.preResolve({
+            data: preResolver.route.data,
+            params: preResolver.params,
+          });
+        });
+      });
+    });
+  }
+}

--- a/libs/speculative-link/src/lib/util.ts
+++ b/libs/speculative-link/src/lib/util.ts
@@ -1,0 +1,62 @@
+import { PRIMARY_OUTLET, Route, Routes } from '@angular/router';
+
+export const PATTERN_ALIAS = '__MatcherPlaceholder__';
+
+export type PathDetails = { url: string; matcherRoutes: Routes };
+
+// copy-paste of ngx-quicklink
+export const findPathDetails = (config: Routes, route: Route): PathDetails => {
+  config = config.slice();
+  const parent = new Map<Route, Route>();
+  const visited = new Set<Route>();
+  while (config.length) {
+    const el = config.shift();
+    if (!el) {
+      continue;
+    }
+    visited.add(el);
+    if (el === route) break;
+
+    let children = el.children ?? (el as any)._loadedRoutes ?? [];
+
+    const lazyChildren = (el as any)._loadedRoutes || [];
+
+    for (const lazyChild of lazyChildren) {
+      if (lazyChild && lazyChild.children) {
+        children = children.concat(lazyChild.children);
+      }
+    }
+    children.forEach((r: Route) => {
+      if (visited.has(r)) return;
+      parent.set(r, el);
+      config.push(r);
+    });
+  }
+  let path = '';
+  let current: Route | undefined = route;
+  const matcherRoutes: Routes = [];
+
+  while (current) {
+    const currentPath = current.matcher ? PATTERN_ALIAS : current.path;
+    if (current.matcher) {
+      matcherRoutes.unshift(current);
+    }
+    if (isPrimaryRoute(current)) {
+      path = `/${currentPath}${path}`;
+    } else {
+      path = `/(${current.outlet}:${currentPath}${path})`;
+    }
+    current = parent.get(current);
+  }
+  /**
+   * Remove duplicate slashes
+   *  - If route contains multiple /  it will transform them only
+   *    example url -> ///section///sub-section/// = /section/sub-section/
+   */
+  const url = path.replace(/\/+/g, '/');
+  return { url, matcherRoutes };
+};
+
+function isPrimaryRoute(route: Route) {
+  return route.outlet === PRIMARY_OUTLET || !route.outlet;
+}

--- a/libs/speculative-link/src/test-setup.ts
+++ b/libs/speculative-link/src/test-setup.ts
@@ -1,0 +1,80 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();
+
+class IntersectionObserverMock implements IntersectionObserver {
+  private callback: IntersectionObserverCallback;
+  private options?: IntersectionObserverInit;
+  private elements: Element[] = [];
+
+  public root: Element | Document | null = null;
+  public rootMargin = '0px';
+  public thresholds: ReadonlyArray<number> = [0];
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.callback = callback;
+    this.options = options;
+    this.root = options?.root || null;
+    this.rootMargin = options?.rootMargin || '0px';
+    this.thresholds = Array.isArray(options?.threshold)
+      ? options.threshold
+      : [options?.threshold || 0];
+  }
+
+  observe(element: Element): void {
+    this.elements.push(element);
+    // // Simulate an intersection
+    // this.callback(
+    //   [
+    //     {
+    //       target: element,
+    //       isIntersecting: true,
+    //       intersectionRatio: 1,
+    //       boundingClientRect: element.getBoundingClientRect(),
+    //       intersectionRect: element.getBoundingClientRect(),
+    //       rootBounds: null,
+    //       time: performance.now(),
+    //     } as IntersectionObserverEntry,
+    //   ],
+    //   this
+    // );
+  }
+
+  unobserve(element: Element): void {
+    this.elements = this.elements.filter((el) => el !== element);
+  }
+
+  disconnect(): void {
+    this.elements = [];
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return this.elements.map((element) => ({
+      target: element,
+      isIntersecting: true,
+      intersectionRatio: 1,
+      boundingClientRect: element.getBoundingClientRect(),
+      intersectionRect: element.getBoundingClientRect(),
+      rootBounds: null,
+      time: performance.now(),
+    }));
+  }
+}
+
+// Assign the mock to the global window object
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: IntersectionObserverMock,
+});

--- a/libs/speculative-link/tsconfig.json
+++ b/libs/speculative-link/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/speculative-link/tsconfig.lib.json
+++ b/libs/speculative-link/tsconfig.lib.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "moduleResolution": "bundler",
+    "types": []
+  },
+  "angularCompilerOptions": {
+    "enableIvy": true,
+    "compilationMode": "partial",
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/speculative-link/tsconfig.spec.json
+++ b/libs/speculative-link/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "types": ["jest", "node"],
+    "isolatedModules": true
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -100,7 +100,14 @@
     "projectSpecificFiles": []
   },
   "release": {
-    "projects": ["cdk", "template", "isr", "state", "eslint-plugin"],
+    "projects": [
+      "cdk",
+      "template",
+      "isr",
+      "state",
+      "eslint-plugin",
+      "speculative-link"
+    ],
     "projectsRelationship": "independent",
     "conventionalCommits": {
       "types": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -45,6 +45,7 @@
       "@rx-angular/isr/browser": ["libs/isr/browser/src/index.ts"],
       "@rx-angular/isr/models": ["libs/isr/models/src/index.ts"],
       "@rx-angular/isr/server": ["libs/isr/server/src/index.ts"],
+      "@rx-angular/speculative-link": ["libs/speculative-link/src/index.ts"],
       "@rx-angular/state": ["libs/state/src/index.ts"],
       "@rx-angular/state/actions": ["libs/state/actions/src/index.ts"],
       "@rx-angular/state/effects": ["libs/state/effects/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11142,6 +11142,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@rx-angular/speculative-link@workspace:libs/speculative-link":
+  version: 0.0.0-use.local
+  resolution: "@rx-angular/speculative-link@workspace:libs/speculative-link"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  peerDependencies:
+    "@angular/common": ^21.0.0
+    "@angular/core": ^21.0.0
+    "@angular/router": ^21.0.0
+    rxjs: ^6.5.3 || ^7.4.0
+  languageName: unknown
+  linkType: soft
+
 "@rx-angular/state@workspace:libs/state":
   version: 0.0.0-use.local
   resolution: "@rx-angular/state@workspace:libs/state"


### PR DESCRIPTION
## Summary

Adds `@rx-angular/speculative-link`, a standalone Angular package for viewport-aware router preloading. The package provides a `SpeculativeLink` directive and `withSpeculativeLinkPreloading()` router feature so lazy routes can be loaded when matching links become visible.

## Usage

Register the preloading strategy with the router:

```ts
import { provideRouter } from "@angular/router";
import { withSpeculativeLinkPreloading } from "@rx-angular/speculative-link";

bootstrapApplication(AppComponent, {
  providers: [provideRouter(routes, withSpeculativeLinkPreloading())],
});
```

Mark links that should trigger speculative loading when they enter the viewport:

```html
<a routerLink="/products/42" speculativeLink="/products/42">Product</a>
```

Routes can opt out with `data.preload === false`:

```ts
{
  path: "admin",
  loadComponent: () => import("./admin.component"),
  data: { preload: false },
}
```

Routes can also provide a `data.preResolve` callback to warm route data before navigation:

```ts
{
  path: "products/:id",
  loadComponent: () => import("./product.component"),
  data: {
    preResolve: ({ params }) => {
      inject(ProductStore).prefetch(params["id"]);
    },
  },
}
```

Absolute same-host URLs are supported; cross-origin URLs are ignored. Preloading is skipped for Save-Data and 2G network conditions.

## Validation

- `yarn nx lint speculative-link --skip-nx-cache`
- `yarn nx test speculative-link --skip-nx-cache`
- `yarn nx build speculative-link --skip-nx-cache`
