### PR TITLE
fix(rebundle): improve generator and build output

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,1 +1,2 @@
 libs/**/*.md
+!libs/rebundle/README.md

--- a/libs/rebundle/package.json
+++ b/libs/rebundle/package.json
@@ -47,7 +47,8 @@
       "types": "./src/index.d.ts",
       "require": "./src/index.js",
       "import": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "generators": "./generators.json",
   "executors": "./executors.json"

--- a/libs/rebundle/project.json
+++ b/libs/rebundle/project.json
@@ -25,6 +25,7 @@
         "packageJson": "libs/rebundle/package.json",
         "main": "libs/rebundle/src/index.ts",
         "assets": [
+          "libs/rebundle/README.md",
           "libs/rebundle/generators.json",
           "libs/rebundle/executors.json",
           "libs/rebundle/src/generators/**/*.json"

--- a/libs/rebundle/src/esbuild-plugin/index.ts
+++ b/libs/rebundle/src/esbuild-plugin/index.ts
@@ -6,6 +6,7 @@ import { rolldownRebundle } from './rolldown/rebundle';
 import { rolldownOutputsToEsbuildOutputs } from './rolldown/to-esbuild-outputs';
 import { getAppEntryPoint, isJavaScriptOutputFile } from './utils/esbuild';
 import { initialChunks } from './utils/initial-chunks';
+import { createRebundleStats, formatRebundleStats } from './utils/stats';
 
 export interface RebundlePluginOptions {
   mergeStrategy?: MergeStrategyConfig;
@@ -37,7 +38,10 @@ export default function rebundlePlugin(
           throw new Error('Unable to extract outputFiles from esbuild result.');
         }
 
+        const startTime = performance.now();
         const entryChunk = getAppEntryPoint(initialOptions, result.metafile);
+        const originalMetafileOutputs = { ...result.metafile.outputs };
+        const originalOutputFiles = [...result.outputFiles];
         const mergeStrategy = mergeStrategyFactory(
           entryChunk,
           result.metafile,
@@ -78,6 +82,19 @@ export default function rebundlePlugin(
 
         result.outputFiles.push(initialChunksFile);
         result.metafile.outputs[initialChunksFile.path] = initialChunksFileMeta;
+
+        console.info(
+          formatRebundleStats(
+            createRebundleStats(
+              entryChunk,
+              originalMetafileOutputs,
+              originalOutputFiles,
+              result.metafile.outputs,
+              result.outputFiles,
+              performance.now() - startTime,
+            ),
+          ),
+        );
       });
     },
   };

--- a/libs/rebundle/src/esbuild-plugin/rolldown/rebundle.ts
+++ b/libs/rebundle/src/esbuild-plugin/rolldown/rebundle.ts
@@ -22,10 +22,20 @@ export async function rolldownRebundle(
     plugins: [loaderPlugin],
     preserveEntrySignatures: false,
     logLevel: 'silent',
+    optimization: {
+      pifeForModuleWrappers: false,
+    },
+    experimental: {
+      attachDebugInfo: 'none',
+    },
   });
 
   const bundleOutput = await bundle.generate({
     sourcemap,
+    minify: true,
+    comments: {
+      legal: false,
+    },
     hashCharacters: 'base36',
     chunkFileNames: preserveFacade,
     codeSplitting: rolldownCodeSplitting(strategy),

--- a/libs/rebundle/src/esbuild-plugin/utils/stats.spec.ts
+++ b/libs/rebundle/src/esbuild-plugin/utils/stats.spec.ts
@@ -1,0 +1,180 @@
+import type { Metafile, OutputFile } from 'esbuild';
+import {
+  calculateChange,
+  calculateReduction,
+  createRebundleStats,
+  formatFileCount,
+  formatRebundleStats,
+  formatReduction,
+  formatSignedBytes,
+  formatSignedFileCount,
+} from './stats';
+
+describe('rebundle stats', () => {
+  it('reports initial and total file count and size changes', () => {
+    const beforeOutputs: Metafile['outputs'] = {
+      'dist/main.js': {
+        entryPoint: 'src/main.ts',
+        imports: [{ path: 'dist/chunk-a.js', kind: 'import-statement' }],
+        exports: [],
+        inputs: {},
+        bytes: 2048,
+      },
+      'dist/chunk-a.js': {
+        imports: [],
+        exports: [],
+        inputs: {},
+        bytes: 1024,
+      },
+      'dist/lazy.js': {
+        imports: [],
+        exports: [],
+        inputs: {},
+        bytes: 512,
+      },
+    };
+    const afterOutputs: Metafile['outputs'] = {
+      'dist/main.js': {
+        entryPoint: 'src/main.ts',
+        imports: [],
+        exports: [],
+        inputs: {},
+        bytes: 4096,
+      },
+      'dist/lazy.js': {
+        imports: [],
+        exports: [],
+        inputs: {},
+        bytes: 512,
+      },
+    };
+
+    const stats = createRebundleStats(
+      'dist/main.js',
+      beforeOutputs,
+      [
+        outputFile('dist/main.js', 2048),
+        outputFile('dist/chunk-a.js', 1024),
+        outputFile('dist/lazy.js', 512),
+      ],
+      afterOutputs,
+      [outputFile('dist/main.js', 4096), outputFile('dist/lazy.js', 512)],
+      123.45,
+    );
+
+    expect(stats).toEqual({
+      durationMs: 123.45,
+      initialBefore: {
+        files: 2,
+        bytes: 3072,
+        transferBytes: 64,
+      },
+      initialAfter: {
+        files: 1,
+        bytes: 4096,
+        transferBytes: 38,
+      },
+      totalBefore: {
+        files: 3,
+        bytes: 3584,
+        transferBytes: 90,
+      },
+      totalAfter: {
+        files: 2,
+        bytes: 4608,
+        transferBytes: 64,
+      },
+    });
+    expect(
+      formatRebundleStats(stats, {
+        colors: false,
+      }),
+    ).toBe(
+      [
+        'Rebundle completed in 123 ms',
+        '',
+        'Scope      | Metric        |   Before |    After |    Change | Reduction',
+        'Initial JS | Files         |        2 |        1 |        -1 |     50.0%',
+        '           | Raw size      |  3.07 kB |  4.10 kB |  +1.02 kB |    -33.3%',
+        '           | Transfer size | 64 bytes | 38 bytes | -26 bytes |     40.6%',
+        '',
+        'Total      | Files         |        3 |        2 |        -1 |     33.3%',
+        '           | Raw size      |  3.58 kB |  4.61 kB |  +1.02 kB |    -28.6%',
+        '           | Transfer size | 90 bytes | 64 bytes | -26 bytes |     28.9%',
+      ].join('\n'),
+    );
+  });
+
+  it('supports colored terminal output', () => {
+    const output = formatRebundleStats(
+      {
+        durationMs: 10,
+        initialBefore: { files: 2, bytes: 2048, transferBytes: 80 },
+        initialAfter: { files: 1, bytes: 1024, transferBytes: 40 },
+        totalBefore: { files: 2, bytes: 2048, transferBytes: 80 },
+        totalAfter: { files: 1, bytes: 1024, transferBytes: 40 },
+      },
+      { colors: true },
+    );
+
+    expect(output).toContain('\u001B[1mScope\u001B[0m');
+    expect(output).toContain(
+      '\u001B[32mInitial JS\u001B[0m\u001B[2m | \u001B[0m\u001B[2mFiles\u001B[0m',
+    );
+    expect(output).toContain('\u001B[32m-1.02 kB\u001B[0m');
+    expect(output).toContain('\u001B[32m50.0%\u001B[0m');
+  });
+
+  it('formats file counts with deterministic thousands separators', () => {
+    expect(formatFileCount(1748)).toBe('1,748');
+    expect(formatFileCount(-1748)).toBe('-1,748');
+    expect(formatSignedFileCount(20)).toBe('+20');
+    expect(formatSignedFileCount(-870)).toBe('-870');
+    expect(formatSignedFileCount(0)).toBe('0');
+  });
+
+  it('formats byte changes from numeric values', () => {
+    expect(formatSignedBytes(-72870)).toBe('-72.87 kB');
+    expect(formatSignedBytes(1024)).toBe('+1.02 kB');
+    expect(formatSignedBytes(0)).toBe('0 bytes');
+  });
+
+  it('calculates reductions, increases, no change, and zero baselines', () => {
+    expect(calculateChange(100, 120)).toBe(20);
+    expect(formatReduction(calculateReduction(100, 120))).toBe('-20.0%');
+    expect(calculateChange(100, 100)).toBe(0);
+    expect(formatReduction(calculateReduction(100, 100))).toBe('0.0%');
+    expect(calculateReduction(0, 10)).toBeUndefined();
+    expect(formatReduction(undefined)).toBe('—');
+  });
+
+  it('formats increases and zero baselines in the table', () => {
+    expect(
+      formatRebundleStats(
+        {
+          durationMs: 10,
+          initialBefore: { files: 100, bytes: 0, transferBytes: 100 },
+          initialAfter: { files: 120, bytes: 1024, transferBytes: 100 },
+          totalBefore: { files: 0, bytes: 0, transferBytes: 0 },
+          totalAfter: { files: 10, bytes: 1024, transferBytes: 0 },
+        },
+        { colors: false },
+      ),
+    ).toContain(
+      [
+        'Initial JS | Files         |       100 |       120 |      +20 |    -20.0%',
+        '           | Raw size      |   0 bytes |   1.02 kB | +1.02 kB |         —',
+        '           | Transfer size | 100 bytes | 100 bytes |  0 bytes |      0.0%',
+      ].join('\n'),
+    );
+  });
+});
+
+function outputFile(path: string, bytes: number): OutputFile {
+  return {
+    path,
+    contents: new Uint8Array(bytes),
+    hash: '',
+    text: '',
+  };
+}

--- a/libs/rebundle/src/esbuild-plugin/utils/stats.ts
+++ b/libs/rebundle/src/esbuild-plugin/utils/stats.ts
@@ -1,0 +1,374 @@
+import type { Metafile, OutputFile } from 'esbuild';
+import { basename } from 'node:path';
+import { stripVTControlCharacters } from 'node:util';
+import { gzipSync } from 'node:zlib';
+import type { OutputPath } from '../../core';
+import { importsInEntryPoint } from './esbuild';
+
+export interface RebundleStats {
+  durationMs: number;
+  initialBefore: FileStats;
+  initialAfter: FileStats;
+  totalBefore: FileStats;
+  totalAfter: FileStats;
+}
+
+export interface FileStats {
+  files: number;
+  bytes: number;
+  transferBytes: number;
+}
+
+export function createRebundleStats(
+  entryChunk: OutputPath,
+  beforeMetafileOutputs: Metafile['outputs'],
+  beforeOutputFiles: OutputFile[],
+  afterMetafileOutputs: Metafile['outputs'],
+  afterOutputFiles: OutputFile[],
+  durationMs: number,
+): RebundleStats {
+  return {
+    durationMs,
+    initialBefore: getInitialStats(
+      entryChunk,
+      beforeMetafileOutputs,
+      beforeOutputFiles,
+    ),
+    initialAfter: getInitialStats(
+      entryChunk,
+      afterMetafileOutputs,
+      afterOutputFiles,
+    ),
+    totalBefore: getOutputFileStats(beforeOutputFiles),
+    totalAfter: getOutputFileStats(afterOutputFiles),
+  };
+}
+
+export function formatRebundleStats(
+  stats: RebundleStats,
+  options: { colors?: boolean } = {},
+): string {
+  const colors = createColors(options.colors ?? shouldUseColor());
+  const rows = createComparisonRows(stats, colors);
+  const widths = getColumnWidths(rows);
+
+  return [
+    `Rebundle completed in ${formatDuration(stats.durationMs)}`,
+    colors.blankLine(),
+    ...rows.map((row) => formatTableRow(row, widths, colors)),
+  ].join('\n');
+}
+
+function getInitialStats(
+  entryChunk: OutputPath,
+  outputs: Metafile['outputs'],
+  outputFiles: OutputFile[],
+): FileStats {
+  const initialFiles = importsInEntryPoint(entryChunk, outputs);
+
+  return {
+    files: initialFiles.length,
+    bytes: sumMetafileOutputBytes(initialFiles, outputs),
+    transferBytes: sumOutputFileTransferBytes(initialFiles, outputFiles),
+  };
+}
+
+function getOutputFileStats(outputFiles: OutputFile[]): FileStats {
+  return {
+    files: outputFiles.length,
+    bytes: outputFiles.reduce((total, file) => total + file.contents.length, 0),
+    transferBytes: sumTransferBytes(outputFiles),
+  };
+}
+
+function sumMetafileOutputBytes(
+  outputPaths: string[],
+  outputs: Metafile['outputs'],
+): number {
+  return outputPaths.reduce(
+    (total, outputPath) => total + (outputs[outputPath]?.bytes ?? 0),
+    0,
+  );
+}
+
+type TableRow = [string, string, string, string, string, string] | [];
+
+function createComparisonRows(
+  stats: RebundleStats,
+  colors: Colors,
+): TableRow[] {
+  return [
+    [
+      colors.bold('Scope'),
+      colors.bold('Metric'),
+      colors.bold('Before'),
+      colors.bold('After'),
+      colors.bold('Change'),
+      colors.bold('Reduction'),
+    ],
+    ...createScopeRows(
+      'Initial JS',
+      stats.initialBefore,
+      stats.initialAfter,
+      colors,
+    ),
+    [],
+    ...createScopeRows('Total', stats.totalBefore, stats.totalAfter, colors),
+  ];
+}
+
+function createScopeRows(
+  scope: string,
+  before: FileStats,
+  after: FileStats,
+  colors: Colors,
+): TableRow[] {
+  return [
+    createMetricRow(scope, 'Files', before.files, after.files, 'files', colors),
+    createMetricRow('', 'Raw size', before.bytes, after.bytes, 'bytes', colors),
+    createMetricRow(
+      '',
+      'Transfer size',
+      before.transferBytes,
+      after.transferBytes,
+      'bytes',
+      colors,
+    ),
+  ];
+}
+
+function createMetricRow(
+  scope: string,
+  metric: string,
+  before: number,
+  after: number,
+  type: 'bytes' | 'files',
+  colors: Colors,
+): TableRow {
+  const change = calculateChange(before, after);
+  const reduction = calculateReduction(before, after);
+
+  return [
+    scope ? colors.green(scope) : '',
+    colors.dim(metric),
+    colors.cyan(formatValue(before, type)),
+    colors.cyan(formatValue(after, type)),
+    colorChange(formatSignedValue(change, type), change, colors),
+    colorReduction(formatReduction(reduction), reduction, colors),
+  ];
+}
+
+function sumOutputFileTransferBytes(
+  outputPaths: string[],
+  outputFiles: OutputFile[],
+): number {
+  const outputFilesByPath = createOutputFilesByPath(outputFiles);
+
+  return sumTransferBytes(
+    outputPaths
+      .map(
+        (outputPath) =>
+          outputFilesByPath.get(outputPath) ??
+          outputFilesByPath.get(basename(outputPath)),
+      )
+      .filter((file): file is OutputFile => Boolean(file)),
+  );
+}
+
+function createOutputFilesByPath(
+  outputFiles: OutputFile[],
+): Map<string, OutputFile> {
+  return new Map(
+    outputFiles.flatMap((outputFile) => [
+      [outputFile.path, outputFile],
+      [basename(outputFile.path), outputFile],
+    ]),
+  );
+}
+
+function sumTransferBytes(outputFiles: OutputFile[]): number {
+  return outputFiles.reduce(
+    (total, outputFile) => total + gzipSync(outputFile.contents).length,
+    0,
+  );
+}
+
+function getColumnWidths(rows: TableRow[]): number[] {
+  return rows.reduce((widths, row) => {
+    if (row.length === 0) {
+      return widths;
+    }
+
+    return row.map((column, index) =>
+      Math.max(widths[index] ?? 0, stripVTControlCharacters(column).length),
+    );
+  }, [] as number[]);
+}
+
+function formatTableRow(
+  columns: string[],
+  widths: number[],
+  colors: Colors,
+): string {
+  if (columns.length === 0) {
+    return colors.blankLine();
+  }
+
+  return columns
+    .map((column, index) => {
+      const width = widths[index] ?? stripVTControlCharacters(column).length;
+      const padding = ' '.repeat(
+        width - stripVTControlCharacters(column).length,
+      );
+
+      return index >= 2 ? padding + column : column + padding;
+    })
+    .join(colors.dim(' | '));
+}
+
+export function calculateChange(before: number, after: number): number {
+  return after - before;
+}
+
+export function calculateReduction(
+  before: number,
+  after: number,
+): number | undefined {
+  if (before === 0) {
+    return undefined;
+  }
+
+  return ((before - after) / before) * 100;
+}
+
+export function formatFileCount(value: number): string {
+  const sign = value < 0 ? '-' : '';
+  const absoluteValue = Math.abs(value).toString();
+  const formattedValue = absoluteValue.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return `${sign}${formattedValue}`;
+}
+
+export function formatSignedFileCount(value: number): string {
+  if (value === 0) {
+    return '0';
+  }
+
+  return `${value > 0 ? '+' : ''}${formatFileCount(value)}`;
+}
+
+export function formatSignedBytes(value: number): string {
+  if (value === 0) {
+    return '0 bytes';
+  }
+
+  return `${value > 0 ? '+' : '-'}${formatBytes(Math.abs(value))}`;
+}
+
+export function formatReduction(value: number | undefined): string {
+  if (value === undefined) {
+    return '—';
+  }
+
+  return `${value.toFixed(1)}%`;
+}
+
+function formatValue(value: number, type: 'bytes' | 'files'): string {
+  return type === 'bytes' ? formatBytes(value) : formatFileCount(value);
+}
+
+function formatSignedValue(value: number, type: 'bytes' | 'files'): string {
+  return type === 'bytes'
+    ? formatSignedBytes(value)
+    : formatSignedFileCount(value);
+}
+
+function colorChange(value: string, change: number, colors: Colors): string {
+  if (change < 0) {
+    return colors.green(value);
+  }
+
+  if (change > 0) {
+    return colors.yellow(value);
+  }
+
+  return value;
+}
+
+function colorReduction(
+  value: string,
+  reduction: number | undefined,
+  colors: Colors,
+): string {
+  if (reduction === undefined || reduction === 0) {
+    return value;
+  }
+
+  if (reduction > 0) {
+    return colors.green(value);
+  }
+
+  return colors.yellow(value);
+}
+
+interface Colors {
+  blankLine: () => string;
+  bold: (value: string) => string;
+  cyan: (value: string) => string;
+  dim: (value: string) => string;
+  green: (value: string) => string;
+  yellow: (value: string) => string;
+}
+
+function createColors(enabled: boolean): Colors {
+  if (!enabled) {
+    return {
+      blankLine: () => '',
+      bold: identity,
+      cyan: identity,
+      dim: identity,
+      green: identity,
+      yellow: identity,
+    };
+  }
+
+  return {
+    blankLine: () => ansi(2)(''),
+    bold: ansi(1),
+    cyan: ansi(36),
+    dim: ansi(2),
+    green: ansi(32),
+    yellow: ansi(33),
+  };
+}
+
+function ansi(code: number): (value: string) => string {
+  return (value) => `\u001B[${code}m${value}\u001B[0m`;
+}
+
+function identity(value: string): string {
+  return value;
+}
+
+function shouldUseColor(): boolean {
+  return (
+    Boolean(process.env['FORCE_COLOR']) ||
+    (process.env['NO_COLOR'] === undefined && Boolean(process.stdout.isTTY))
+  );
+}
+
+function formatDuration(durationMs: number): string {
+  return `${Math.round(durationMs)} ms`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) {
+    return '0 bytes';
+  }
+
+  const abbreviations = ['bytes', 'kB', 'MB', 'GB'];
+  const index = Math.floor(Math.log(bytes) / Math.log(1000));
+  const roundedSize = bytes / Math.pow(1000, index);
+
+  return `${roundedSize.toFixed(index === 0 ? 0 : 2)} ${abbreviations[index]}`;
+}

--- a/libs/rebundle/src/generators/configure/generator.spec.ts
+++ b/libs/rebundle/src/generators/configure/generator.spec.ts
@@ -110,6 +110,43 @@ describe('configure generator', () => {
     );
   });
 
+  it('migrates Angular application build targets to Nx executors', async () => {
+    const project = readProjectConfiguration(tree, 'demo');
+    const buildTarget = project.targets?.['build'];
+    if (!buildTarget) {
+      throw new Error(
+        'Expected demo project to have a configured build target.',
+      );
+    }
+
+    buildTarget.executor = '@angular/build:application';
+    project.targets ??= {};
+    project.targets['serve'] = {
+      executor: '@angular/build:dev-server',
+      options: {
+        buildTarget: 'demo:build',
+      },
+    };
+    updateProjectConfiguration(tree, 'demo', project);
+
+    await configureGenerator(tree, {
+      project: 'demo',
+      skipFormat: true,
+    });
+
+    const updatedProject = readProjectConfiguration(tree, 'demo');
+
+    expect(updatedProject.targets?.['build'].executor).toBe(
+      '@nx/angular:application',
+    );
+    expect(updatedProject.targets?.['build'].options?.['plugins']).toEqual([
+      '@rx-angular/rebundle',
+    ]);
+    expect(updatedProject.targets?.['serve'].executor).toBe(
+      '@nx/angular:dev-server',
+    );
+  });
+
   it('throws when the project does not have a build target', async () => {
     addProjectConfiguration(
       tree,

--- a/libs/rebundle/src/generators/configure/generator.ts
+++ b/libs/rebundle/src/generators/configure/generator.ts
@@ -12,6 +12,11 @@ import initGenerator from '../init/generator';
 import { ConfigureGeneratorSchema } from './schema';
 
 const pluginPath = '@rx-angular/rebundle';
+const nxApplicationExecutor = '@nx/angular:application';
+const nxBrowserEsbuildExecutor = '@nx/angular:browser-esbuild';
+const angularApplicationExecutor = '@angular/build:application';
+const nxDevServerExecutor = '@nx/angular:dev-server';
+const angularDevServerExecutor = '@angular/build:dev-server';
 
 type EsbuildPluginSpec = string | { path: string; options?: unknown };
 
@@ -27,6 +32,8 @@ export async function configureGenerator(
 
   const project = readProjectConfiguration(tree, options.project);
   const buildTarget = getBuildTarget(project, options.project);
+
+  migrateAngularBuildTargets(project);
 
   buildTarget.options ??= {};
   const plugins = normalizePlugins(buildTarget.options['plugins']);
@@ -45,6 +52,18 @@ export async function configureGenerator(
   return runTasksInSerial(initTask);
 }
 
+function migrateAngularBuildTargets(project: ProjectConfiguration): void {
+  const buildTarget = project.targets?.['build'];
+  if (buildTarget?.executor === angularApplicationExecutor) {
+    buildTarget.executor = nxApplicationExecutor;
+  }
+
+  const serveTarget = project.targets?.['serve'];
+  if (serveTarget?.executor === angularDevServerExecutor) {
+    serveTarget.executor = nxDevServerExecutor;
+  }
+}
+
 export default configureGenerator;
 
 function getBuildTarget(
@@ -58,11 +77,12 @@ function getBuildTarget(
   }
 
   if (
-    buildTarget.executor !== '@nx/angular:application' &&
-    buildTarget.executor !== '@nx/angular:browser-esbuild'
+    buildTarget.executor !== nxApplicationExecutor &&
+    buildTarget.executor !== nxBrowserEsbuildExecutor &&
+    buildTarget.executor !== angularApplicationExecutor
   ) {
     throw new Error(
-      `Project "${projectName}" build target must use "@nx/angular:application" or "@nx/angular:browser-esbuild".`,
+      `Project "${projectName}" build target must use "@nx/angular:application", "@nx/angular:browser-esbuild", or "@angular/build:application".`,
     );
   }
 


### PR DESCRIPTION
## Summary

- migrate Angular application and dev-server targets to the Nx executors required by the configure generator
- include the rebundle README and package metadata in the published package
- enable Rolldown minification while removing legal comments and debug metadata
- log before/after file counts, raw sizes, transfer sizes, and rebundle duration

## Why

The configure generator accepted only Nx executors even though Angular CLI projects use the Angular build executors, which prevented rebundle from being configured directly. The published package also omitted its README and did not expose its package metadata. Finally, rebundled output needed explicit production minification settings and visible build statistics.

## Impact

Angular CLI projects can now run the configure generator and be migrated to compatible Nx executors. Published packages include their README and exported package metadata, while production builds produce smaller output and a comparison table showing rebundle results.

